### PR TITLE
🛡️ Sentinel: [SECURITY] Fix potential SQL injection in db_migrate

### DIFF
--- a/app/utils/db_migrate.py
+++ b/app/utils/db_migrate.py
@@ -85,7 +85,8 @@ def preview_migration(source_url: str) -> dict[str, Any]:
         with src_engine.connect() as conn:
             for table_name in tables:
                 # table_name is safe — sourced from inspect().get_table_names(), not user input
-                row = conn.execute(text(f'SELECT COUNT(*) FROM "{table_name}"')).fetchone()  # noqa: S608
+                quoted_table = conn.dialect.identifier_preparer.quote(table_name)
+                row = conn.execute(text(f"SELECT COUNT(*) FROM {quoted_table}")).fetchone()  # noqa: S608
                 count = row[0] if row else 0
                 result.append({"name": table_name, "row_count": count})
                 total += count


### PR DESCRIPTION
🚨 Severity: LOW / MEDIUM (Defense in Depth)
💡 Vulnerability: Potential SQL injection / Syntax error via manual identifier quoting
🎯 Impact: While the table names are sourced from `inspect().get_table_names()` and are not direct user input, manually quoting identifiers with `"{table_name}"` is unsafe and can fail if a table name contains a double quote or other special characters. It also bypasses dialect-specific quoting rules.
🔧 Fix: Replaced manual string interpolation with `conn.dialect.identifier_preparer.quote(table_name)` before passing it to `text()`.
✅ Verification: Ran `pytest tests/test_db_migrate.py` and `ruff check`.

---
*PR created automatically by Jules for task [454366986287082539](https://jules.google.com/task/454366986287082539) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database migration queries to properly escape table names according to the target database dialect, improving compatibility across different database systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->