### PR TITLE
🧪 [testing improvement] Add error path tests for API token revocation

### DIFF
--- a/tests/test_api_tokens.py
+++ b/tests/test_api_tokens.py
@@ -68,6 +68,34 @@ def _make_client(tok_engine, owner_id: str = _OWNER) -> TestClient:
     return client
 
 
+def _make_unauthenticated_client(tok_engine) -> TestClient:
+    """Return a TestClient that only overrides ``get_db`` (no auth injection).
+
+    This exercises the real ``_get_owner_id`` → ``get_current_owner_id``
+    authentication path.  Any request made with this client that does not
+    carry a valid session or Bearer token will receive a 401 from the
+    actual auth code, not from a mocked dependency.
+
+    The caller is responsible for clearing overrides via ``_cleanup(app)``
+    after the test completes (typically in a ``finally`` block).
+    """
+    from app.main import app
+
+    Session = sessionmaker(bind=tok_engine)
+
+    def _override_get_db():
+        session = Session()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    client = TestClient(app, base_url="http://localhost", raise_server_exceptions=False)
+    return client
+
+
 def _cleanup(app):
     """Remove dependency overrides after test."""
     app.dependency_overrides.clear()
@@ -240,20 +268,16 @@ class TestTokenRevoke:
 
     @pytest.mark.unit
     def test_revoke_token_unauthenticated(self, tok_engine):
-        """Revoking a token without authentication should return 401."""
-        from fastapi import HTTPException, status
+        """Revoking a token without authentication should return 401.
 
-        from app.api.api_tokens import _get_owner_id
+        Uses a client that only overrides ``get_db`` so that the real
+        ``_get_owner_id`` → ``get_current_owner_id`` path is exercised.
+        Sending no session or Bearer credentials means ``get_current_owner_id``
+        returns ``None``, and ``_get_owner_id`` raises a 401.
+        """
         from app.main import app
 
-        client = _make_client(tok_engine)
-
-        # Simulating unauthenticated by forcing the dependency to raise 401
-        def _override_owner_fail():
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
-
-        app.dependency_overrides[_get_owner_id] = _override_owner_fail
-
+        client = _make_unauthenticated_client(tok_engine)
         try:
             resp = client.delete("/api/api-tokens/1")
             assert resp.status_code == 401


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The testing gap addressed was the lack of comprehensive error path testing for the API token revocation endpoint. While some basic tests existed, they lacked detailed assertions on error responses, and several critical scenarios (authentication, database failures, and input validation) were missing.

### 📊 Coverage: What scenarios are now tested
- **400 Bad Request**: Attempting to revoke an already-revoked token (with detailed error message assertion).
- **404 Not Found**: Attempting to revoke a token that does not exist or belongs to another user (with detailed error message assertion).
- **401 Unauthorized**: Attempting to revoke a token without valid authentication credentials.
- **500 Internal Server Error**: Handling of database commit failures during the revocation process, ensuring a proper transaction rollback occurs and the token remains active.
- **422 Unprocessable Entity**: Handling of invalid token ID formats (e.g., non-integer values).

### ✨ Result: The improvement in test coverage
The improvement in test coverage ensures that the API token revocation endpoint is robust against various failure modes and that the application maintains data integrity even when unexpected errors occur. The tests follow established project patterns and use mocking where appropriate to simulate complex error conditions.

---
*PR created automatically by Jules for task [8200211521533028876](https://jules.google.com/task/8200211521533028876) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for token revocation API with additional error scenarios including authentication failures, database errors, invalid ID formats, and duplicate revocation attempts.
  * Added validation for detailed error messages across various failure modes, ensuring consistent and informative API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->