### PR TITLE
🔒 fix(tasks): prevent command injection in rclone commands

### DIFF
--- a/app/tasks/upload_with_rclone.py
+++ b/app/tasks/upload_with_rclone.py
@@ -55,12 +55,12 @@ def upload_with_rclone(self, file_path: str, destination: str):
 
     try:
         # Ensure the remote path exists (create folders if needed)
-        mkdir_cmd = ["rclone", "mkdir", "--config", rclone_config_path, destination]
+        mkdir_cmd = ["rclone", "mkdir", "--config", rclone_config_path, "--", destination]
 
         subprocess.run(mkdir_cmd, check=True, capture_output=True)  # noqa: S603
 
         # Construct the upload command
-        upload_cmd = ["rclone", "copy", "--config", rclone_config_path, file_path, destination, "--progress"]
+        upload_cmd = ["rclone", "copy", "--config", rclone_config_path, "--progress", "--", file_path, destination]
 
         log_task_progress(task_id, "rclone_upload", "in_progress", f"Executing rclone copy to {destination}")
 
@@ -71,7 +71,7 @@ def upload_with_rclone(self, file_path: str, destination: str):
         if result.returncode == 0:
             # Try to get a public link if possible
             try:
-                link_cmd = ["rclone", "link", "--config", rclone_config_path, f"{destination}/{filename}"]
+                link_cmd = ["rclone", "link", "--config", rclone_config_path, "--", f"{destination}/{filename}"]
                 link_result = subprocess.run(link_cmd, capture_output=True, text=True, check=False)  # noqa: S603
                 public_url = link_result.stdout.strip() if link_result.returncode == 0 else None
             except (subprocess.SubprocessError, OSError) as e:


### PR DESCRIPTION
🎯 **What:** Fixed a potential command injection vulnerability in `app/tasks/upload_with_rclone.py` where a filename or destination starting with a hyphen could be interpreted as a command-line flag by `rclone`.
⚠️ **Risk:** If a user uploaded a file named `-something` or used a destination starting with `-`, it could trigger unintended command-line flags in the `rclone` subprocess, leading to denial of service, unexpected behavior, or potentially command injection.
🛡️ **Solution:** Added `--` before positional arguments in `rclone` subprocess calls to ensure they are always treated as paths, regardless of whether they start with a hyphen.

---
*PR created automatically by Jules for task [16912117938106238295](https://jules.google.com/task/16912117938106238295) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload reliability by enhancing command argument handling to prevent file paths from being misinterpreted as system options, ensuring more robust operations especially with unconventional file naming patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->