### PR TITLE
🧪 add error test for deleting saved search

### DIFF
--- a/tests/test_api_advanced_filters.py
+++ b/tests/test_api_advanced_filters.py
@@ -318,6 +318,22 @@ class TestSavedSearchesCRUD:
         response = client.delete("/api/saved-searches/999")
         assert response.status_code == 404
 
+    def test_delete_saved_search_db_error(self, client: TestClient):
+        """DELETE /api/saved-searches/{id} handles database errors (500)."""
+        from unittest.mock import patch
+
+        # Create
+        create_resp = client.post(
+            "/api/saved-searches",
+            json={"name": "To Delete DB Error", "filters": {"status": "failed"}},
+        )
+        search_id = create_resp.json()["id"]
+
+        with patch("sqlalchemy.orm.Session.delete", side_effect=Exception("DB Delete Error")):
+            response = client.delete(f"/api/saved-searches/{search_id}")
+            assert response.status_code == 500
+            assert response.json()["detail"] == "Failed to delete saved search"
+
     def test_create_name_too_long(self, client: TestClient):
         """POST /api/saved-searches with name > 100 chars returns 422."""
         payload = {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The delete_saved_search endpoint lacked a test for the 500 error path that happens when a database exception occurs during deletion.

📊 **Coverage:** What scenarios are now tested
A new test `test_delete_saved_search_db_error` was added that uses unittest mock to mock `Session.delete` causing it to throw an exception, and verifying that the API correctly handles the database exception and returns a 500 response. The 404 path was already covered.

✨ **Result:** The improvement in test coverage
The delete endpoint for saved searches now has 100% test coverage for its error states, improving the reliability and coverage of the API endpoints.

---
*PR created automatically by Jules for task [10537352409448038219](https://jules.google.com/task/10537352409448038219) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error handling test coverage for saved search deletion operations to ensure proper HTTP error responses during database failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->