### PR TITLE
🔒 Fix potential command injection in rclone task

### DIFF
--- a/app/tasks/upload_with_rclone.py
+++ b/app/tasks/upload_with_rclone.py
@@ -55,12 +55,12 @@ def upload_with_rclone(self, file_path: str, destination: str):
 
     try:
         # Ensure the remote path exists (create folders if needed)
-        mkdir_cmd = ["rclone", "mkdir", "--config", rclone_config_path, destination]
+        mkdir_cmd = ["rclone", "mkdir", "--config", rclone_config_path, "--", destination]
 
         subprocess.run(mkdir_cmd, check=True, capture_output=True)  # noqa: S603
 
         # Construct the upload command
-        upload_cmd = ["rclone", "copy", "--config", rclone_config_path, file_path, destination, "--progress"]
+        upload_cmd = ["rclone", "copy", "--config", rclone_config_path, "--progress", "--", file_path, destination]
 
         log_task_progress(task_id, "rclone_upload", "in_progress", f"Executing rclone copy to {destination}")
 
@@ -71,7 +71,7 @@ def upload_with_rclone(self, file_path: str, destination: str):
         if result.returncode == 0:
             # Try to get a public link if possible
             try:
-                link_cmd = ["rclone", "link", "--config", rclone_config_path, f"{destination}/{filename}"]
+                link_cmd = ["rclone", "link", "--config", rclone_config_path, "--", f"{destination}/{filename}"]
                 link_result = subprocess.run(link_cmd, capture_output=True, text=True, check=False)  # noqa: S603
                 public_url = link_result.stdout.strip() if link_result.returncode == 0 else None
             except (subprocess.SubprocessError, OSError) as e:


### PR DESCRIPTION
🎯 **What:** Fixed a potential command injection vulnerability in the `upload_with_rclone` Celery task. The vulnerability could be triggered by manipulating the destination or file_path arguments to start with `-`, which rclone would then parse as command flags rather than positional file paths or remote names.

⚠️ **Risk:** An attacker who controls the destination input string could supply malicious flag combinations to alter the rclone execution context, potentially leading to unauthorized data exfiltration, system compromise via malicious configuration execution, or other unintended behaviors inside the execution environment.

🛡️ **Solution:** Implemented the `--` (end of options) argument separator in the `rclone copy`, `rclone mkdir`, and `rclone link` command arrays. This is a standard security best practice when executing command-line interfaces, definitively instructing the tool that any subsequent arguments (regardless of whether they begin with a dash) must be interpreted as literal, positional path strings, effectively mitigating option-based injection.

---
*PR created automatically by Jules for task [10804853329672964529](https://jules.google.com/task/10804853329672964529) started by @christianlouis*