### PR TITLE
🧪 Add tests for notify_settings_updated error handling

### DIFF
--- a/tests/test_settings_audit_log.py
+++ b/tests/test_settings_audit_log.py
@@ -289,7 +289,8 @@ class TestNotifySettingsUpdated:
         call_args = mock_redis_instance.set.call_args[0]
         assert call_args[0] == SETTINGS_VERSION_KEY
 
-    def test_does_not_raise_on_redis_failure(self):
+    @patch("app.utils.settings_sync.logger")
+    def test_does_not_raise_on_redis_failure(self, mock_logger):
         """notify_settings_updated must not propagate Redis errors."""
         from app.utils.settings_sync import notify_settings_updated
 
@@ -297,6 +298,35 @@ class TestNotifySettingsUpdated:
             mock_redis_module.from_url.side_effect = Exception("Redis down")
             # Should not raise
             notify_settings_updated()
+            mock_logger.warning.assert_any_call("Could not publish settings update to Redis: Redis down")
+
+    @patch("app.utils.settings_sync.logger")
+    def test_does_not_raise_on_reload_failure(self, mock_logger):
+        """notify_settings_updated must not propagate settings reload errors."""
+        from app.utils.settings_sync import notify_settings_updated
+
+        with patch("app.utils.config_loader.reload_settings_from_db") as mock_reload:
+            mock_reload.side_effect = Exception("Reload error")
+            # We mock redis so that we skip over the redis block, and mock ensure_ocr_languages_async to prevent its side effects.
+            with patch("app.utils.settings_sync.redis"):
+                with patch("app.utils.ocr_language_manager.ensure_ocr_languages_async"):
+                    # Should not raise
+                    notify_settings_updated()
+            mock_logger.warning.assert_any_call("Could not reload in-process settings: Reload error")
+
+    @patch("app.utils.settings_sync.logger")
+    def test_does_not_raise_on_ocr_language_check_failure(self, mock_logger):
+        """notify_settings_updated must not propagate OCR language check errors."""
+        from app.utils.settings_sync import notify_settings_updated
+
+        with patch("app.utils.ocr_language_manager.ensure_ocr_languages_async") as mock_ensure:
+            mock_ensure.side_effect = Exception("OCR error")
+            # We mock redis and reload_settings_from_db so we only test the OCR block failure.
+            with patch("app.utils.settings_sync.redis"):
+                with patch("app.utils.config_loader.reload_settings_from_db"):
+                    # Should not raise
+                    notify_settings_updated()
+            mock_logger.warning.assert_any_call("Could not schedule OCR language check: OCR error")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
🎯 **What:** The testing gap in `notify_settings_updated` error handling.
📊 **Coverage:** The three exception handling blocks are now tested. They test that:
- Redis publish failure raises a warning and no exception
- Settings reload failure raises a warning and no exception
- OCR language check failure raises a warning and no exception
✨ **Result:** Test coverage improved for `notify_settings_updated` with 3 new test scenarios covering all paths.

---
*PR created automatically by Jules for task [9908300433097254406](https://jules.google.com/task/9908300433097254406) started by @christianlouis*