### PR TITLE
🔒 Fix potential SQL injection in db_migrate preview

### DIFF
--- a/app/utils/db_migrate.py
+++ b/app/utils/db_migrate.py
@@ -12,6 +12,7 @@ The utility:
 """
 
 import logging
+import re
 from typing import Any
 
 from sqlalchemy import MetaData, create_engine, inspect, text
@@ -84,6 +85,9 @@ def preview_migration(source_url: str) -> dict[str, Any]:
         total = 0
         with src_engine.connect() as conn:
             for table_name in tables:
+                if not re.match(r"^[a-zA-Z0-9_]+$", table_name):
+                    logger.warning(f"Skipping table with invalid name format: {table_name}")
+                    continue
                 # table_name is safe — sourced from inspect().get_table_names(), not user input
                 quoted_table = conn.dialect.identifier_preparer.quote(table_name)
                 row = conn.execute(text(f"SELECT COUNT(*) FROM {quoted_table}")).fetchone()  # noqa: S608


### PR DESCRIPTION
Added a strict regex validation allowlist for table names in `preview_migration` before using them in raw SQL queries. This ensures that only alphanumeric characters and underscores are allowed, preventing potential SQL injection even if the source of table names were to be manipulated. Formatted code with ruff format.