### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via HTTP redirects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Vulnerability:** The `_test_imap_connection` and `_test_s3_connection` functions in `app/api/integrations.py` did not validate user-provided `host` and `endpoint_url` variables against `is_private_ip()`. This allowed an attacker to test the presence of internal IMAP servers or direct S3 SDK API calls to internal infrastructure via SSRF.
 **Learning:** Any time a new generic connection or integration test is added, SSRF validation may be forgotten if the core network utility (`is_private_ip`) is not systematically applied to all outbound network operations, regardless of the protocol (e.g., IMAP, S3).
 **Prevention:** Establish a pattern where any user-configurable host or endpoint URL is immediately passed through the centralized `is_private_ip` validation function before any network call or third-party client initialization.
+## 2026-03-27 - SSRF Bypass via HTTP Redirects
+**Vulnerability:** The URL upload endpoint was vulnerable to SSRF bypass because the `httpx.AsyncClient` followed HTTP redirects without re-validating the target URL of the `Location` header.
+**Learning:** Even if the initial user-provided URL is validated against internal IPs and cloud metadata endpoints, HTTP clients that automatically follow redirects can be tricked into fetching internal resources if the initial safe URL redirects to an unsafe one.
+**Prevention:** Always implement response hooks or custom redirect handlers to run security validations on every URL in the redirect chain when `follow_redirects=True` is enabled.

--- a/app/api/url_upload.py
+++ b/app/api/url_upload.py
@@ -78,6 +78,19 @@ def validate_url_safety(url: str) -> None:
         raise HTTPException(status_code=400, detail="Access to cloud metadata endpoints is not allowed")
 
 
+async def validate_redirect(response: httpx.Response) -> None:
+    """
+    Event hook to validate redirects to ensure they don't bypass SSRF protections.
+    """
+    if response.status_code in (301, 302, 303, 307, 308):
+        location = response.headers.get("Location")
+        if location:
+            # Handle relative redirects by joining with the base URL
+            if not location.startswith(("http://", "https://")):
+                location = str(response.request.url.join(location))
+            validate_url_safety(location)
+
+
 def validate_file_type(content_type: str, filename: str) -> bool:
     """
     Validate that the file type is supported (i.e. processable by Gotenberg).
@@ -162,6 +175,7 @@ async def process_url(
         async with httpx.AsyncClient(
             timeout=settings.http_request_timeout,
             follow_redirects=True,
+            event_hooks={"response": [validate_redirect]},
             headers={
                 "User-Agent": "DocuElevate/1.0",  # Identify ourselves
             },

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -879,3 +879,34 @@ class TestURLUploadCoverageGaps:
         # Generic exception (not HTTPException/OSError/RequestException) is caught and returns 500
         assert response.status_code == 500
         assert "Unexpected error" in response.json()["detail"]
+
+    def test_validate_redirect_blocks_private_ip(self):
+        """Test that validate_redirect hook raises HTTPException when redirected to private IP"""
+        from fastapi import HTTPException
+
+        from app.api.url_upload import validate_redirect
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 302
+        mock_response.headers = httpx.Headers({"Location": "http://192.168.1.1/file.pdf"})
+
+        import asyncio
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(validate_redirect(mock_response))
+
+        assert exc_info.value.status_code == 400
+        assert "private/internal" in exc_info.value.detail
+
+    def test_validate_redirect_allows_public_ip(self):
+        """Test that validate_redirect hook allows redirect to public IP"""
+        from app.api.url_upload import validate_redirect
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 302
+        mock_response.headers = httpx.Headers({"Location": "https://example.com/file.pdf"})
+
+        import asyncio
+
+        # Should not raise exception
+        asyncio.run(validate_redirect(mock_response))

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -910,3 +910,49 @@ class TestURLUploadCoverageGaps:
 
         # Should not raise exception
         asyncio.run(validate_redirect(mock_response))
+
+    def test_validate_redirect_relative_url(self):
+        """Test that validate_redirect hook correctly handles relative URLs"""
+        from app.api.url_upload import validate_redirect
+        from httpx import URL
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 302
+        mock_response.headers = httpx.Headers({"Location": "/internal/metadata"})
+        mock_request = MagicMock()
+        mock_request.url = URL("https://example.com/base")
+        mock_response.request = mock_request
+
+        import asyncio
+
+        # Should not raise an exception, as example.com is public
+        # (The test ensures the hook doesn't crash on relative paths)
+        asyncio.run(validate_redirect(mock_response))
+
+    def test_validate_redirect_ignored_status_code(self):
+        """Test that validate_redirect ignores non-redirect status codes"""
+        from app.api.url_upload import validate_redirect
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        # The hook should return early for 200, so we don't even set headers
+        mock_response.headers = httpx.Headers()
+
+        import asyncio
+
+        # Should not raise exception
+        asyncio.run(validate_redirect(mock_response))
+
+    def test_validate_redirect_missing_location(self):
+        """Test that validate_redirect handles missing Location header"""
+        from app.api.url_upload import validate_redirect
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 302
+        # Location header is missing
+        mock_response.headers = httpx.Headers()
+
+        import asyncio
+
+        # Should not raise exception
+        asyncio.run(validate_redirect(mock_response))

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -913,8 +913,9 @@ class TestURLUploadCoverageGaps:
 
     def test_validate_redirect_relative_url(self):
         """Test that validate_redirect hook correctly handles relative URLs"""
-        from app.api.url_upload import validate_redirect
         from httpx import URL
+
+        from app.api.url_upload import validate_redirect
 
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 302


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix SSRF bypass via HTTP redirects

🚨 Severity: HIGH
💡 Vulnerability: The `/api/process-url` endpoint was vulnerable to an SSRF bypass. While the initial user-provided URL was validated against a list of blocked internal IP addresses and cloud metadata endpoints, the underlying `httpx.AsyncClient` was configured with `follow_redirects=True`. If an attacker provided a valid external URL that returned an HTTP 302 redirect to an internal IP or `http://169.254.169.254`, the client would blindly follow it, bypassing the initial SSRF check.
🎯 Impact: Attackers could potentially access internal services, read sensitive cloud metadata, or map the internal network.
🔧 Fix: Added an asynchronous `validate_redirect` hook to the `httpx.AsyncClient`'s `event_hooks` list. This hook intercepts the response *before* following the redirect, parses the `Location` header (handling relative URLs safely via `URL.join`), and re-runs the `validate_url_safety` function. If the new URL resolves to a malicious IP, the application throws an `HTTPException`, aborting the request safely.
✅ Verification: Ran the test suite `tests/test_url_upload.py`. All tests passed, including new integration tests (`test_validate_redirect_blocks_private_ip` and `test_validate_redirect_allows_public_ip`) verifying that redirect headers to internal IPs properly trigger a 400 Bad Request while public IPs pass.

Also added a Sentinel journal entry in `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [16159489246812037319](https://jules.google.com/task/16159489246812037319) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for URL uploads by validating every redirect destination when following redirects, preventing SSRF via redirect chains.

* **Tests**
  * Added comprehensive unit tests covering redirect validation behavior, relative redirects, non-redirect responses, and missing Location headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->