### PR TITLE
🛡️ Sentinel: [HIGH] Fix multiple event hooks syntax error in URL upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -28,3 +28,8 @@
 **Vulnerability:** The `/process-url` endpoint used `httpx.AsyncClient(follow_redirects=True)` after validating the initial user-provided URL against SSRF protections. However, it did not validate the target URLs of any subsequent HTTP redirects, allowing an attacker to provide a safe URL that redirects to an internal/private IP, bypassing the security check.
 **Learning:** Initial URL validation is insufficient when the HTTP client is configured to follow redirects automatically. The client must be explicitly configured to validate every redirect target.
 **Prevention:** When using `httpx.AsyncClient(follow_redirects=True)` for user-provided URLs, always implement a redirect validator hook function (e.g., using `event_hooks={'response': [validate_redirect]}`) that resolves the `Location` header and passes it through the same SSRF validation logic before the redirect is followed.
+## 2026-04-28 - Multiple Event Hooks Definition
+
+**Vulnerability:** SyntaxError crashing the application when passing multiple event hooks to `httpx.AsyncClient` sequentially.
+**Learning:** In Python, passing the same keyword argument (e.g., `event_hooks`) multiple times to a function call raises a `SyntaxError: keyword argument repeated`. The codebase attempted to assign two different `event_hooks` blocks back-to-back, breaking functionality that was responsible for SSRF prevention (`verify_redirect` and `validate_redirect`).
+**Prevention:** When combining multiple event hooks (such as global and local SSRF redirect validators) in `httpx.AsyncClient`, always combine them into a single list for the event key (e.g., `event_hooks={'response': [hook1, hook2]}`) rather than passing multiple kwargs.

--- a/app/api/url_upload.py
+++ b/app/api/url_upload.py
@@ -194,11 +194,10 @@ async def process_url(
         async with httpx.AsyncClient(
             timeout=settings.http_request_timeout,
             follow_redirects=True,
-            event_hooks={"response": [validate_redirect]},
+            event_hooks={"response": [validate_redirect, verify_redirect]},
             headers={
                 "User-Agent": "DocuElevate/1.0",  # Identify ourselves
             },
-            event_hooks={"response": [verify_redirect]},
         ) as client:
             async with client.stream("GET", url) as response:
                 response.raise_for_status()

--- a/app/tasks/watch_folder_tasks.py
+++ b/app/tasks/watch_folder_tasks.py
@@ -666,9 +666,11 @@ def _scan_onedrive_folder(folder_path: str, cache: dict[str, str], delete_after:
     list_url = f"https://graph.microsoft.com/v1.0/me/drive/root:/{encoded_path}:/children"
 
     count = 0
+    timeout = getattr(settings, "http_request_timeout", 120)
+
     while list_url:
         try:
-            resp = req_lib.get(list_url, headers=headers, timeout=getattr(settings, "http_request_timeout", 120))
+            resp = req_lib.get(list_url, headers=headers, timeout=timeout)
             resp.raise_for_status()
             data = resp.json()
         except Exception as exc:
@@ -704,9 +706,7 @@ def _scan_onedrive_folder(folder_path: str, cache: dict[str, str], delete_after:
                 dest_path = os.path.join(settings.workdir, f"{base}_{int(datetime.now().timestamp())}{ext2}")
 
             try:
-                dl_resp = req_lib.get(
-                    download_url, headers=headers, timeout=getattr(settings, "http_request_timeout", 120)
-                )
+                dl_resp = req_lib.get(download_url, headers=headers, timeout=timeout)
                 dl_resp.raise_for_status()
                 with open(dest_path, "wb") as f:
                     f.write(dl_resp.content)
@@ -726,7 +726,7 @@ def _scan_onedrive_folder(folder_path: str, cache: dict[str, str], delete_after:
                     del_resp = req_lib.delete(
                         f"https://graph.microsoft.com/v1.0/me/drive/items/{item_id}",
                         headers=headers,
-                        timeout=getattr(settings, "http_request_timeout", 120),
+                        timeout=timeout,
                     )
                     del_resp.raise_for_status()
                     logger.info("OneDrive ingest: deleted %s after ingestion", filename)
@@ -1789,6 +1789,8 @@ def _scan_user_onedrive_folder(
         logger.warning("User OneDrive watch folder: folder_path not configured.")
         return 0
 
+    timeout = getattr(settings, "http_request_timeout", 120)
+
     # Exchange refresh token for an access token
     try:
         token_resp = req_lib.post(
@@ -1800,7 +1802,7 @@ def _scan_user_onedrive_folder(
                 "client_secret": client_secret,
                 "scope": "https://graph.microsoft.com/.default",
             },
-            timeout=getattr(settings, "http_request_timeout", 120),
+            timeout=timeout,
         )
         token_resp.raise_for_status()
         access_token = token_resp.json()["access_token"]
@@ -1815,7 +1817,6 @@ def _scan_user_onedrive_folder(
     list_url: str | None = f"https://graph.microsoft.com/v1.0/me/drive/root:/{encoded_path}:/children"
 
     count = 0
-    timeout = getattr(settings, "http_request_timeout", 120)
 
     while list_url:
         try:


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A `SyntaxError: keyword argument repeated` prevented the URL Upload endpoint from starting and validating redirects.
🎯 **Impact:** Prevents the SSRF protection hooks from running and crashes the service when `url_upload` is invoked.
🔧 **Fix:** Combined the two hooks (`validate_redirect`, `verify_redirect`) into a single `event_hooks={"response": [...]}` list.
✅ **Verification:** Run `PYTHONPATH=. /home/jules/.pyenv/versions/3.12.13/bin/python3 -m pytest -k 'url_upload' tests/` and verify the syntax error no longer occurs and the endpoint functions correctly.

---
*PR created automatically by Jules for task [10859443215846415133](https://jules.google.com/task/10859443215846415133) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP client event hook configuration issue that prevented proper redirect validation in file upload operations
  * Improved reliability of redirect handling

* **Refactor**
  * Consolidated request timeout configuration for all OneDrive folder operations including scanning, file downloads, and item deletions

* **Documentation**
  * Added documentation on event hook configuration failures with recommended setup approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->