### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SyntaxError in httpx.AsyncClient by combining duplicate event_hooks

### DIFF
--- a/app/api/url_upload.py
+++ b/app/api/url_upload.py
@@ -194,11 +194,10 @@ async def process_url(
         async with httpx.AsyncClient(
             timeout=settings.http_request_timeout,
             follow_redirects=True,
-            event_hooks={"response": [validate_redirect]},
             headers={
                 "User-Agent": "DocuElevate/1.0",  # Identify ourselves
             },
-            event_hooks={"response": [verify_redirect]},
+            event_hooks={"response": [validate_redirect, verify_redirect]},
         ) as client:
             async with client.stream("GET", url) as response:
                 response.raise_for_status()


### PR DESCRIPTION
Fix SyntaxError by combining duplicate event_hooks in httpx.AsyncClient

The `/process-url` endpoint instantiated `httpx.AsyncClient` with two identical keyword arguments (`event_hooks`). This fixes the resulting SyntaxError by combining the `validate_redirect` and `verify_redirect` hooks into a single list, ensuring both SSRF protection hooks run as intended.

---
*PR created automatically by Jules for task [16995462348179572123](https://jules.google.com/task/16995462348179572123) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue with URL upload redirect handling to ensure all validation checks are properly applied during streaming uploads from external URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->