### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix httpx.AsyncClient syntax error

### DIFF
--- a/app/api/url_upload.py
+++ b/app/api/url_upload.py
@@ -194,11 +194,10 @@ async def process_url(
         async with httpx.AsyncClient(
             timeout=settings.http_request_timeout,
             follow_redirects=True,
-            event_hooks={"response": [validate_redirect]},
+            event_hooks={"response": [validate_redirect, verify_redirect]},
             headers={
                 "User-Agent": "DocuElevate/1.0",  # Identify ourselves
             },
-            event_hooks={"response": [verify_redirect]},
         ) as client:
             async with client.stream("GET", url) as response:
                 response.raise_for_status()

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -924,3 +924,54 @@ class TestURLUploadCoverageGaps:
 
         # Should not raise any exception and should ignore missing Location header
         await verify_redirect(resp)
+
+    @patch("app.api.url_upload.httpx.AsyncClient.stream")
+    def test_process_url_validate_redirect_hook_blocks_unsafe_url(self, mock_stream, client):
+        """Test the local validate_redirect hook blocks unsafe redirects."""
+        from fastapi import HTTPException
+        import httpx
+
+        # Simulate the AsyncClient behavior by directly triggering the event hook
+        # We need to capture the function from the API or construct it for testing.
+        # Since it's nested inside `process_url`, we test its execution via mocking an unsafe response
+        # that would trigger it, but it's simpler to test the `verify_redirect` directly which does the same.
+        # However, to get coverage on line 197 we need `process_url` to successfully initialize `httpx.AsyncClient`.
+        # The line is the `event_hooks={"response": [validate_redirect, verify_redirect]},` argument.
+
+        # We will make a successful request, but we patch `AsyncClient` to track its initialization
+        # or we just let it initialize and since it does we hit line 197!
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/pdf", "Content-Length": "100"}
+
+        async def mock_aiter_bytes(chunk_size=None):
+            yield b"PDF content"
+
+        mock_response.aiter_bytes = mock_aiter_bytes
+        mock_response.raise_for_status = Mock()
+
+        mock_context = AsyncMock()
+        mock_context.__aenter__.return_value = mock_response
+        mock_stream.return_value = mock_context
+
+        # We need to use `patch` on `httpx.AsyncClient` to verify how it's called
+        # mock process_document inside url_upload so we don't actually process it
+        with patch("app.api.url_upload.httpx.AsyncClient", wraps=httpx.AsyncClient) as mock_client:
+            with patch("app.api.url_upload.process_document") as mock_process_document:
+                # We also need to patch stream on the returned instance
+                mock_client_instance = AsyncMock()
+                mock_client_instance.__aenter__.return_value.stream = mock_stream
+                mock_client.return_value = mock_client_instance
+
+                mock_task = Mock()
+                mock_task.id = "test-task-id-hooks"
+                mock_process_document.delay.return_value = mock_task
+
+                response = client.post("/api/process-url", json={"url": "https://example.com/file.pdf"})
+                assert response.status_code == 200
+
+                # Verify event hooks are properly configured
+                _, kwargs = mock_client.call_args
+                assert "event_hooks" in kwargs
+                assert "response" in kwargs["event_hooks"]
+                assert len(kwargs["event_hooks"]["response"]) == 2

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -928,7 +928,6 @@ class TestURLUploadCoverageGaps:
     @patch("app.api.url_upload.httpx.AsyncClient.stream")
     def test_process_url_validate_redirect_hook_blocks_unsafe_url(self, mock_stream, client):
         """Test the local validate_redirect hook blocks unsafe redirects."""
-        from fastapi import HTTPException
         import httpx
 
         # Simulate the AsyncClient behavior by directly triggering the event hook

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -974,3 +974,24 @@ class TestURLUploadCoverageGaps:
                 assert "event_hooks" in kwargs
                 assert "response" in kwargs["event_hooks"]
                 assert len(kwargs["event_hooks"]["response"]) == 2
+
+                # To cover the validate_redirect function block (lines 174-184), we can call it manually.
+                # It's an inner function, but we can access it through the mock's arguments.
+                validate_redirect_fn = kwargs["event_hooks"]["response"][0]
+
+                # Test safe redirect
+                safe_req = httpx.Request("GET", "https://example.com")
+                safe_resp = httpx.Response(301, headers={"Location": "https://google.com"}, request=safe_req)
+                # It shouldn't raise
+                import asyncio
+
+                asyncio.run(validate_redirect_fn(safe_resp))
+
+                # Test unsafe redirect
+                unsafe_req = httpx.Request("GET", "https://example.com")
+                unsafe_resp = httpx.Response(301, headers={"Location": "http://127.0.0.1"}, request=unsafe_req)
+
+                # It should raise httpx.RequestError
+                with pytest.raises(httpx.RequestError) as exc_info:
+                    asyncio.run(validate_redirect_fn(unsafe_resp))
+                assert "Unsafe redirect target" in str(exc_info.value)


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix httpx.AsyncClient syntax error

🚨 Severity: CRITICAL
💡 Vulnerability: `app/api/url_upload.py` contained a syntax error where `event_hooks` was passed twice as a keyword argument to `httpx.AsyncClient`, causing module initialization and url uploading to fail.
🎯 Impact: System failure for any operations related to URL file uploads due to `SyntaxError: keyword argument repeated: event_hooks`.
🔧 Fix: Combined the two lists of response hooks (`validate_redirect` and `verify_redirect`) into a single dictionary entry for `event_hooks`.
✅ Verification: Ran `python3 -m py_compile app/api/url_upload.py` and `./run_fast_tests.sh`. No errors.

---
*PR created automatically by Jules for task [1102527056685366386](https://jules.google.com/task/1102527056685366386) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured URL redirect validation runs consistently during file uploads so unsafe redirects are reliably blocked.

* **Tests**
  * Added an integration test that verifies redirect validation blocks unsafe targets and prevents regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christianlouis/DocuElevate/pull/855)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->