### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SyntaxError breaking SSRF protection in URL upload

### DIFF
--- a/app/api/url_upload.py
+++ b/app/api/url_upload.py
@@ -194,11 +194,10 @@ async def process_url(
         async with httpx.AsyncClient(
             timeout=settings.http_request_timeout,
             follow_redirects=True,
-            event_hooks={"response": [validate_redirect]},
+            event_hooks={"response": [validate_redirect, verify_redirect]},
             headers={
                 "User-Agent": "DocuElevate/1.0",  # Identify ourselves
             },
-            event_hooks={"response": [verify_redirect]},
         ) as client:
             async with client.stream("GET", url) as response:
                 response.raise_for_status()

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -924,3 +924,105 @@ class TestURLUploadCoverageGaps:
 
         # Should not raise any exception and should ignore missing Location header
         await verify_redirect(resp)
+
+    @patch("app.api.url_upload.httpx.AsyncClient")
+    @patch("app.api.url_upload.process_document")
+    def test_process_url_async_client_initialization(self, mock_process_document, mock_async_client_class, client):
+        """Test that AsyncClient is initialized with the correct event_hooks list"""
+        # We need to mock the context manager properly
+        mock_client_instance = AsyncMock()
+        mock_async_client_class.return_value.__aenter__.return_value = mock_client_instance
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/pdf"}
+        mock_response.raise_for_status = Mock()
+
+        async def mock_aiter_bytes(chunk_size=None):
+            yield b"PDF content"
+        mock_response.aiter_bytes = mock_aiter_bytes
+
+        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx.__aenter__.return_value = mock_response
+        mock_client_instance.stream.return_value = mock_stream_ctx
+
+        # Make request
+        client.post("/api/process-url", json={"url": "https://example.com/test.pdf"})
+
+        # Verify the initialization had the combined event_hooks
+        mock_async_client_class.assert_called_once()
+        kwargs = mock_async_client_class.call_args.kwargs
+        assert "event_hooks" in kwargs
+        assert "response" in kwargs["event_hooks"]
+        hooks = kwargs["event_hooks"]["response"]
+        assert len(hooks) == 2
+        assert hooks[0].__name__ == "validate_redirect"
+        assert hooks[1].__name__ == "verify_redirect"
+
+    @patch("app.api.url_upload.httpx.AsyncClient")
+    @patch("app.api.url_upload.process_document")
+    def test_process_url_verify_redirect_unreachable(self, mock_process_document, mock_async_client_class, client):
+        """Test the verify_redirect hook error specifically"""
+        import httpx
+        from app.api.url_upload import verify_redirect
+        import asyncio
+        loop = asyncio.get_event_loop()
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 302
+        mock_response.headers = {"Location": "http://127.0.0.1/internal"}
+
+        mock_url = MagicMock()
+        mock_url.join.return_value = "http://127.0.0.1/internal"
+        mock_response.url = mock_url
+        mock_response.request = MagicMock()
+
+        with pytest.raises(httpx.RequestError) as exc_info:
+            loop.run_until_complete(verify_redirect(mock_response))
+
+        assert "Redirect to unsafe URL blocked" in str(exc_info.value)
+
+
+    @patch("app.api.url_upload.httpx.AsyncClient")
+    @patch("app.api.url_upload.process_document")
+    def test_process_url_validate_redirect_hook(self, mock_process_document, mock_async_client_class, client):
+        """Test the inner validate_redirect hook inside process_url"""
+        import httpx
+        from fastapi import HTTPException
+        import asyncio
+        loop = asyncio.get_event_loop()
+
+        # We need to capture the hook when it's passed to AsyncClient
+        mock_client_instance = AsyncMock()
+        mock_async_client_class.return_value.__aenter__.return_value = mock_client_instance
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/pdf"}
+        mock_response.raise_for_status = Mock()
+
+        async def mock_aiter_bytes(chunk_size=None):
+            yield b"PDF content"
+        mock_response.aiter_bytes = mock_aiter_bytes
+
+        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx.__aenter__.return_value = mock_response
+        mock_client_instance.stream.return_value = mock_stream_ctx
+
+        # Make request to capture the hooks
+        client.post("/api/process-url", json={"url": "https://example.com/test.pdf"})
+
+        hooks = mock_async_client_class.call_args.kwargs["event_hooks"]["response"]
+        validate_redirect_hook = next(h for h in hooks if h.__name__ == "validate_redirect")
+
+        # Test the hook logic
+        mock_hook_response = MagicMock(spec=httpx.Response)
+        mock_hook_response.is_redirect = True
+        mock_hook_response.headers = {"Location": "http://127.0.0.1/internal"}
+        mock_hook_response.url = "http://example.com"
+        mock_hook_response.request = MagicMock()
+
+        with pytest.raises(httpx.RequestError) as exc_info:
+            loop.run_until_complete(validate_redirect_hook(mock_hook_response))
+
+        assert "Unsafe redirect target" in str(exc_info.value)

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -1034,11 +1034,14 @@ class TestURLUploadCoverageGaps:
 
     @patch("app.api.url_upload.httpx.AsyncClient")
     @patch("app.api.url_upload.process_document")
-    def test_process_url_validate_redirect_hook_missing_location(self, mock_process_document, mock_async_client_class, client):
+    def test_process_url_validate_redirect_hook_missing_location(
+        self, mock_process_document, mock_async_client_class, client
+    ):
         """Test the inner validate_redirect hook inside process_url when Location header is missing"""
         import asyncio
 
         import httpx
+
         loop = asyncio.get_event_loop()
 
         # We need to capture the hook when it's passed to AsyncClient
@@ -1052,6 +1055,7 @@ class TestURLUploadCoverageGaps:
 
         async def mock_aiter_bytes(chunk_size=None):
             yield b"PDF content"
+
         mock_response.aiter_bytes = mock_aiter_bytes
 
         mock_stream_ctx = AsyncMock()
@@ -1066,18 +1070,21 @@ class TestURLUploadCoverageGaps:
         # Test the hook logic
         mock_hook_response = MagicMock(spec=httpx.Response)
         mock_hook_response.is_redirect = True
-        mock_hook_response.headers = {} # Missing Location
+        mock_hook_response.headers = {}  # Missing Location
 
         # Should complete without error
         loop.run_until_complete(validate_redirect_hook(mock_hook_response))
 
     @patch("app.api.url_upload.httpx.AsyncClient")
     @patch("app.api.url_upload.process_document")
-    def test_process_url_validate_redirect_hook_not_redirect(self, mock_process_document, mock_async_client_class, client):
+    def test_process_url_validate_redirect_hook_not_redirect(
+        self, mock_process_document, mock_async_client_class, client
+    ):
         """Test the inner validate_redirect hook inside process_url when response is not a redirect"""
         import asyncio
 
         import httpx
+
         loop = asyncio.get_event_loop()
 
         # We need to capture the hook when it's passed to AsyncClient
@@ -1091,6 +1098,7 @@ class TestURLUploadCoverageGaps:
 
         async def mock_aiter_bytes(chunk_size=None):
             yield b"PDF content"
+
         mock_response.aiter_bytes = mock_aiter_bytes
 
         mock_stream_ctx = AsyncMock()
@@ -1116,12 +1124,14 @@ class TestURLUploadCoverageGaps:
         import asyncio
 
         import httpx
+
         from app.api.url_upload import verify_redirect
+
         loop = asyncio.get_event_loop()
 
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 302
-        mock_response.headers = {} # Missing Location
+        mock_response.headers = {}  # Missing Location
 
         # Should complete without error
         loop.run_until_complete(verify_redirect(mock_response))

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -940,7 +940,6 @@ class TestURLUploadCoverageGaps:
 
         async def mock_aiter_bytes(chunk_size=None):
             yield b"PDF content"
-
         mock_response.aiter_bytes = mock_aiter_bytes
 
         mock_stream_ctx = AsyncMock()
@@ -969,7 +968,6 @@ class TestURLUploadCoverageGaps:
         import httpx
 
         from app.api.url_upload import verify_redirect
-
         loop = asyncio.get_event_loop()
 
         mock_response = MagicMock(spec=httpx.Response)
@@ -986,6 +984,7 @@ class TestURLUploadCoverageGaps:
 
         assert "Redirect to unsafe URL blocked" in str(exc_info.value)
 
+
     @patch("app.api.url_upload.httpx.AsyncClient")
     @patch("app.api.url_upload.process_document")
     def test_process_url_validate_redirect_hook(self, mock_process_document, mock_async_client_class, client):
@@ -993,7 +992,6 @@ class TestURLUploadCoverageGaps:
         import asyncio
 
         import httpx
-
         loop = asyncio.get_event_loop()
 
         # We need to capture the hook when it's passed to AsyncClient
@@ -1007,7 +1005,6 @@ class TestURLUploadCoverageGaps:
 
         async def mock_aiter_bytes(chunk_size=None):
             yield b"PDF content"
-
         mock_response.aiter_bytes = mock_aiter_bytes
 
         mock_stream_ctx = AsyncMock()

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -940,6 +940,7 @@ class TestURLUploadCoverageGaps:
 
         async def mock_aiter_bytes(chunk_size=None):
             yield b"PDF content"
+
         mock_response.aiter_bytes = mock_aiter_bytes
 
         mock_stream_ctx = AsyncMock()
@@ -963,9 +964,12 @@ class TestURLUploadCoverageGaps:
     @patch("app.api.url_upload.process_document")
     def test_process_url_verify_redirect_unreachable(self, mock_process_document, mock_async_client_class, client):
         """Test the verify_redirect hook error specifically"""
-        import httpx
-        from app.api.url_upload import verify_redirect
         import asyncio
+
+        import httpx
+
+        from app.api.url_upload import verify_redirect
+
         loop = asyncio.get_event_loop()
 
         mock_response = MagicMock(spec=httpx.Response)
@@ -982,14 +986,14 @@ class TestURLUploadCoverageGaps:
 
         assert "Redirect to unsafe URL blocked" in str(exc_info.value)
 
-
     @patch("app.api.url_upload.httpx.AsyncClient")
     @patch("app.api.url_upload.process_document")
     def test_process_url_validate_redirect_hook(self, mock_process_document, mock_async_client_class, client):
         """Test the inner validate_redirect hook inside process_url"""
-        import httpx
-        from fastapi import HTTPException
         import asyncio
+
+        import httpx
+
         loop = asyncio.get_event_loop()
 
         # We need to capture the hook when it's passed to AsyncClient
@@ -1003,6 +1007,7 @@ class TestURLUploadCoverageGaps:
 
         async def mock_aiter_bytes(chunk_size=None):
             yield b"PDF content"
+
         mock_response.aiter_bytes = mock_aiter_bytes
 
         mock_stream_ctx = AsyncMock()

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -1031,3 +1031,97 @@ class TestURLUploadCoverageGaps:
             loop.run_until_complete(validate_redirect_hook(mock_hook_response))
 
         assert "Unsafe redirect target" in str(exc_info.value)
+
+    @patch("app.api.url_upload.httpx.AsyncClient")
+    @patch("app.api.url_upload.process_document")
+    def test_process_url_validate_redirect_hook_missing_location(self, mock_process_document, mock_async_client_class, client):
+        """Test the inner validate_redirect hook inside process_url when Location header is missing"""
+        import asyncio
+
+        import httpx
+        loop = asyncio.get_event_loop()
+
+        # We need to capture the hook when it's passed to AsyncClient
+        mock_client_instance = AsyncMock()
+        mock_async_client_class.return_value.__aenter__.return_value = mock_client_instance
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/pdf"}
+        mock_response.raise_for_status = Mock()
+
+        async def mock_aiter_bytes(chunk_size=None):
+            yield b"PDF content"
+        mock_response.aiter_bytes = mock_aiter_bytes
+
+        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx.__aenter__.return_value = mock_response
+        mock_client_instance.stream.return_value = mock_stream_ctx
+
+        client.post("/api/process-url", json={"url": "https://example.com/test.pdf"})
+
+        hooks = mock_async_client_class.call_args.kwargs["event_hooks"]["response"]
+        validate_redirect_hook = next(h for h in hooks if h.__name__ == "validate_redirect")
+
+        # Test the hook logic
+        mock_hook_response = MagicMock(spec=httpx.Response)
+        mock_hook_response.is_redirect = True
+        mock_hook_response.headers = {} # Missing Location
+
+        # Should complete without error
+        loop.run_until_complete(validate_redirect_hook(mock_hook_response))
+
+    @patch("app.api.url_upload.httpx.AsyncClient")
+    @patch("app.api.url_upload.process_document")
+    def test_process_url_validate_redirect_hook_not_redirect(self, mock_process_document, mock_async_client_class, client):
+        """Test the inner validate_redirect hook inside process_url when response is not a redirect"""
+        import asyncio
+
+        import httpx
+        loop = asyncio.get_event_loop()
+
+        # We need to capture the hook when it's passed to AsyncClient
+        mock_client_instance = AsyncMock()
+        mock_async_client_class.return_value.__aenter__.return_value = mock_client_instance
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/pdf"}
+        mock_response.raise_for_status = Mock()
+
+        async def mock_aiter_bytes(chunk_size=None):
+            yield b"PDF content"
+        mock_response.aiter_bytes = mock_aiter_bytes
+
+        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx.__aenter__.return_value = mock_response
+        mock_client_instance.stream.return_value = mock_stream_ctx
+
+        client.post("/api/process-url", json={"url": "https://example.com/test.pdf"})
+
+        hooks = mock_async_client_class.call_args.kwargs["event_hooks"]["response"]
+        validate_redirect_hook = next(h for h in hooks if h.__name__ == "validate_redirect")
+
+        # Test the hook logic
+        mock_hook_response = MagicMock(spec=httpx.Response)
+        mock_hook_response.is_redirect = False
+
+        # Should complete without error
+        loop.run_until_complete(validate_redirect_hook(mock_hook_response))
+
+    @patch("app.api.url_upload.httpx.AsyncClient")
+    @patch("app.api.url_upload.process_document")
+    def test_verify_redirect_hook_missing_location(self, mock_process_document, mock_async_client_class, client):
+        """Test the outer verify_redirect hook when Location header is missing"""
+        import asyncio
+
+        import httpx
+        from app.api.url_upload import verify_redirect
+        loop = asyncio.get_event_loop()
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 302
+        mock_response.headers = {} # Missing Location
+
+        # Should complete without error
+        loop.run_until_complete(verify_redirect(mock_response))

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -940,6 +940,7 @@ class TestURLUploadCoverageGaps:
 
         async def mock_aiter_bytes(chunk_size=None):
             yield b"PDF content"
+
         mock_response.aiter_bytes = mock_aiter_bytes
 
         mock_stream_ctx = AsyncMock()
@@ -968,6 +969,7 @@ class TestURLUploadCoverageGaps:
         import httpx
 
         from app.api.url_upload import verify_redirect
+
         loop = asyncio.get_event_loop()
 
         mock_response = MagicMock(spec=httpx.Response)
@@ -984,7 +986,6 @@ class TestURLUploadCoverageGaps:
 
         assert "Redirect to unsafe URL blocked" in str(exc_info.value)
 
-
     @patch("app.api.url_upload.httpx.AsyncClient")
     @patch("app.api.url_upload.process_document")
     def test_process_url_validate_redirect_hook(self, mock_process_document, mock_async_client_class, client):
@@ -992,6 +993,7 @@ class TestURLUploadCoverageGaps:
         import asyncio
 
         import httpx
+
         loop = asyncio.get_event_loop()
 
         # We need to capture the hook when it's passed to AsyncClient
@@ -1005,6 +1007,7 @@ class TestURLUploadCoverageGaps:
 
         async def mock_aiter_bytes(chunk_size=None):
             yield b"PDF content"
+
         mock_response.aiter_bytes = mock_aiter_bytes
 
         mock_stream_ctx = AsyncMock()


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SyntaxError breaking SSRF protection

**Severity:** CRITICAL
**Vulnerability:** A `SyntaxError` existed in `app/api/url_upload.py` where the `event_hooks` keyword argument was passed twice to the `httpx.AsyncClient` initialization. This broke the file and prevented successful deployment/execution. Additionally, if the first or second hook was simply removed to fix the SyntaxError without combining them, SSRF protection against malicious redirect chains (from external to internal IP/metadata endpoint mappings) would be degraded or bypassed.
**Impact:** A broken file upload service and a potential SSRF vulnerability allowing attackers to exfiltrate data from internal or cloud metadata networks via HTTP 3xx redirects during file ingest.
**Fix:** Combined the event hook lists into a single list (`event_hooks={"response": [validate_redirect, verify_redirect]}`). This ensures `httpx` properly parses the arguments and successfully executes both validation steps. 
**Verification:** Ran `pytest tests/test_url_upload.py` successfully. Tests correctly run and no `SyntaxError` is observed.

---
*PR created automatically by Jules for task [6499640413954783161](https://jules.google.com/task/6499640413954783161) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL upload security by enhancing redirect handling to detect and block redirects to unsafe or private destinations during fetches.

* **Tests**
  * Added extensive tests covering redirect-safety enforcement, including unreachable or unsafe redirect targets and edge cases (missing Location or non-redirect responses).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christianlouis/DocuElevate/pull/858)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->