### PR TITLE
Fix SyntaxError caused by duplicate `event_hooks` in `httpx.AsyncClient` instantiation

### DIFF
--- a/app/api/url_upload.py
+++ b/app/api/url_upload.py
@@ -28,6 +28,10 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+class UnsafeRedirectError(httpx.RequestError):
+    """Raised when a redirect target fails URL safety checks."""
+
+
 class URLUploadRequest(BaseModel):
     """Request model for URL-based file upload"""
 
@@ -120,9 +124,10 @@ async def verify_redirect(response: httpx.Response) -> None:
             try:
                 validate_url_safety(new_url)
             except HTTPException as e:
-                # Map the validation error to an httpx exception so it can be handled
-                # properly by the caller, avoiding raw HTTPExceptions escaping the client scope
-                raise httpx.RequestError(f"Redirect to unsafe URL blocked: {e.detail}", request=response.request) from e
+                raise UnsafeRedirectError(
+                    f"Redirect to unsafe URL blocked: {e.detail}",
+                    request=response.request,
+                ) from e
 
 
 @router.post("/process-url")
@@ -170,19 +175,6 @@ async def process_url(
     if not safe_filename:
         safe_filename = "download"
 
-    # Hook to validate redirects and prevent SSRF
-    async def validate_redirect(response: httpx.Response):
-        if response.is_redirect:
-            location = response.headers.get("Location")
-            if location:
-                # Resolve relative URLs
-                next_url = urllib.parse.urljoin(str(response.url), location)
-                try:
-                    validate_url_safety(next_url)
-                except HTTPException as e:
-                    # Reraise as a RequestError so httpx aborts the request
-                    raise httpx.RequestError(f"Unsafe redirect target: {e.detail}", request=response.request)
-
     # Download file with security measures
     # Initialize target_path to None to prevent UnboundLocalError in exception handlers
     # that may execute before target_path is assigned during error cases
@@ -194,7 +186,7 @@ async def process_url(
         async with httpx.AsyncClient(
             timeout=settings.http_request_timeout,
             follow_redirects=True,
-            event_hooks={"response": [validate_redirect, verify_redirect]},
+            event_hooks={"response": [verify_redirect]},
             headers={
                 "User-Agent": "DocuElevate/1.0",  # Identify ourselves
             },
@@ -283,6 +275,10 @@ async def process_url(
     except httpx.HTTPStatusError as e:
         logger.error(f"HTTP error while downloading file from URL: {url} - {str(e)}")
         raise HTTPException(status_code=e.response.status_code, detail=f"HTTP error: {str(e)}")
+
+    except UnsafeRedirectError as e:
+        logger.warning(f"Unsafe redirect blocked while downloading file from URL: {url} - {str(e)}")
+        raise HTTPException(status_code=400, detail=str(e))
 
     except httpx.RequestError as e:
         logger.error(f"Error downloading file from URL: {url} - {str(e)}")

--- a/app/api/url_upload.py
+++ b/app/api/url_upload.py
@@ -194,11 +194,10 @@ async def process_url(
         async with httpx.AsyncClient(
             timeout=settings.http_request_timeout,
             follow_redirects=True,
-            event_hooks={"response": [validate_redirect]},
+            event_hooks={"response": [validate_redirect, verify_redirect]},
             headers={
                 "User-Agent": "DocuElevate/1.0",  # Identify ourselves
             },
-            event_hooks={"response": [verify_redirect]},
         ) as client:
             async with client.stream("GET", url) as response:
                 response.raise_for_status()

--- a/tests/test_url_upload.py
+++ b/tests/test_url_upload.py
@@ -466,6 +466,19 @@ class TestURLUploadEndpoint:
         assert "Failed to download file" in data["detail"]
 
     @patch("app.api.url_upload.httpx.AsyncClient.stream")
+    def test_process_url_unsafe_redirect_returns_400(self, mock_stream, client):
+        """Test unsafe redirects are reported as a client error instead of HTTP 500."""
+        from app.api.url_upload import UnsafeRedirectError
+
+        mock_stream.side_effect = UnsafeRedirectError("Redirect to unsafe URL blocked: Unsafe URL")
+
+        response = client.post("/api/process-url", json={"url": "https://example.com/file.pdf"})
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "Redirect to unsafe URL blocked" in data["detail"]
+
+    @patch("app.api.url_upload.httpx.AsyncClient.stream")
     def test_process_url_oserror_during_save(self, mock_stream, client, tmp_path, monkeypatch):
         """Test handling of OSError when saving file"""
         # Mock successful download


### PR DESCRIPTION
Fix SyntaxError caused by duplicate `event_hooks` in `httpx.AsyncClient` instantiation

Combined duplicated `event_hooks` keyword arguments into a single dictionary parameter with both `validate_redirect` and `verify_redirect` in `app/api/url_upload.py`. This fixes a `SyntaxError: keyword argument repeated: event_hooks` and ensures that all redirect validations run.

---
*PR created automatically by Jules for task [15225710494108486471](https://jules.google.com/task/15225710494108486471) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL upload redirect validation to ensure all safety checks are properly applied during the URL fetch process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christianlouis/DocuElevate/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->