### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM-based XSS in OAuth callback templates

### DIFF
--- a/frontend/templates/dropbox_callback.html
+++ b/frontend/templates/dropbox_callback.html
@@ -400,9 +400,13 @@ DROPBOX_FOLDER=${folderPath || '/Documents/Uploads'}`;
 
   // ── Folder browser ────────────────────────────────────────────────
   function escapeHtml(str) {
-    const div = document.createElement('div');
-    div.appendChild(document.createTextNode(str));
-    return div.innerHTML;
+    if (!str) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
   }
 
   function initFolderBrowser(accessToken, integrationId) {

--- a/frontend/templates/onedrive_callback.html
+++ b/frontend/templates/onedrive_callback.html
@@ -331,9 +331,13 @@ ONEDRIVE_FOLDER_PATH=${folderPath || 'Documents/Uploads'}`;
 
   // ── Folder browser ────────────────────────────────────────────────
   function escapeHtml(str) {
-    const div = document.createElement('div');
-    div.appendChild(document.createTextNode(str));
-    return div.innerHTML;
+    if (!str) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
   }
 
   function initFolderBrowser(accessToken, integrationId) {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix DOM-based XSS in OAuth callback templates

🚨 Severity: HIGH
💡 Vulnerability: The `escapeHtml` function in `dropbox_callback.html` and `onedrive_callback.html` used a DOM-based approach (`document.createTextNode`) which failed to escape quotes (`'` and `"`). This left the templates vulnerable to DOM-based XSS if user-controlled names/paths containing quotes were injected into HTML attributes.
🎯 Impact: An attacker could potentially inject malicious JavaScript by providing crafted directory or file names, leading to arbitrary script execution in the context of the user's browser.
🔧 Fix: Replaced the DOM-based `escapeHtml` implementations with a regex-based version that correctly escapes `<`, `>`, `&`, `"`, and `'`.
✅ Verification: Ensure the new regex correctly escapes malicious payload characters such as `<img src=x onerror=alert() />` inside rendered output.

---
*PR created automatically by Jules for task [2167230632026054088](https://jules.google.com/task/2167230632026054088) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTML escaping in Dropbox and OneDrive callback templates to properly sanitize user-provided and API-provided strings during HTML generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->