### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM XSS via unsanitized error messages in innerHTML

### DIFF
--- a/frontend/templates/file_view.html
+++ b/frontend/templates/file_view.html
@@ -620,6 +620,16 @@
     });
   }
 
+  function escapeHtml(str) {
+    if (!str) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
   // ── On-demand text extraction (when ocr_text not in DB) ──
   var _textCache = null;
   function loadText(fileId) {
@@ -638,7 +648,7 @@
         renderText(area, data.text);
       })
       .catch(function(err) {
-        area.innerHTML = '<div style="color:#dc2626;padding:0.75rem;background:#fee2e2;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-exclamation-triangle"></i> Failed to extract text: ' + err.message + '</div>';
+        area.innerHTML = '<div style="color:#dc2626;padding:0.75rem;background:#fee2e2;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-exclamation-triangle"></i> Failed to extract text: ' + escapeHtml(err.message) + '</div>';
       });
   }
 
@@ -869,7 +879,7 @@
         area.appendChild(pre);
       })
       .catch(function(err) {
-        area.innerHTML = '<div style="color:#92400e;padding:0.75rem;background:#fef3c7;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-info-circle" aria-hidden="true"></i> ' + err.message + '</div>';
+        area.innerHTML = '<div style="color:#92400e;padding:0.75rem;background:#fef3c7;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-info-circle" aria-hidden="true"></i> ' + escapeHtml(err.message) + '</div>';
       });
   }
 
@@ -901,7 +911,7 @@
         if (copyBtn) copyBtn.style.display = '';
       })
       .catch(function(err) {
-        area.innerHTML = '<div style="color:#dc2626;padding:0.75rem;background:#fee2e2;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> Translation failed: ' + err.message + '</div>';
+        area.innerHTML = '<div style="color:#dc2626;padding:0.75rem;background:#fee2e2;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> Translation failed: ' + escapeHtml(err.message) + '</div>';
       });
   }
 


### PR DESCRIPTION
Sentinel has identified and patched a High severity DOM-based XSS vulnerability in `frontend/templates/file_view.html`. 

Vulnerability:
The code was taking network error payloads via `.catch(function(err) {})` and injecting `err.message` directly into `area.innerHTML`. If an error payload contained unescaped HTML characters, it would be evaluated as HTML/JS by the browser. 

Fix:
Introduced an `escapeHtml` utility and securely sanitized all error injections.

---
*PR created automatically by Jules for task [13508857434058006782](https://jules.google.com/task/13508857434058006782) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security handling for error messages in three separate asynchronous workflows: on-demand text extraction failures, default-language translation loading errors, and on-the-fly translation processing failures. Error messages are now properly HTML-escaped to prevent them from being unintentionally interpreted or executed as code when displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->