### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM-based XSS via unescaped error messages in file_view.html

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** A Cross-Site Scripting (XSS) vulnerability existed in `frontend/templates/status_dashboard.html` where untrusted configuration settings (`value`), external service messages (`data.message`), and token expirations (`data.token_info.expires_in_human`) were injected directly into the DOM via `.innerHTML` without sanitization.
 **Learning:** Even internal or admin-focused dashboards can be vulnerable if they display external or user-configurable data without escaping. Constructing HTML strings dynamically from unvalidated sources is a common vector for DOM-based XSS.
 **Prevention:** Always use a sanitization function like `escapeHtml` to escape dangerous characters (`<`, `>`, `&`, `"`, `'`) before assigning dynamic content to `.innerHTML`, or prefer `.textContent` when only plaintext is intended.
+
+## 2025-02-26 - [DOM-Based XSS in Frontend Templates]
+**Vulnerability:** Fetch error handlers assigned `err.message` directly to `innerHTML` without sanitization, allowing DOM-based Cross-Site Scripting (XSS) if the API returned an error message reflecting malicious input.
+**Learning:** Error messages returned by APIs should always be treated as untrusted input when rendered in the DOM, especially when using `innerHTML`. This codebase frequently uses vanilla JavaScript with direct DOM manipulation.
+**Prevention:** Always define and use an `escapeHtml` function to sanitize user-controlled or API-returned strings before inserting them into the DOM via `innerHTML`, or use `textContent` where applicable.

--- a/frontend/templates/file_view.html
+++ b/frontend/templates/file_view.html
@@ -6,6 +6,16 @@
   <!-- PDF.js library (Apache 2.0 License - compatible) -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
   <script>
+  function escapeHtml(str) {
+    if (!str) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
     pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
   </script>
   <style>
@@ -638,7 +648,7 @@
         renderText(area, data.text);
       })
       .catch(function(err) {
-        area.innerHTML = '<div style="color:#dc2626;padding:0.75rem;background:#fee2e2;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-exclamation-triangle"></i> Failed to extract text: ' + err.message + '</div>';
+        area.innerHTML = '<div style="color:#dc2626;padding:0.75rem;background:#fee2e2;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-exclamation-triangle"></i> Failed to extract text: ' + escapeHtml(err.message) + '</div>';
       });
   }
 
@@ -869,7 +879,7 @@
         area.appendChild(pre);
       })
       .catch(function(err) {
-        area.innerHTML = '<div style="color:#92400e;padding:0.75rem;background:#fef3c7;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-info-circle" aria-hidden="true"></i> ' + err.message + '</div>';
+        area.innerHTML = '<div style="color:#92400e;padding:0.75rem;background:#fef3c7;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-info-circle" aria-hidden="true"></i> ' + escapeHtml(err.message) + '</div>';
       });
   }
 
@@ -901,7 +911,7 @@
         if (copyBtn) copyBtn.style.display = '';
       })
       .catch(function(err) {
-        area.innerHTML = '<div style="color:#dc2626;padding:0.75rem;background:#fee2e2;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> Translation failed: ' + err.message + '</div>';
+        area.innerHTML = '<div style="color:#dc2626;padding:0.75rem;background:#fee2e2;border-radius:0.375rem;font-size:0.875rem;"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> Translation failed: ' + escapeHtml(err.message) + '</div>';
       });
   }
 


### PR DESCRIPTION
**Vulnerability Fixed**:
When the file view frontend logic catches an error from fetch requests (e.g., text extraction, translation), it directly injects the `err.message` into an HTML template using `.innerHTML`. If an API returns an error message that reflects unsanitized user input or external content, this opens up a vector for DOM-based Cross-Site Scripting (XSS).

**Solution**:
- Defined an `escapeHtml` function within `frontend/templates/file_view.html` (identical to the one used elsewhere in the codebase).
- Updated the three vulnerable `.catch()` blocks in the file to sanitize `err.message` through `escapeHtml` before assignment to `.innerHTML`.
- Appended a learning entry to `.jules/sentinel.md` regarding DOM manipulation and untrusted API error messages.

---
*PR created automatically by Jules for task [18150530942002175726](https://jules.google.com/task/18150530942002175726) started by @christianlouis*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages displayed during file loading, text extraction, and translation operations are now rendered securely, preventing potential security vulnerabilities through error injection.

* **Documentation**
  * Updated security documentation to track vulnerability remediation and prevention measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->