### PR TITLE
fix: override shell-quote to patched version

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -11571,9 +11571,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -59,6 +59,7 @@
     "typescript": "^5.3.0"
   },
   "overrides": {
+    "shell-quote": "1.8.4",
     "postcss": "8.5.15",
     "uuid": "11.1.1",
     "brace-expansion@^1.1.7": "1.1.13",


### PR DESCRIPTION
## Summary\n- override transitive `shell-quote` in the mobile app to `1.8.4`\n- refresh the mobile lockfile so `react-devtools-core` resolves the patched package\n\n## Validation\n- `npm install --package-lock-only`\n- `npm ls shell-quote --all --package-lock-only` shows `1.8.4` overridden\n\nCloses Dependabot alert #83.