### PR TITLE
Fix search error message escaping

### DIFF
--- a/frontend/templates/files.html
+++ b/frontend/templates/files.html
@@ -1534,7 +1534,7 @@
         .then(data => renderSearchResults(data, q))
         .catch(err => {
           const errorMessage = err && err.message ? err.message : '';
-          list.innerHTML = '<div style="padding: 1rem; color: #dc2626; font-size: 0.875rem;"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> ' + escapeHtml(__i18n.searchUnavailable.replace('{error}', errorMessage)) + '</div>';
+          list.innerHTML = '<div role="alert" aria-live="assertive" style="padding: 1rem; color: #dc2626; font-size: 0.875rem;"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> ' + escapeHtml(__i18n.searchUnavailable.replace('{error}', errorMessage)) + '</div>';
           summary.textContent = '';
         });
     }

--- a/frontend/templates/files.html
+++ b/frontend/templates/files.html
@@ -1533,7 +1533,8 @@
         })
         .then(data => renderSearchResults(data, q))
         .catch(err => {
-          list.innerHTML = '<div style="padding: 1rem; color: #dc2626; font-size: 0.875rem;"><i class="fas fa-exclamation-triangle"></i> ' + __i18n.searchUnavailable.replace('{error}', err.message) + '</div>';
+          const errorMessage = err && err.message ? err.message : '';
+          list.innerHTML = '<div style="padding: 1rem; color: #dc2626; font-size: 0.875rem;"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> ' + escapeHtml(__i18n.searchUnavailable.replace('{error}', errorMessage)) + '</div>';
           summary.textContent = '';
         });
     }


### PR DESCRIPTION
## Summary
- escape the files search error message before writing it via innerHTML
- keep only static icon markup in the generated error banner

## Validation
- checked that the previous unescaped err.message pattern is no longer present in frontend/templates/files.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search error handling by safely escaping error text before showing it in the results banner.
  * Prevents untrusted error content from being displayed directly to users.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->