### PR TITLE
test: cover automation samples and pending counts

### DIFF
--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -370,12 +370,22 @@ class TestAutomationAPI:
         assert len(data) == 1
         assert data[0]["event"] == "document.uploaded"
         assert "id" in data[0]
+        assert data[0] == SAMPLE_PAYLOADS["document.uploaded"]
+
+    @pytest.mark.parametrize("event", sorted(VALID_EVENTS))
+    def test_trigger_sample_matches_configured_payloads(self, client, event):
+        """Each valid trigger sample returns the configured Zapier payload."""
+        self._with_auth(client)
+        resp = client.get(f"/api/automation/triggers/sample/{event}")
+        assert resp.status_code == 200
+        assert resp.json() == [SAMPLE_PAYLOADS[event]]
 
     def test_trigger_sample_unknown_event(self, client):
         """GET /api/automation/triggers/sample/bad returns 404."""
         self._with_auth(client)
         resp = client.get("/api/automation/triggers/sample/bad.event")
         assert resp.status_code == 404
+        assert "Unknown event: bad.event" in resp.json()["detail"]
 
     # ── Events listing ───────────────────────────────────────────────
 

--- a/tests/test_queue_monitoring.py
+++ b/tests/test_queue_monitoring.py
@@ -194,14 +194,52 @@ class TestPendingCountEndpoint:
         assert data["total_pending"] >= 0
 
     @patch("app.api.queue.redis.Redis")
-    def test_pending_count_redis_failure_still_works(self, mock_redis_cls, client):
+    def test_pending_count_combines_redis_and_processing_db_rows(self, mock_redis_cls, client, db_session):
+        """Pending count includes all queue depths plus distinct in-progress files."""
+        from app.models import FileProcessingStep, FileRecord
+
+        file1 = FileRecord(filehash="pending-1", local_filename="pending-1.pdf", file_size=100, is_duplicate=False)
+        file2 = FileRecord(filehash="pending-2", local_filename="pending-2.pdf", file_size=100, is_duplicate=False)
+        db_session.add_all([file1, file2])
+        db_session.commit()
+        db_session.add_all(
+            [
+                FileProcessingStep(file_id=file1.id, step_name="extract_text", status="in_progress"),
+                FileProcessingStep(file_id=file1.id, step_name="classify", status="in_progress"),
+                FileProcessingStep(file_id=file2.id, step_name="extract_text", status="success"),
+            ]
+        )
+        db_session.commit()
+
+        mock_redis_instance = MagicMock()
+        mock_redis_instance.llen.side_effect = [2, 3, 5]
+        mock_redis_cls.from_url.return_value = mock_redis_instance
+
+        response = client.get("/api/queue/pending-count")
+        assert response.status_code == 200
+        assert response.json() == {"total_pending": 11}
+        assert mock_redis_instance.llen.call_args_list == [
+            (("document_processor",),),
+            (("default",),),
+            (("celery",),),
+        ]
+        mock_redis_instance.close.assert_called_once()
+
+    @patch("app.api.queue.redis.Redis")
+    def test_pending_count_redis_failure_still_counts_processing_db_rows(self, mock_redis_cls, client, db_session):
         """Test pending count still works when Redis is down."""
+        from app.models import FileProcessingStep, FileRecord
+
+        file_record = FileRecord(filehash="pending-redis-down", local_filename="pending.pdf", file_size=100)
+        db_session.add(file_record)
+        db_session.commit()
+        db_session.add(FileProcessingStep(file_id=file_record.id, step_name="extract_text", status="in_progress"))
+        db_session.commit()
         mock_redis_cls.from_url.side_effect = Exception("Connection refused")
 
         response = client.get("/api/queue/pending-count")
         assert response.status_code == 200
-        data = response.json()
-        assert "total_pending" in data
+        assert response.json() == {"total_pending": 1}
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- strengthen automation trigger sample endpoint coverage against configured sample payloads
- assert unknown trigger sample errors include the invalid event
- cover /api/queue/pending-count with Redis queue depths plus distinct in-progress DB rows and Redis-down fallback

## Validation
- python3 -m compileall tests/test_automation.py tests/test_queue_monitoring.py
- git diff --check

Local pytest/black/flake8 modules are not installed in this Python environment, so full validation is delegated to GitHub CI.