### PR TITLE
Avoid blocking folder listing endpoints

### DIFF
--- a/app/api/dropbox.py
+++ b/app/api/dropbox.py
@@ -2,6 +2,7 @@
 Dropbox API endpoints
 """
 
+import asyncio
 import logging
 import os
 from typing import Annotated, Optional
@@ -344,7 +345,8 @@ async def list_dropbox_folders(
             "include_mounted_folders": True,
         }
 
-        response = requests.post(
+        response = await asyncio.to_thread(
+            requests.post,
             "https://api.dropboxapi.com/2/files/list_folder",
             headers=headers,
             json=payload,

--- a/app/api/onedrive.py
+++ b/app/api/onedrive.py
@@ -2,6 +2,7 @@
 OneDrive API endpoints
 """
 
+import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import Annotated, Optional
@@ -229,7 +230,8 @@ async def list_onedrive_folders(
             "$top": "200",
         }
 
-        response = requests.get(
+        response = await asyncio.to_thread(
+            requests.get,
             url,
             headers=headers,
             params=params,

--- a/app/api/onedrive.py
+++ b/app/api/onedrive.py
@@ -230,13 +230,8 @@ async def list_onedrive_folders(
             "$top": "200",
         }
 
-        response = await asyncio.to_thread(
-            requests.get,
-            url,
-            headers=headers,
-            params=params,
-            timeout=settings.http_request_timeout,
-        )
+        request_kwargs = {"headers": headers, "params": params, "timeout": settings.http_request_timeout}
+        response = await asyncio.to_thread(requests.get, url, **request_kwargs)
 
         if response.status_code == 401:
             raise HTTPException(


### PR DESCRIPTION
## Summary
- run Dropbox folder listing HTTP calls in a worker thread from the async endpoint
- run OneDrive folder listing HTTP calls in a worker thread from the async endpoint
- keep existing requests-based error handling and response parsing unchanged

## Validation
- python3 -m py_compile app/api/dropbox.py app/api/onedrive.py
- git diff --check

## Notes
- Local focused pytest attempts in existing DocuElevate venvs hang while importing pytest/iniconfig before collection, so CI should be treated as the authoritative test run.