### PR TITLE
ci: serialize semantic release pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: semantic-release-main
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write
@@ -63,7 +67,8 @@ jobs:
             if ! git diff --quiet CHANGELOG.md; then
               git add CHANGELOG.md
               git commit -m "docs(changelog): update changelog [skip ci]"
-              git push
+              git pull --rebase origin main
+              git push origin HEAD:main
             fi
           fi
 
@@ -76,5 +81,6 @@ jobs:
           done
           if ! git diff --staged --quiet; then
             git commit -m "chore(release): update build metadata files [skip ci]"
-            git push
+            git pull --rebase origin main
+            git push origin HEAD:main
           fi


### PR DESCRIPTION
## Summary
- serialize Semantic Release workflow runs on main to reduce Dependabot merge-burst push races
- rebase automated changelog/build-metadata commits onto current main before pushing

## Root cause
Multiple main push runs tried to commit and push generated CHANGELOG.md updates in parallel. Earlier runs failed with non-fast-forward push rejections while the latest run eventually succeeded.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation reliability by coordinating concurrent release jobs to avoid conflicting updates.
  * Updated the release process to synchronize with the latest main branch before publishing changes, reducing push conflicts and failed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->