### PR TITLE
docs: reconcile release naming anchors

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -318,8 +318,6 @@ Starting with v0.6.0, releases are fully automated using `python-semantic-releas
 - [ ] Documentation updated
 - [ ] Release notes generated
 - [ ] Migration guide (if breaking changes)
-- [ ] Release notes drafted
-- [ ] Version numbers bumped
 - [ ] Docker images built and tested
 
 ### Release Artifacts

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -23,18 +23,20 @@ DocuElevate follows [Semantic Versioning 2.0.0](https://semver.org/):
 
 DocuElevate ships continuously via automated semantic versioning. Use **GitHub Releases** for the latest build artifacts and **GitHub Milestones** (below) for roadmap tracking.
 
-### Last Shipped Milestone: v0.5.0 (Released February 8, 2026)
+### Last Completed Named Milestone Anchor: v0.5.0 (Released February 8, 2026)
 - Database-backed settings management with encryption
 - Setup wizard for first-time configuration
 - Admin UI for runtime configuration
 - Release automation via semantic-release
+
+The current build number is managed by semantic-release and may be ahead of the planning anchors below. Check `VERSION` and GitHub Releases for the exact current release stream.
 
 ### Important Note on Versioning
 As of February 2026, DocuElevate uses **automated semantic versioning**:
 - Version management handled by `python-semantic-release`
 - Releases automated via GitHub Actions on merge to main
 - Version bumps determined by conventional commit messages
-- `VERSION` and `CHANGELOG.md` automatically updated
+- `VERSION` and generated release notes are automatically updated; `CHANGELOG.md` is release automation output and is not edited manually
 - GitHub Releases created automatically with release notes
 
 ---
@@ -126,7 +128,7 @@ As of February 2026, DocuElevate uses **automated semantic versioning**:
 
 ---
 
-## Upcoming Milestones
+## Upcoming Planning Anchors
 
 ### v0.6.0 - Clarity: Enhanced Search & UI (Target: July 31, 2026)
 **Target Date:** July 31, 2026
@@ -297,11 +299,11 @@ Starting with v0.6.0, releases are fully automated using `python-semantic-releas
 3. **Automated Analysis**: semantic-release determines version from commits
 4. **Automatic Updates**:
    - Updates `VERSION` file
-   - Generates/updates `CHANGELOG.md`
+   - Generates release notes and updates generated changelog state where configured
    - Creates Git tag (e.g., `v0.173.1`)
    - Creates GitHub Release with notes
    - Triggers Docker image builds
-5. **No Manual Steps**: VERSION and CHANGELOG are never edited manually
+5. **No Manual Steps**: VERSION and generated changelog state are never edited manually
 
 ### Version Bump Rules
 - `feat:` commits → Minor version (e.g., 0.173.1 → 0.174.0)
@@ -314,7 +316,7 @@ Starting with v0.6.0, releases are fully automated using `python-semantic-releas
 - [ ] Security scan passed
 - [ ] Code review completed
 - [ ] Documentation updated
-- [ ] CHANGELOG.md updated
+- [ ] Release notes generated
 - [ ] Migration guide (if breaking changes)
 - [ ] Release notes drafted
 - [ ] Version numbers bumped
@@ -329,9 +331,9 @@ Starting with v0.6.0, releases are fully automated using `python-semantic-releas
 
 ---
 
-## Version History
+## Version History and Planning Anchors
 
-| Version | Release Date | Theme | Status |
+| Anchor | Release Date | Theme | Status |
 |---------|-------------|-------|--------|
 | v0.1.0 | 2024-Q1 | Initial Release | Released |
 | v0.2.0 | 2024-Q3 | Multi-provider Support | Released |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,9 @@ For the detailed milestone breakdown and target dates, see [MILESTONES.md](MILES
 
 ## Release Naming
 
-Each major milestone release carries a codename to anchor key project moments. These names appear in the status dashboard, build metadata, and changelog. For details, see [docs/ReleaseNaming.md](docs/ReleaseNaming.md).
+Selected milestone anchors carry codenames to mark key project moments. These names appear in runtime surfaces only when the current automated release stream matches an entry in `release_names.json`; continuous release streams such as `0.173.x` may remain unnamed. For details, see [docs/ReleaseNaming.md](docs/ReleaseNaming.md).
 
-| Milestone | Codename        | Theme |
+| Planning Anchor | Codename        | Theme |
 |----------|------------------|-------|
 | v0.6.0   | **Clarity**      | Search, discovery, and modern UX |
 | v0.7.0   | **Conductor**    | Workflows, orchestration, and integrations |
@@ -76,7 +76,7 @@ Each major milestone release carries a codename to anchor key project moments. T
 
 ## Release Plan (Extended)
 
-This plan extends the existing milestones with a clearer thematic arc and a forward-looking “beyond v2.0” horizon. Each milestone links to an epic issue that owns scope and sub-issues.
+This plan extends the existing milestone anchors with a clearer thematic arc and a forward-looking “beyond v2.0” horizon. The anchor labels are planning references, not promises that the automated semantic-release stream will stay numerically below them. Each milestone links to an epic issue that owns scope and sub-issues.
 
 ### v0.6.0 — Clarity (Search & UX)
 - **Outcome:** users can reliably find, preview, and act on documents in seconds

--- a/docs/ReleaseNaming.md
+++ b/docs/ReleaseNaming.md
@@ -19,9 +19,11 @@ This happens automatically — no manual intervention needed.
 Major milestone releases carry a **codename** that anchors the release in project history. Codenames:
 
 - Are defined in [`release_names.json`](../release_names.json) at the project root
-- Map to **minor version ranges** (e.g., all `0.5.x` releases share the codename "Foundation")
-- Appear in the status dashboard, build metadata, and footer
+- Map to **selected minor version anchors** (e.g., all `0.5.x` releases share the codename "Foundation")
+- Appear in the status dashboard, build metadata, and footer when the current release stream matches a named anchor
 - Do **not** interfere with automatic version numbering
+
+Not every automated release stream has a codename. For example, a continuous release such as `0.173.x` may be intentionally unnamed unless `release_names.json` defines a matching `0.173` anchor.
 
 ### Current Release Names
 
@@ -30,9 +32,12 @@ Major milestone releases carry a **codename** that anchors the release in projec
 | 0.5.x         | **Foundation** | Core platform with multi-provider storage, AI, and UI    |
 | 0.6.x         | **Clarity**    | Enhanced search, filtering, and improved UI/UX           |
 | 0.7.x         | **Conductor**  | Workflow automation, custom pipelines, rule-based logic   |
+| 0.8.x         | **Signal**     | AI quality, retrieval, and multi-language foundations     |
 | 1.0.x         | **Summit**     | Enterprise-ready: multi-tenancy, RBAC, horizontal scaling|
 | 1.1.x         | **Bridge**     | Collaboration features, document sharing, analytics      |
 | 2.0.x         | **Horizon**    | On-premise AI, advanced management, platform expansion   |
+| 2.1.x         | **Sentinel**   | Governance, compliance, and policy-driven automation     |
+| 3.0.x         | **Constellation** | Integration hub, agent platform, interoperability     |
 
 ## Adding a New Release Name
 
@@ -67,7 +72,7 @@ The application resolves codenames using a cascading lookup against the current 
 2. **Minor prefix**: Checks the minor version prefix (e.g., `0.5`)
 3. **Major prefix**: Checks the major version prefix (e.g., `0`)
 
-This means all patch releases within a minor version series inherit the same codename.
+This means all patch releases within a named minor version series inherit the same codename. If no exact, minor, or major entry exists, the application leaves the release name empty rather than inventing one.
 
 ## Codename Naming Conventions
 
@@ -95,7 +100,7 @@ This creates a clear link between planning (milestones), delivery (releases), an
 ### Do
 
 - ✅ Let semantic-release handle all version numbering automatically
-- ✅ Use codenames for **milestone releases** (minor/major versions), not every patch
+- ✅ Use codenames for **selected milestone anchors** (minor/major versions), not every patch or every continuous-release stream
 - ✅ Reference codenames in release notes and changelogs for major versions
 - ✅ Keep `release_names.json` in sync with `ROADMAP.md`
 - ✅ Announce codenames in GitHub Release descriptions for milestone versions
@@ -115,6 +120,8 @@ This creates a clear link between planning (milestones), delivery (releases), an
 | Page footer             | `Version 0.5.3 "Foundation"`            |
 | RUNTIME_INFO metadata   | `Release Name: Foundation`              |
 | ROADMAP.md              | Section headers include codenames       |
+
+Unnamed automated releases omit the codename portion in runtime surfaces.
 
 ## File Reference
 

--- a/release_names.json
+++ b/release_names.json
@@ -17,6 +17,11 @@
       "description": "Workflow automation, custom pipelines, and rule-based processing",
       "milestone": "v0.7.0 - Workflow Automation"
     },
+    "0.8": {
+      "codename": "Signal",
+      "description": "AI quality, retrieval, and multi-language foundations",
+      "milestone": "v0.8.0 - Advanced AI & Multi-language"
+    },
     "1.0": {
       "codename": "Summit",
       "description": "Enterprise-ready with multi-tenancy, RBAC, and horizontal scaling",
@@ -31,6 +36,16 @@
       "codename": "Horizon",
       "description": "On-premise AI, advanced document management, and platform expansion",
       "milestone": "v2.0.0 - Next Generation"
+    },
+    "2.1": {
+      "codename": "Sentinel",
+      "description": "Governance, compliance, and policy-driven automation",
+      "milestone": "v2.1.0 - Governance & Policy"
+    },
+    "3.0": {
+      "codename": "Constellation",
+      "description": "Integration hub, agent platform, and interoperability",
+      "milestone": "v3.0.0 - Integration Hub & Agent Platform"
     }
   }
 }

--- a/tests/test_release_names.py
+++ b/tests/test_release_names.py
@@ -283,8 +283,7 @@ class TestReleaseNamesJson:
         assert roadmap_codenames, "ROADMAP.md should list at least one named release anchor"
         missing_codenames = roadmap_codenames - known_codenames
         assert not missing_codenames, (
-            "ROADMAP.md contains release anchors missing from release_names.json: "
-            f"{sorted(missing_codenames)}"
+            f"ROADMAP.md contains release anchors missing from release_names.json: {sorted(missing_codenames)}"
         )
 
     def test_release_names_json_entries_are_documented(self):

--- a/tests/test_release_names.py
+++ b/tests/test_release_names.py
@@ -280,7 +280,12 @@ class TestReleaseNamesJson:
         )
         known_codenames = {entry["codename"] for entry in data["releases"].values()}
 
-        assert roadmap_codenames <= known_codenames
+        assert roadmap_codenames, "ROADMAP.md should list at least one named release anchor"
+        missing_codenames = roadmap_codenames - known_codenames
+        assert not missing_codenames, (
+            "ROADMAP.md contains release anchors missing from release_names.json: "
+            f"{sorted(missing_codenames)}"
+        )
 
     def test_release_names_json_entries_are_documented(self):
         """Test that release_names.json codenames are listed in the naming guide."""

--- a/tests/test_release_names.py
+++ b/tests/test_release_names.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 from unittest.mock import Mock, patch
 
 import pytest
@@ -231,9 +232,13 @@ class TestReleaseNameInStatusView:
 class TestReleaseNamesJson:
     """Tests for the release_names.json data file."""
 
+    @staticmethod
+    def _repo_file(*parts):
+        return os.path.join(os.path.dirname(os.path.dirname(__file__)), *parts)
+
     def test_release_names_json_is_valid(self):
         """Test that release_names.json is valid JSON."""
-        release_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), "release_names.json")
+        release_file = self._repo_file("release_names.json")
         with open(release_file, "r") as f:
             data = json.load(f)
 
@@ -242,7 +247,7 @@ class TestReleaseNamesJson:
 
     def test_release_names_json_entries_have_codename(self):
         """Test that all entries in release_names.json have a codename."""
-        release_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), "release_names.json")
+        release_file = self._repo_file("release_names.json")
         with open(release_file, "r") as f:
             data = json.load(f)
 
@@ -253,9 +258,39 @@ class TestReleaseNamesJson:
 
     def test_release_names_json_codenames_are_unique(self):
         """Test that all codenames in release_names.json are unique."""
-        release_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), "release_names.json")
+        release_file = self._repo_file("release_names.json")
         with open(release_file, "r") as f:
             data = json.load(f)
 
         codenames = [entry["codename"] for entry in data["releases"].values()]
         assert len(codenames) == len(set(codenames)), "Codenames must be unique"
+
+    def test_roadmap_named_anchors_exist_in_release_names_json(self):
+        """Test that roadmap codenames are backed by release_names.json."""
+        release_file = self._repo_file("release_names.json")
+        with open(release_file, "r") as f:
+            data = json.load(f)
+
+        roadmap_file = self._repo_file("ROADMAP.md")
+        with open(roadmap_file, "r") as f:
+            roadmap = f.read()
+
+        roadmap_codenames = set(
+            re.findall(r"^\|\s*v[\d.]+(?:\+)?\s*\|\s*\*\*([A-Z][A-Za-z]+)\*\*", roadmap, re.MULTILINE)
+        )
+        known_codenames = {entry["codename"] for entry in data["releases"].values()}
+
+        assert roadmap_codenames <= known_codenames
+
+    def test_release_names_json_entries_are_documented(self):
+        """Test that release_names.json codenames are listed in the naming guide."""
+        release_file = self._repo_file("release_names.json")
+        with open(release_file, "r") as f:
+            data = json.load(f)
+
+        guide_file = self._repo_file("docs", "ReleaseNaming.md")
+        with open(guide_file, "r") as f:
+            guide = f.read()
+
+        for entry in data["releases"].values():
+            assert f"**{entry['codename']}**" in guide


### PR DESCRIPTION
## Summary
- clarify that codenames are selected milestone anchors, not every automated release stream
- add missing release-name entries for roadmap anchors Signal, Sentinel, and Constellation
- align roadmap and milestone docs with the current semantic-release stream
- add tests that keep release_names.json, ROADMAP.md, and the naming guide in sync

Closes #955

## Testing
- .venv312/bin/python -m pytest tests/test_release_names.py -q
- .venv312/bin/python -m ruff check tests/test_release_names.py
- .venv312/bin/python -m ruff format --check tests/test_release_names.py
- python3 -m json.tool release_names.json >/dev/null
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how named release codenames work and where they appear.
  * Updated planning and milestone terminology across release docs.
  * Added guidance for unnamed automated releases and expanded the codename reference list.

* **New Features**
  * Added new release name entries for additional version ranges, including new codenames for 0.8.x, 2.1.x, and 3.0.x.

* **Tests**
  * Expanded validation to ensure roadmap planning anchors match documented release names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->