### PR TITLE
test: clarify release-name roadmap coverage

### DIFF
--- a/tests/test_release_names.py
+++ b/tests/test_release_names.py
@@ -266,7 +266,7 @@ class TestReleaseNamesJson:
         assert len(codenames) == len(set(codenames)), "Codenames must be unique"
 
     def test_roadmap_named_anchors_exist_in_release_names_json(self):
-        """Test that roadmap codenames are backed by release_names.json."""
+        """Test that current roadmap release anchors are backed by release_names.json."""
         release_file = self._repo_file("release_names.json")
         with open(release_file, "r") as f:
             data = json.load(f)
@@ -280,6 +280,8 @@ class TestReleaseNamesJson:
         )
         known_codenames = {entry["codename"] for entry in data["releases"].values()}
 
+        # release_names.json also keeps historical and future names; only roadmap anchors
+        # are required to resolve back to release metadata.
         assert roadmap_codenames, "ROADMAP.md should list at least one named release anchor"
         missing_codenames = roadmap_codenames - known_codenames
         assert not missing_codenames, (


### PR DESCRIPTION
## Summary
- clarify that release_names.json can contain historical/future codenames beyond current ROADMAP anchors
- keep the roadmap coverage assertion one-way so roadmap anchors must resolve to release metadata

## Validation
- git diff --check
- python3 -m pytest tests/test_release_names.py -q *(blocked: pytest is not installed in this local Python)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified test wording around release name anchors and historical entries.
  * No functional behavior, data handling, or user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->