### PR TITLE
fix: clarify processing profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ DocuElevate is an intelligent document processing system that automates the inge
 - **Multi-Engine OCR** — Azure Document Intelligence, Tesseract, EasyOCR, Mistral OCR, Google Cloud Document AI, and AWS Textract with configurable merge strategies
 - **13 Storage Destinations** — Dropbox, Google Drive, OneDrive, Amazon S3, Nextcloud, WebDAV, FTP, SFTP, iCloud Drive, Email (SMTP), Paperless-ngx, Evernote, and Rclone
 - **Multi-Channel Ingestion** — web upload, browser extension, mobile app, CLI, REST API, IMAP email, and watched folders (local, cloud, FTP/SFTP)
-- **Processing Pipelines** — customizable multi-step workflows with conditional routing rules
+- **Processing Profiles** — per-profile OCR behavior, default selection, and conditional routing rules
 - **Full-Text Search** — powered by Meilisearch for instant document discovery
 - **Multi-User with SSO** — local accounts, OAuth2/OIDC (Authentik), and social login (Google, Microsoft, Apple, Dropbox)
 
@@ -116,7 +116,7 @@ Processed documents are distributed to any combination of configured destination
 - **AI metadata extraction** using any supported provider (OpenAI, Anthropic, Gemini, Ollama, OpenRouter, Portkey, Azure OpenAI)
 - **PDF conversion** via Gotenberg with optional PDF/A archival format
 - **Duplicate detection** — exact (SHA-256) and near-duplicate (content similarity with vector embeddings)
-- **Customizable pipelines** — define multi-step processing workflows with conditional routing rules
+- **Customizable processing profiles** — select OCR behavior and route documents to profile defaults
 
 ### Document Management
 - **Full-text search** powered by Meilisearch with saved searches

--- a/app/api/pipelines.py
+++ b/app/api/pipelines.py
@@ -35,17 +35,23 @@ DbSession = Annotated[Session, Depends(get_db)]
 PIPELINE_STEP_TYPES: dict[str, dict[str, Any]] = {
     "convert_to_pdf": {
         "label": "Convert to PDF",
-        "description": "Convert non-PDF documents to PDF format using Gotenberg.",
+        "description": "Convert non-PDF documents to PDF format using Gotenberg. Runtime order is system-managed.",
+        "runtime_effect": "metadata_only",
+        "runtime_effect_description": "Stored for profile planning; it does not currently change processing order.",
         "config_schema": {},
     },
     "check_duplicates": {
         "label": "Check for Duplicates",
-        "description": "Compare file hash against existing documents to detect duplicates.",
+        "description": "Compare file hash against existing documents to detect duplicates. Runtime order is system-managed.",
+        "runtime_effect": "metadata_only",
+        "runtime_effect_description": "Stored for profile planning; duplicate checks use global settings today.",
         "config_schema": {},
     },
     "ocr": {
-        "label": "OCR Processing",
-        "description": "Extract text using Azure Document Intelligence or local Tesseract.",
+        "label": "OCR Profile Settings",
+        "description": "Configure OCR behavior that is applied during the system-managed processing flow.",
+        "runtime_effect": "applied_config",
+        "runtime_effect_description": "OCR language and force-cloud OCR are applied at runtime.",
         "config_schema": {
             "force_cloud_ocr": {
                 "type": "boolean",
@@ -97,27 +103,37 @@ PIPELINE_STEP_TYPES: dict[str, dict[str, Any]] = {
     },
     "extract_metadata": {
         "label": "Metadata Extraction",
-        "description": "Extract structured metadata (document type, sender, recipient, tags) using AI.",
+        "description": "Extract structured metadata (document type, sender, recipient, tags) using AI. Runtime order is system-managed.",
+        "runtime_effect": "metadata_only",
+        "runtime_effect_description": "Stored for profile planning; it does not currently change processing order.",
         "config_schema": {},
     },
     "embed_metadata": {
         "label": "Embed Metadata into PDF",
-        "description": "Write the extracted metadata into the PDF document properties.",
+        "description": "Write the extracted metadata into the PDF document properties. Runtime order is system-managed.",
+        "runtime_effect": "metadata_only",
+        "runtime_effect_description": "Stored for profile planning; it does not currently change processing order.",
         "config_schema": {},
     },
     "compute_embedding": {
         "label": "Compute Text Embedding",
-        "description": "Compute semantic text embeddings for full-text and similarity search.",
+        "description": "Compute semantic text embeddings for full-text and similarity search. Runtime order is system-managed.",
+        "runtime_effect": "metadata_only",
+        "runtime_effect_description": "Stored for profile planning; it does not currently change processing order.",
         "config_schema": {},
     },
     "send_to_destinations": {
         "label": "Send to Storage Destinations",
-        "description": "Upload the processed document to all configured storage destinations.",
+        "description": "Upload the processed document to all configured storage destinations. Runtime order is system-managed.",
+        "runtime_effect": "metadata_only",
+        "runtime_effect_description": "Stored for profile planning; destination uploads use configured integrations today.",
         "config_schema": {},
     },
     "classify": {
         "label": "Document Classification",
-        "description": "Classify the document type using built-in and custom rules (filename patterns, content keywords, metadata matching).",
+        "description": "Classify the document type using built-in and custom rules. Runtime order is system-managed.",
+        "runtime_effect": "metadata_only",
+        "runtime_effect_description": "Stored for profile planning; classification rules use their own settings today.",
         "config_schema": {
             "use_builtin_rules": {
                 "type": "boolean",

--- a/app/models.py
+++ b/app/models.py
@@ -385,12 +385,16 @@ class SubscriptionPlan(Base):
 
 
 class Pipeline(Base):
-    """User-defined processing pipeline: an ordered set of steps.
+    """User-defined processing profile for document handling.
 
     Pipelines are user-specific.  A pipeline with ``owner_id = NULL`` is a
     *system default* pipeline that only admins may create.  Regular users
     create pipelines under their own ``owner_id``.  When a file has no
     explicit pipeline assigned, the active system default is used.
+
+    The current runtime uses these records as processing profiles, not as an
+    executable workflow engine.  OCR step config is applied at runtime; step
+    order and non-OCR steps are stored for planning and UI context.
     """
 
     __tablename__ = "pipelines"
@@ -419,11 +423,11 @@ class Pipeline(Base):
 
 
 class PipelineStep(Base):
-    """A single step in a processing pipeline.
+    """A processing profile step entry.
 
-    Steps are executed in ascending ``position`` order.  Each step has a
-    ``step_type`` that maps to a built-in processing action and an optional
-    ``config`` JSON blob with step-specific parameters.
+    Step order, labels, and enabled state are retained as profile metadata.
+    The current runtime applies OCR step config but does not execute this
+    table as an ordered workflow plan.
     """
 
     __tablename__ = "pipeline_steps"
@@ -431,7 +435,7 @@ class PipelineStep(Base):
     id = Column(Integer, primary_key=True, index=True)
     pipeline_id = Column(Integer, ForeignKey(_PIPELINES_ID_FK), nullable=False, index=True)
 
-    # Execution order within the pipeline (lower = earlier)
+    # Display/planning order within the profile (lower = earlier)
     position = Column(Integer, nullable=False, default=0)
 
     # One of the recognised step types (see PIPELINE_STEP_TYPES in pipelines.py)
@@ -443,7 +447,7 @@ class PipelineStep(Base):
     # JSON-encoded step-specific configuration dict
     config = Column(Text, nullable=True)
 
-    # When False this step is skipped during execution
+    # Profile metadata only for most step types; OCR config is runtime-applied.
     enabled = Column(Boolean, nullable=False, default=True)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/app/tasks/process_document.py
+++ b/app/tasks/process_document.py
@@ -30,17 +30,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _get_pipeline_ocr_language(db: "Session", file_record: FileRecord, owner_id: str | None) -> str | None:
-    """Look up the OCR language override from the file's pipeline OCR step config.
+def _get_pipeline_ocr_config(db: "Session", file_record: FileRecord, owner_id: str | None) -> dict[str, object]:
+    """Look up runtime OCR overrides from the file's processing profile.
 
     Resolution order:
     1. Explicit pipeline assigned to the file (``file_record.pipeline_id``).
     2. User's own default pipeline (``owner_id``, ``is_default=True``).
     3. System default pipeline (``owner_id=NULL``, ``is_default=True``).
 
-    Returns the ``ocr_language`` value from the pipeline's OCR step config, or
-    ``None`` when no override is configured.
+    Returns normalized OCR config. ``ocr_language`` is ``None`` when no
+    override is configured or the profile uses ``auto``.
     """
+    result: dict[str, object] = {"ocr_language": None, "force_cloud_ocr": False}
     pipeline = None
 
     if file_record.pipeline_id:
@@ -69,7 +70,7 @@ def _get_pipeline_ocr_language(db: "Session", file_record: FileRecord, owner_id:
         )
 
     if pipeline is None:
-        return None
+        return result
 
     ocr_step = (
         db.query(PipelineStep)
@@ -82,15 +83,23 @@ def _get_pipeline_ocr_language(db: "Session", file_record: FileRecord, owner_id:
     )
 
     if ocr_step is None or not ocr_step.config:
-        return None
+        return result
 
     try:
         step_config = json.loads(ocr_step.config)
         lang = step_config.get("ocr_language")
         # "auto" is treated as no override
-        return lang if lang and lang != "auto" else None
+        result["ocr_language"] = lang if lang and lang != "auto" else None
+        result["force_cloud_ocr"] = bool(step_config.get("force_cloud_ocr"))
+        return result
     except Exception:
-        return None
+        return result
+
+
+def _get_pipeline_ocr_language(db: "Session", file_record: FileRecord, owner_id: str | None) -> str | None:
+    """Return only the OCR language override from the selected processing profile."""
+    config = _get_pipeline_ocr_config(db, file_record, owner_id)
+    return config["ocr_language"] if isinstance(config["ocr_language"], str) else None
 
 
 @celery.task(base=BaseTaskWithRetry, bind=True)
@@ -110,8 +119,8 @@ def process_document(
         original_filename: Optional original filename (if different from path basename)
         file_id: Optional existing file record ID. When provided, skips duplicate
                  detection and reuses the existing record (used for reprocessing).
-        force_cloud_ocr: If True, forces Azure Document Intelligence OCR processing
-                        regardless of embedded text quality. Used for re-processing.
+        force_cloud_ocr: If True, forces OCR processing regardless of embedded
+                         text quality. Used for re-processing and profile overrides.
         owner_id: Optional user identifier for multi-user mode. When provided, the
                   created FileRecord is associated with this user.
 
@@ -123,7 +132,7 @@ def process_document(
          - Copy file to /workdir/tmp for processing
          - Check for embedded text. If present, run local GPT extraction
          - Otherwise, queue Azure Document Intelligence processing
-      3. If force_cloud_ocr is True, skip local text extraction and use cloud OCR
+      3. If force_cloud_ocr is True, skip local text extraction and queue OCR
     """
     # Fall back to the configured default_owner_id when no explicit owner was provided
     default_owner_id = settings.default_owner_id
@@ -179,7 +188,8 @@ def process_document(
         )
 
     # Acquire DB session in the task
-    ocr_language: str | None = None  # Pipeline OCR language override resolved inside DB session
+    # Profile OCR overrides resolved inside DB session.
+    ocr_language: str | None = None
     with SessionLocal() as db:
         # When file_id is provided, we are reprocessing an existing file.
         # Skip the duplicate check and reuse the existing record.
@@ -376,13 +386,17 @@ def process_document(
         new_record.local_filename = new_local_path
         db.commit()
 
-        # Look up pipeline OCR language override before the session closes.
+        # Look up processing-profile OCR overrides before the session closes.
         # This reads the OCR step config from the file's assigned pipeline (or
-        # the user/system default pipeline) so the language is available when
+        # the user/system default pipeline) so the settings are available when
         # dispatching process_with_ocr below.
-        ocr_language = _get_pipeline_ocr_language(db, new_record, owner_id)
+        ocr_config = _get_pipeline_ocr_config(db, new_record, owner_id)
+        ocr_language = ocr_config["ocr_language"] if isinstance(ocr_config["ocr_language"], str) else None
+        force_cloud_ocr = force_cloud_ocr or bool(ocr_config["force_cloud_ocr"])
         if ocr_language:
             logger.info(f"[{task_id}] Pipeline OCR language override: {ocr_language!r}")
+        if force_cloud_ocr:
+            logger.info(f"[{task_id}] Pipeline force-cloud OCR override enabled")
 
         # Store file_id before session closes to avoid DetachedInstanceError
         file_id = new_record.id

--- a/docs/API.md
+++ b/docs/API.md
@@ -1879,7 +1879,13 @@ Execute a full data migration from source to target database.
 
 ## Pipelines
 
-The pipeline API lets you build and manage custom document processing workflows. Each pipeline is owned by a single user (or by the system when `owner_id` is `null`).
+The pipeline API manages processing profiles. Each profile is owned by a single user (or by the system when `owner_id` is `null`).
+
+Current runtime contract:
+
+- OCR step config is applied at runtime. `ocr_language` and `force_cloud_ocr` affect document processing.
+- Step order, non-OCR step entries, and enabled flags are stored as profile metadata. They do not currently orchestrate the worker chain.
+- The system-managed processing flow still controls conversion, duplicate handling, metadata extraction, embedding, storage uploads, and classification.
 
 ### Step-types catalogue
 
@@ -1895,11 +1901,15 @@ Returns the catalogue of built-in step types.
   "convert_to_pdf": {
     "label": "Convert to PDF",
     "description": "Convert non-PDF documents to PDF format using Gotenberg.",
+    "runtime_effect": "metadata_only",
+    "runtime_effect_description": "Stored for profile planning; it does not currently change processing order.",
     "config_schema": {}
   },
   "ocr": {
-    "label": "OCR Processing",
-    "description": "Extract text using Azure Document Intelligence or local Tesseract.",
+    "label": "OCR Profile Settings",
+    "description": "Configure OCR behavior that is applied during the system-managed processing flow.",
+    "runtime_effect": "applied_config",
+    "runtime_effect_description": "OCR language and force-cloud OCR are applied at runtime.",
     "config_schema": {
       "force_cloud_ocr": { "type": "boolean", "default": false },
       "ocr_language": {
@@ -1937,8 +1947,8 @@ POST /api/pipelines
 Content-Type: application/json
 
 {
-  "name": "My Workflow",
-  "description": "Converts, OCRs, and stores documents.",
+  "name": "German OCR Profile",
+  "description": "Uses German OCR defaults.",
   "is_default": false,
   "is_active": true
 }
@@ -1949,8 +1959,8 @@ Content-Type: application/json
 {
   "id": 1,
   "owner_id": "alice",
-  "name": "My Workflow",
-  "description": "Converts, OCRs, and stores documents.",
+  "name": "German OCR Profile",
+  "description": "Uses German OCR defaults.",
   "is_default": false,
   "is_active": true,
   "created_at": "2026-03-07T10:00:00+00:00",
@@ -1981,7 +1991,7 @@ GET /api/pipelines/{pipeline_id}
 {
   "id": 1,
   "owner_id": "alice",
-  "name": "My Workflow",
+  "name": "German OCR Profile",
   "steps": [
     { "id": 1, "position": 0, "step_type": "convert_to_pdf", "enabled": true, "config": {} },
     { "id": 2, "position": 1, "step_type": "ocr", "enabled": true, "config": { "force_cloud_ocr": false } }
@@ -2057,7 +2067,7 @@ Content-Type: application/json
 [3, 1, 2]
 ```
 
-Provide a complete ordered list of **all** step IDs. Their positions are reassigned 0, 1, 2, … in the given order.
+Provide a complete ordered list of **all** step IDs. Their positions are reassigned 0, 1, 2, … in the given order. Reordering is metadata-only in the current runtime and does not change worker execution order.
 
 ### Assign pipeline to a file
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -549,16 +549,23 @@ PAPERLESS_CUSTOM_FIELDS_MAPPING='{"absender": "Sender", "empfaenger": "Recipient
 3. After successful upload, custom fields are automatically populated
 4. You can view the populated fields in your Paperless-ngx document details
 
-## Processing Pipelines
+## Processing Profiles
 
-Processing pipelines let you define exactly what happens to your documents when they are uploaded. Each pipeline is an ordered sequence of **steps** — for example: convert to PDF → OCR → extract metadata → send to storage.
+Processing profiles let you select defaults and OCR behavior for uploaded documents. The current processor still uses DocuElevate's system-managed execution flow; profiles do not yet act as an ordered workflow engine.
+
+At runtime, profile OCR settings are honored:
+
+- `ocr_language`
+- `force_cloud_ocr`
+
+Other step entries, ordering, and enabled flags are saved as profile metadata for planning and future workflow automation.
 
 ### Key concepts
 
 | Term | Meaning |
 |------|---------|
-| **Pipeline** | A named, ordered list of processing steps |
-| **Step** | A single processing action (e.g., OCR, metadata extraction) |
+| **Pipeline / profile** | A named processing profile used for defaults and OCR behavior |
+| **Step** | A profile setting entry. OCR step config is applied at runtime; other entries are metadata today |
 | **System pipeline** | Created by an admin; visible to all users as a shared default |
 | **User pipeline** | Created by a regular user; private to that user |
 | **Default pipeline** | Marked `is_default=true`; used automatically for new uploads |
@@ -566,23 +573,22 @@ Processing pipelines let you define exactly what happens to your documents when 
 ### Managing your pipelines
 
 1. Navigate to **Pipelines** in the top navigation bar.
-2. Click **New Pipeline** to create a pipeline, give it a name and optional description.
-3. Expand the pipeline card and click **Add Step** to build the workflow.
-4. Use the ↑ / ↓ arrows to reorder steps, or click the edit icon to change step settings.
-5. Mark a pipeline as **Default** so new documents are automatically processed by it.
+2. Click **New Pipeline** to create a profile, give it a name and optional description.
+3. Expand the profile card and add an OCR setting when you need per-profile OCR behavior.
+4. Mark a profile as **Default** so new documents use it automatically.
 
 ### Available step types
 
 | Step Type | Description |
 |-----------|-------------|
-| `convert_to_pdf` | Convert non-PDF files to PDF using Gotenberg |
-| `check_duplicates` | Detect duplicate files by content hash |
-| `ocr` | Extract text with OCR (supports multi-language configuration, see below) |
-| `extract_metadata` | Extract structured metadata (type, sender, tags) with AI |
-| `embed_metadata` | Write extracted metadata into the PDF document properties |
-| `compute_embedding` | Compute semantic embeddings for similarity search |
-| `send_to_destinations` | Upload the processed document to all configured storage destinations |
-| `classify` | Classify the document type using rules (filename patterns, content keywords, metadata) |
+| `ocr` | Applied at runtime. Supports multi-language configuration and force-cloud OCR |
+| `convert_to_pdf` | Metadata only today. Conversion runs in the system-managed flow |
+| `check_duplicates` | Metadata only today. Duplicate handling uses global settings |
+| `extract_metadata` | Metadata only today. Metadata extraction runs in the system-managed flow |
+| `embed_metadata` | Metadata only today. PDF metadata embedding runs in the system-managed flow |
+| `compute_embedding` | Metadata only today. Embedding runs in the system-managed flow |
+| `send_to_destinations` | Metadata only today. Destination uploads use configured integrations |
+| `classify` | Metadata only today. Classification rules use their own settings |
 
 #### Classify step – rule-based document classification
 
@@ -608,12 +614,12 @@ The `ocr` step supports two optional configuration fields:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `force_cloud_ocr` | boolean | `false` | Always run cloud OCR even if the PDF already has embedded text |
+| `force_cloud_ocr` | boolean | `false` | Always run OCR even if the PDF already has embedded text |
 | `ocr_language` | string | `"auto"` | Language(s) to use for OCR text extraction (see below) |
 
 **`ocr_language` — per-pipeline language override**
 
-This option enables manual language control per pipeline, overriding the global Tesseract/EasyOCR language settings for all documents processed by that pipeline. The following values are supported (28 languages total):
+This option enables manual language control per profile, overriding the global Tesseract/EasyOCR language settings for all documents processed by that profile. The following values are supported (28 languages total):
 
 | Value | Language | Value | Language |
 |-------|----------|-------|----------|
@@ -639,7 +645,7 @@ This option enables manual language control per pipeline, overriding the global 
 > - For multi-language documents with Tesseract, combine codes with `+`, e.g. `eng+deu`.
 > - Setting `ocr_language` to `auto` or leaving it unset uses the global `TESSERACT_LANGUAGE` / `EASYOCR_LANGUAGES` environment variables.
 
-### Assigning a pipeline to a file
+### Assigning a profile to a file
 
 You can assign (or change) the pipeline for an individual document via the file detail page or the API:
 
@@ -647,15 +653,15 @@ You can assign (or change) the pipeline for an individual document via the file 
 POST /api/files/{file_id}/assign-pipeline?pipeline_id=3
 ```
 
-Pass no `pipeline_id` to clear the assignment and fall back to the system default.
+Pass no `pipeline_id` to clear the assignment and fall back to the system default profile.
 
 ### Admin: system-wide pipelines
 
-Admins can create **system pipelines** that appear in every user's pipeline list. These can be set as the global default so all users benefit from a consistent processing baseline. Navigate to **Pipelines** and check the **System pipeline** box when creating a new one (admin only).
+Admins can create **system pipelines** that appear in every user's pipeline list. These can be set as the global default so all users benefit from a consistent processing profile. Navigate to **Pipelines** and check the **System pipeline** box when creating a new one (admin only).
 
 ### Conditional routing rules
 
-Routing rules automatically assign incoming documents to the right pipeline
+Routing rules automatically assign incoming documents to the right profile
 based on their properties — no manual pipeline selection required.
 
 **How it works:**

--- a/frontend/templates/pipelines.html
+++ b/frontend/templates/pipelines.html
@@ -12,7 +12,7 @@
         {{ _("pipelines.page_title") }}
       </h1>
       <p class="text-gray-500 dark:text-gray-400 text-sm mt-1">
-        {{ _("pipelines.subtitle_intro") }}
+        Processing profiles apply OCR options and default selection. Document execution order is system-managed.
         {{ _("pipelines.subtitle_system_pre") }}
         <span class="text-xs font-semibold text-purple-700 bg-purple-50 border border-purple-200 rounded px-1">{{ _("pipelines.system_label") }}</span>
         {{ _("pipelines.subtitle_system_post") }}
@@ -26,6 +26,11 @@
     >
       <i class="fas fa-plus mr-2" aria-hidden="true"></i> {{ _("pipelines.new_pipeline_btn") }}
     </button>
+  </div>
+
+  <div class="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+    <p class="font-medium">Current profile contract</p>
+    <p>OCR language and force-cloud OCR are applied at runtime. Other step entries, ordering, and enabled flags are saved as profile metadata for planning and future workflow automation.</p>
   </div>
 
   <!-- ── Alert banner ───────────────────────────────────────────────────────── -->
@@ -105,7 +110,7 @@
                 :aria-label="`${pipeline._expanded ? 'Collapse' : 'Expand'} steps for ${pipeline.name}`"
               >
                 <i class="fas fa-list-ul mr-1" aria-hidden="true"></i>
-                <span x-text="(pipeline.steps || []).length + ' step' + ((pipeline.steps || []).length !== 1 ? 's' : '')"></span>
+                <span x-text="(pipeline.steps || []).length + ' setting' + ((pipeline.steps || []).length !== 1 ? 's' : '')"></span>
                 <i :class="pipeline._expanded ? 'fa-chevron-up' : 'fa-chevron-down'" class="fas ml-1 text-xs" aria-hidden="true"></i>
               </button>
               <button
@@ -150,10 +155,10 @@
                       <span class="flex-shrink-0 w-6 h-6 rounded-full bg-blue-100 text-blue-600 text-xs font-bold flex items-center justify-center" x-text="idx + 1" aria-hidden="true"></span>
                       <div class="min-w-0">
                         <p class="text-sm font-medium text-gray-800 dark:text-gray-200 truncate" x-text="step.label || stepTypeLabel(step.step_type)"></p>
-                        <p class="text-xs text-gray-400 truncate" x-text="step.step_type"></p>
+                        <p class="text-xs text-gray-400 truncate" x-text="stepRuntimeText(step)"></p>
                       </div>
                       <template x-if="!step.enabled">
-                        <span class="text-xs text-gray-400 bg-gray-200 rounded px-1.5 py-0.5 flex-shrink-0">{{ _("pipelines.disabled_label") }}</span>
+                        <span class="text-xs text-gray-400 bg-gray-200 rounded px-1.5 py-0.5 flex-shrink-0">metadata disabled</span>
                       </template>
                     </div>
                     <div class="flex items-center gap-1.5 flex-shrink-0">
@@ -164,22 +169,6 @@
                         style="min-height:36px;min-width:36px;"
                         :aria-label="`Edit step ${step.label || step.step_type}`"
                       ><i class="fas fa-pencil-alt text-xs" aria-hidden="true"></i></button>
-                      <button
-                        type="button"
-                        @click="moveStep(pipeline, idx, -1)"
-                        :disabled="idx === 0"
-                        class="p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-600 rounded disabled:opacity-30"
-                        style="min-height:36px;min-width:36px;"
-                        :aria-label="`Move step up: ${step.label || step.step_type}`"
-                      ><i class="fas fa-arrow-up text-xs" aria-hidden="true"></i></button>
-                      <button
-                        type="button"
-                        @click="moveStep(pipeline, idx, 1)"
-                        :disabled="idx === (pipeline.steps || []).length - 1"
-                        class="p-1.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-600 rounded disabled:opacity-30"
-                        style="min-height:36px;min-width:36px;"
-                        :aria-label="`Move step down: ${step.label || step.step_type}`"
-                      ><i class="fas fa-arrow-down text-xs" aria-hidden="true"></i></button>
                       <button
                         type="button"
                         @click="confirmDeleteStep(pipeline, step)"
@@ -201,7 +190,7 @@
               style="min-height:36px;"
               :aria-label="`Add step to ${pipeline.name}`"
             >
-              <i class="fas fa-plus mr-1" aria-hidden="true"></i> {{ _("pipelines.add_step_btn") }}
+              <i class="fas fa-plus mr-1" aria-hidden="true"></i> Add profile setting
             </button>
           </div>
 
@@ -349,8 +338,12 @@
       <h2
         :id="stepModal.editMode ? 'editStepTitle' : 'addStepTitle'"
         class="text-xl font-semibold text-gray-900 dark:text-white mb-5"
-        x-text="stepModal.editMode ? 'Edit Step' : 'Add Step'"
+        x-text="stepModal.editMode ? 'Edit Profile Setting' : 'Add Profile Setting'"
       ></h2>
+
+      <p class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        Only OCR settings are applied by the current processor. Other step entries are saved as profile metadata.
+      </p>
 
       <form @submit.prevent="saveStep()" novalidate>
         <div class="space-y-4">
@@ -451,15 +444,7 @@
             </div>
           </template>
 
-          <!-- Enabled -->
-          <label class="inline-flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              x-model="stepModal.form.enabled"
-              class="rounded border-gray-300 text-blue-600 focus:ring-blue-400"
-            />
-            <span class="text-sm text-gray-700 dark:text-gray-300">{{ _("pipelines.enabled_label") }}</span>
-          </label>
+          <input type="hidden" x-model="stepModal.form.enabled" />
 
           <!-- Error -->
           <p x-show="stepModal.error" class="text-sm text-red-600" x-text="stepModal.error" role="alert"></p>
@@ -481,7 +466,7 @@
             <template x-if="stepModal.saving">
               <i class="fas fa-spinner fa-spin mr-1" aria-hidden="true"></i>
             </template>
-            <span x-text="stepModal.editMode ? 'Save Changes' : 'Add Step'"></span>
+            <span x-text="stepModal.editMode ? 'Save Changes' : 'Add Setting'"></span>
           </button>
         </div>
       </form>
@@ -616,6 +601,13 @@ function pipelinesApp() {
 
     stepTypeLabel(key) {
       return this.stepTypes[key] ? this.stepTypes[key].label : key;
+    },
+
+    stepRuntimeText(step) {
+      const meta = this.stepTypes[step.step_type] || {};
+      return meta.runtime_effect === 'applied_config'
+        ? `${step.step_type} · applied at runtime`
+        : `${step.step_type} · profile metadata`;
     },
 
     showAlert(type, title, message) {
@@ -864,8 +856,8 @@ function pipelinesApp() {
     confirmDeleteStep(pipeline, step) {
       this.confirmModal = {
         open: true,
-        title: 'Delete step?',
-        message: `Remove "${step.label || step.step_type}" from pipeline "${pipeline.name}"?`,
+        title: 'Delete profile setting?',
+        message: `Remove "${step.label || step.step_type}" from profile "${pipeline.name}"?`,
         action: () => this.deleteStep(pipeline, step),
       };
     },
@@ -885,7 +877,7 @@ function pipelinesApp() {
         if (pIdx !== -1) {
           this.pipelines[pIdx] = { ...updated, _expanded: true };
         }
-        this.showAlert('success', 'Step deleted', `"${step.label || step.step_type}" removed.`);
+        this.showAlert('success', 'Profile setting deleted', `"${step.label || step.step_type}" removed.`);
       } catch (err) {
         this.showAlert('error', 'Delete failed', err.message || String(err));
       }

--- a/tests/test_api_pipelines.py
+++ b/tests/test_api_pipelines.py
@@ -61,6 +61,19 @@ class TestStepTypesCatalogue:
             assert "label" in meta, f"Step type '{key}' missing 'label'"
             assert "description" in meta, f"Step type '{key}' missing 'description'"
 
+    def test_step_types_declare_runtime_effect(self, client):
+        """Step-type metadata identifies what currently affects processing."""
+        r = client.get("/api/pipelines/step-types")
+        data = r.json()
+
+        assert data["ocr"]["runtime_effect"] == "applied_config"
+        assert data["ocr"]["runtime_effect_description"]
+
+        metadata_only = set(data) - {"ocr"}
+        for key in metadata_only:
+            assert data[key]["runtime_effect"] == "metadata_only"
+            assert data[key]["runtime_effect_description"]
+
 
 # ---------------------------------------------------------------------------
 # Integration tests – Pipeline CRUD

--- a/tests/test_process_document.py
+++ b/tests/test_process_document.py
@@ -917,6 +917,49 @@ def test_get_pipeline_ocr_language_returns_language_from_system_default(db_sessi
 
 @pytest.mark.unit
 @pytest.mark.requires_db
+def test_get_pipeline_ocr_config_returns_force_cloud_ocr(db_session):
+    """Returns force_cloud_ocr from the selected profile OCR step config."""
+    import json
+
+    from app.models import Pipeline, PipelineStep
+    from app.tasks.process_document import _get_pipeline_ocr_config
+
+    pipeline = Pipeline(
+        owner_id=None,
+        name="Force OCR Profile",
+        is_default=True,
+        is_active=True,
+    )
+    db_session.add(pipeline)
+    db_session.commit()
+
+    ocr_step = PipelineStep(
+        pipeline_id=pipeline.id,
+        position=0,
+        step_type="ocr",
+        config=json.dumps({"force_cloud_ocr": True, "ocr_language": "eng"}),
+        enabled=True,
+    )
+    db_session.add(ocr_step)
+    db_session.commit()
+
+    file_record = FileRecord(
+        filehash="force123",
+        original_filename="force.pdf",
+        local_filename="/tmp/force.pdf",
+        file_size=256,
+        mime_type="application/pdf",
+        is_duplicate=False,
+    )
+    db_session.add(file_record)
+    db_session.commit()
+
+    result = _get_pipeline_ocr_config(db_session, file_record, owner_id=None)
+    assert result == {"ocr_language": "eng", "force_cloud_ocr": True}
+
+
+@pytest.mark.unit
+@pytest.mark.requires_db
 def test_get_pipeline_ocr_language_auto_returns_none(db_session):
     """Returns None when ocr_language is 'auto' (should use global settings)."""
     import json


### PR DESCRIPTION
## Summary
- make pipeline step metadata explicit about what currently affects runtime
- apply profile `force_cloud_ocr` alongside the existing OCR language override
- update the Pipelines UI to present profile settings instead of an executable workflow order
- align README/API/User Guide wording with the current processing-profile contract
- add tests for runtime-effect metadata and force-cloud OCR profile config

Closes #956

## Testing
- .venv312/bin/python -m pytest tests/test_api_pipelines.py::TestStepTypesCatalogue tests/test_process_document.py::test_get_pipeline_ocr_language_returns_none_when_no_pipeline tests/test_process_document.py::test_get_pipeline_ocr_language_returns_language_from_system_default tests/test_process_document.py::test_get_pipeline_ocr_config_returns_force_cloud_ocr tests/test_process_document.py::test_get_pipeline_ocr_language_auto_returns_none tests/test_process_document.py::test_get_pipeline_ocr_language_explicit_pipeline_takes_priority -q
- .venv312/bin/python -m ruff check app/api/pipelines.py app/models.py app/tasks/process_document.py tests/test_api_pipelines.py tests/test_process_document.py
- .venv312/bin/python -m ruff format --check app/api/pipelines.py app/models.py app/tasks/process_document.py tests/test_api_pipelines.py tests/test_process_document.py
- python3.12 -m py_compile app/api/pipelines.py app/tasks/process_document.py

Note: app/models.py and app/tasks/process_document.py are stored with CRLF in the repository; plain git diff --check reports CRLF on changed lines.