### PR TITLE
Fix ingestion routing rule application

### DIFF
--- a/app/api/files.py
+++ b/app/api/files.py
@@ -1721,6 +1721,13 @@ def assign_pipeline_to_file(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Pipeline not found")
 
     file_record.pipeline_id = pipeline_id
+    file_record.pipeline_routing_rule_id = None
+    if pipeline_id is None:
+        file_record.pipeline_assignment_source = "default"
+        file_record.pipeline_assignment_reason = "Manual assignment cleared; using the owner or system default profile"
+    else:
+        file_record.pipeline_assignment_source = "manual"
+        file_record.pipeline_assignment_reason = "Processing profile manually assigned through the API"
 
     try:
         db.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -84,6 +84,11 @@ class FileRecord(Base):
     # Processing pipeline assigned to this file (NULL = use system default)
     pipeline_id = Column(Integer, ForeignKey(_PIPELINES_ID_FK), nullable=True, index=True)
 
+    # Why the current processing profile was selected.
+    pipeline_assignment_source = Column(String(50), nullable=True, index=True)
+    pipeline_routing_rule_id = Column(Integer, ForeignKey(f"{_ROUTING_RULES_TABLE}.id"), nullable=True, index=True)
+    pipeline_assignment_reason = Column(Text, nullable=True)
+
     # Detected document language (ISO 639-1 code, e.g. "de", "en", "fr")
     # Extracted from AI metadata during processing; cached here for fast access.
     detected_language = Column(String(10), nullable=True)

--- a/app/tasks/process_document.py
+++ b/app/tasks/process_document.py
@@ -21,6 +21,7 @@ from app.tasks.extract_metadata_with_gpt import extract_metadata_with_gpt
 from app.tasks.process_with_ocr import process_with_ocr
 from app.tasks.retry_config import BaseTaskWithRetry
 from app.utils import get_unique_filepath_with_counter, hash_file, log_task_progress
+from app.utils.routing_engine import evaluate_pre_processing_routing_rules
 from app.utils.step_manager import initialize_file_steps
 from app.utils.text_quality import check_text_quality, detect_pdf_text_source
 
@@ -100,6 +101,45 @@ def _get_pipeline_ocr_language(db: "Session", file_record: FileRecord, owner_id:
     """Return only the OCR language override from the selected processing profile."""
     config = _get_pipeline_ocr_config(db, file_record, owner_id)
     return config["ocr_language"] if isinstance(config["ocr_language"], str) else None
+
+
+def _apply_pre_processing_routing(
+    db: "Session",
+    file_record: FileRecord,
+    owner_id: str | None,
+    task_id: str | None = None,
+) -> None:
+    """Assign a processing profile from routing rules known before OCR runs."""
+    if file_record.pipeline_id is not None:
+        if not file_record.pipeline_assignment_source:
+            file_record.pipeline_assignment_source = "manual"
+            file_record.pipeline_routing_rule_id = None
+            file_record.pipeline_assignment_reason = "Processing profile was already assigned before ingestion routing"
+        return
+
+    decision = evaluate_pre_processing_routing_rules(db, owner_id, file_record)
+    if decision is None:
+        file_record.pipeline_assignment_source = "default"
+        file_record.pipeline_routing_rule_id = None
+        file_record.pipeline_assignment_reason = (
+            "No pre-processing routing rule matched; using the owner or system default profile"
+        )
+        return
+
+    file_record.pipeline_id = decision.pipeline.id
+    file_record.pipeline_assignment_source = "routing_rule"
+    file_record.pipeline_routing_rule_id = decision.rule.id
+    file_record.pipeline_assignment_reason = (
+        f"Matched pre-processing routing rule '{decision.rule.name}' on {decision.rule.field}"
+    )
+
+    logger.info(
+        "[%s] Pre-processing routing matched rule_id=%s, pipeline_id=%s for file_id=%s",
+        task_id or "-",
+        decision.rule.id,
+        decision.pipeline.id,
+        file_record.id,
+    )
 
 
 @celery.task(base=BaseTaskWithRetry, bind=True)
@@ -384,7 +424,27 @@ def process_document(
 
         # Update the DB with local_filename
         new_record.local_filename = new_local_path
+        _apply_pre_processing_routing(db, new_record, owner_id, task_id)
         db.commit()
+
+        if new_record.pipeline_assignment_source == "routing_rule":
+            log_task_progress(
+                task_id,
+                "route_pipeline",
+                "success",
+                "Processing profile selected by routing rule",
+                file_id=new_record.id,
+                detail=new_record.pipeline_assignment_reason,
+            )
+        elif new_record.pipeline_assignment_source == "default":
+            log_task_progress(
+                task_id,
+                "route_pipeline",
+                "skipped",
+                "No routing rule matched; using default profile",
+                file_id=new_record.id,
+                detail=new_record.pipeline_assignment_reason,
+            )
 
         # Look up processing-profile OCR overrides before the session closes.
         # This reads the OCR step config from the file's assigned pipeline (or

--- a/app/utils/routing_engine.py
+++ b/app/utils/routing_engine.py
@@ -23,6 +23,7 @@ Supported comparison operators
 import json
 import logging
 import re
+from dataclasses import dataclass
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -57,6 +58,10 @@ BUILTIN_FIELDS: frozenset[str] = frozenset(
     }
 )
 
+# Fields known before OCR and AI metadata extraction. Only these can affect the
+# initial processing profile selected during ingestion.
+PRE_PROCESSING_ROUTING_FIELDS: frozenset[str] = frozenset({"file_type", "filename", "size"})
+
 TEXT_OPERATORS = {
     "equals": lambda actual, expected: actual == expected,
     "not_equals": lambda actual, expected: actual != expected,
@@ -72,6 +77,14 @@ NUMERIC_OPERATORS = {
 }
 
 MAX_REGEX_PATTERN_LENGTH = 256
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    """A matched routing rule and its active target pipeline."""
+
+    pipeline: Pipeline
+    rule: PipelineRoutingRule
 
 
 def _resolve_field(field: str, doc_props: dict[str, Any]) -> Any:
@@ -91,6 +104,18 @@ def _resolve_field(field: str, doc_props: dict[str, Any]) -> Any:
         return metadata.get(meta_key)
 
     return doc_props.get(field)
+
+
+def _field_matches_allowed_stage(field: str, allowed_fields: frozenset[str] | None) -> bool:
+    """Return whether *field* can be evaluated for the requested routing stage."""
+    if allowed_fields is None:
+        return True
+
+    normalized_field = "document_type" if field == "category" else field
+    if normalized_field.startswith("metadata."):
+        normalized_field = "metadata"
+
+    return normalized_field in allowed_fields
 
 
 def _to_float(value: Any) -> float | None:
@@ -187,16 +212,22 @@ def build_document_properties(file_record: Any) -> dict[str, Any]:
     }
 
 
-def evaluate_routing_rules(
+def evaluate_routing_decision(
     db: Session,
     owner_id: str | None,
     doc_props: dict[str, Any],
-) -> Pipeline | None:
-    """Evaluate routing rules and return the first matching pipeline.
+    *,
+    allowed_fields: frozenset[str] | None = None,
+) -> RoutingDecision | None:
+    """Evaluate routing rules and return the first matching decision.
 
     Rules are fetched for the given *owner_id* **plus** any system-wide rules
     (``owner_id IS NULL``).  Owner rules are evaluated first (by position),
     then system rules.
+
+    ``allowed_fields`` limits evaluation to properties available at the
+    current stage. This is required during ingestion so late-bound metadata
+    rules do not match against missing values.
 
     Args:
         db: Active database session.
@@ -205,8 +236,8 @@ def evaluate_routing_rules(
             :func:`build_document_properties`.
 
     Returns:
-        The first matching :class:`Pipeline`, or ``None`` when no rule
-        matches (caller should fall back to the default pipeline).
+        The first matching :class:`RoutingDecision`, or ``None`` when no rule
+        matches.
     """
     # Fetch active rules for the owner + system rules, ordered by position.
     rules = (
@@ -224,6 +255,9 @@ def evaluate_routing_rules(
     )
 
     for rule in rules:
+        if not _field_matches_allowed_stage(rule.field, allowed_fields):
+            continue
+
         actual = _resolve_field(rule.field, doc_props)
         if _evaluate_condition(actual, rule.operator, rule.value):
             pipeline = db.query(Pipeline).filter(Pipeline.id == rule.target_pipeline_id).first()
@@ -234,7 +268,7 @@ def evaluate_routing_rules(
                     rule.name,
                     rule.target_pipeline_id,
                 )
-                return pipeline
+                return RoutingDecision(pipeline=pipeline, rule=rule)
             logger.warning(
                 "Routing rule %s matched but target pipeline %s is inactive or missing",
                 rule.id,
@@ -242,3 +276,27 @@ def evaluate_routing_rules(
             )
 
     return None
+
+
+def evaluate_routing_rules(
+    db: Session,
+    owner_id: str | None,
+    doc_props: dict[str, Any],
+) -> Pipeline | None:
+    """Evaluate all routing rules and return the first matching pipeline."""
+    decision = evaluate_routing_decision(db, owner_id, doc_props)
+    return decision.pipeline if decision else None
+
+
+def evaluate_pre_processing_routing_rules(
+    db: Session,
+    owner_id: str | None,
+    file_record: Any,
+) -> RoutingDecision | None:
+    """Evaluate only routing rules that are safe before document processing."""
+    return evaluate_routing_decision(
+        db,
+        owner_id,
+        build_document_properties(file_record),
+        allowed_fields=PRE_PROCESSING_ROUTING_FIELDS,
+    )

--- a/docs/API.md
+++ b/docs/API.md
@@ -2091,6 +2091,12 @@ metadata.  Rules are evaluated in **position order** (lowest first); the first
 rule that matches wins.  If no rule matches, the system falls back to the
 owner's (or global) default pipeline.
 
+During initial ingestion, routing can only use fields known before processing:
+`file_type`, `filename`, and `size`.  Rules that depend on `document_type`,
+`category`, or `metadata.<key>` are still accepted and can be tested with the
+dry-run endpoint, but they are not used for the initial processing-profile
+selection until classification metadata exists.
+
 ### Supported operators and fields
 
 ```bash
@@ -2111,6 +2117,8 @@ populate dropdowns without hard-coding values.
 
 > **Tip:** For AI metadata fields use the `metadata.` prefix, e.g.
 > `metadata.sender`, `metadata.amount`.
+> These fields are available for dry-run evaluation and post-classification
+> routing logic; they do not affect the initial ingestion profile.
 
 ### List routing rules
 
@@ -2216,7 +2224,8 @@ Content-Type: application/json
 ```
 
 Tests which rule (if any) would match the given properties **without**
-actually routing a document.
+actually routing a document.  Dry-run evaluation accepts both pre-processing
+fields and post-classification fields.
 
 **Response (200) – match found:**
 ```json

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -670,9 +670,10 @@ based on their properties — no manual pipeline selection required.
    (`POST /api/routing-rules`).
 2. Each rule specifies a **field** to inspect, an **operator** (condition),
    a **value** to compare against, and a **target pipeline**.
-3. When a document is processed, rules are evaluated **in position order**
-   (lowest first).  The first matching rule wins and the document is routed
-   to that pipeline.
+3. During initial ingestion, rules are evaluated **in position order**
+   (lowest first) using the fields that are already known before OCR and
+   metadata extraction: `file_type`, `filename`, and `size`.  The first
+   matching rule wins and the document is routed to that profile.
 4. If no rule matches, the document is processed by the default pipeline.
 
 **Available fields:**
@@ -682,9 +683,9 @@ based on their properties — no manual pipeline selection required.
 | `file_type` | MIME type, e.g. `application/pdf` |
 | `filename` | Original filename |
 | `size` | File size in bytes |
-| `document_type` | AI-classified type (Invoice, Contract, …) |
-| `category` | Alias for `document_type` |
-| `metadata.<key>` | Any key from the AI-extracted metadata JSON |
+| `document_type` | AI-classified type (Invoice, Contract, …); available after classification |
+| `category` | Alias for `document_type`; available after classification |
+| `metadata.<key>` | Any key from the AI-extracted metadata JSON; available after classification |
 
 **Available operators:**
 
@@ -702,10 +703,10 @@ Rule 1: field=document_type, operator=equals, value=Invoice, target_pipeline=3
 Rule 2: field=size,          operator=gt,     value=1048576, target_pipeline=5
 ```
 
-With first-match-wins logic, an invoice of any size matches Rule 1 and is
-routed to pipeline 3.  A non-invoice file larger than 1 MB matches Rule 2
-and is routed to pipeline 5.  Everything else falls back to the default
-pipeline.
+At ingestion time, Rule 2 can select the initial profile because file size is
+known before processing starts.  Rule 1 depends on AI classification metadata,
+so it is available for dry-run evaluation and post-classification routing logic
+rather than initial profile selection.
 
 You can test your rules without actually routing a document using the
 **evaluate** endpoint (`POST /api/routing-rules/evaluate`).  For the full

--- a/migrations/versions/043_add_pipeline_assignment_provenance.py
+++ b/migrations/versions/043_add_pipeline_assignment_provenance.py
@@ -1,0 +1,84 @@
+"""Add pipeline assignment provenance to files.
+
+Revision ID: 043_add_pipeline_assignment_provenance
+Revises: 042_add_file_shares
+Create Date: 2026-07-06
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "043_add_pipeline_assignment_provenance"
+down_revision: Union[str, None] = "042_add_file_shares"
+branch_labels = None
+depends_on = None
+
+
+def _column_names(table_name: str) -> set[str]:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _index_names(table_name: str) -> set[str]:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    """Add provenance columns for pipeline assignment decisions."""
+    columns = _column_names("files")
+
+    if "pipeline_assignment_source" not in columns:
+        op.add_column("files", sa.Column("pipeline_assignment_source", sa.String(length=50), nullable=True))
+    if "pipeline_routing_rule_id" not in columns:
+        op.add_column("files", sa.Column("pipeline_routing_rule_id", sa.Integer(), nullable=True))
+    if "pipeline_assignment_reason" not in columns:
+        op.add_column("files", sa.Column("pipeline_assignment_reason", sa.Text(), nullable=True))
+
+    indexes = _index_names("files")
+    if "ix_files_pipeline_assignment_source" not in indexes:
+        op.create_index("ix_files_pipeline_assignment_source", "files", ["pipeline_assignment_source"])
+    if "ix_files_pipeline_routing_rule_id" not in indexes:
+        op.create_index("ix_files_pipeline_routing_rule_id", "files", ["pipeline_routing_rule_id"])
+
+    bind = op.get_bind()
+    if bind.dialect.name != "sqlite":
+        op.create_foreign_key(
+            "fk_files_pipeline_routing_rule_id",
+            "files",
+            "pipeline_routing_rules",
+            ["pipeline_routing_rule_id"],
+            ["id"],
+        )
+
+
+def downgrade() -> None:
+    """Remove pipeline assignment provenance columns."""
+    bind = op.get_bind()
+    indexes = _index_names("files")
+
+    if bind.dialect.name != "sqlite":
+        op.drop_constraint("fk_files_pipeline_routing_rule_id", "files", type_="foreignkey")
+
+    if "ix_files_pipeline_routing_rule_id" in indexes:
+        op.drop_index("ix_files_pipeline_routing_rule_id", table_name="files")
+    if "ix_files_pipeline_assignment_source" in indexes:
+        op.drop_index("ix_files_pipeline_assignment_source", table_name="files")
+
+    columns = _column_names("files")
+    if "pipeline_assignment_reason" in columns:
+        op.drop_column("files", "pipeline_assignment_reason")
+    if "pipeline_routing_rule_id" in columns:
+        op.drop_column("files", "pipeline_routing_rule_id")
+    if "pipeline_assignment_source" in columns:
+        op.drop_column("files", "pipeline_assignment_source")

--- a/tests/test_api_pipelines.py
+++ b/tests/test_api_pipelines.py
@@ -368,6 +368,9 @@ class TestAssignPipelineToFile:
 
         db_session.refresh(fr)
         assert fr.pipeline_id == pipeline["id"]
+        assert fr.pipeline_assignment_source == "manual"
+        assert fr.pipeline_routing_rule_id is None
+        assert "manually assigned" in fr.pipeline_assignment_reason
 
     def test_clear_pipeline_from_file(self, client, db_session):
         """Passing no pipeline_id clears the assignment."""
@@ -378,6 +381,11 @@ class TestAssignPipelineToFile:
         r = client.post(f"/api/files/{fr.id}/assign-pipeline")
         assert r.status_code == 200
         assert r.json()["pipeline_id"] is None
+
+        db_session.refresh(fr)
+        assert fr.pipeline_assignment_source == "default"
+        assert fr.pipeline_routing_rule_id is None
+        assert "Manual assignment cleared" in fr.pipeline_assignment_reason
 
     def test_assign_nonexistent_pipeline_returns_404(self, client, db_session):
         """Assigning a non-existent pipeline returns 404."""

--- a/tests/test_process_document.py
+++ b/tests/test_process_document.py
@@ -851,6 +851,107 @@ startxref
 
 @pytest.mark.unit
 @pytest.mark.requires_db
+def test_apply_pre_processing_routing_assigns_matching_profile(db_session):
+    """Pre-processing routing stores the matched profile and provenance."""
+    from app.models import Pipeline, PipelineRoutingRule
+    from app.tasks.process_document import _apply_pre_processing_routing
+
+    pipeline = Pipeline(owner_id="user1", name="Invoice Profile", is_default=False, is_active=True)
+    db_session.add(pipeline)
+    db_session.commit()
+
+    rule = PipelineRoutingRule(
+        owner_id="user1",
+        name="Invoice Filename",
+        position=0,
+        field="filename",
+        operator="contains",
+        value="invoice",
+        target_pipeline_id=pipeline.id,
+        is_active=True,
+    )
+    db_session.add(rule)
+    db_session.commit()
+
+    file_record = FileRecord(
+        owner_id="user1",
+        filehash="route123",
+        original_filename="invoice-2026.pdf",
+        local_filename="/tmp/invoice-2026.pdf",
+        file_size=1024,
+        mime_type="application/pdf",
+        is_duplicate=False,
+    )
+    db_session.add(file_record)
+    db_session.commit()
+
+    _apply_pre_processing_routing(db_session, file_record, owner_id="user1", task_id="test-task")
+
+    assert file_record.pipeline_id == pipeline.id
+    assert file_record.pipeline_assignment_source == "routing_rule"
+    assert file_record.pipeline_routing_rule_id == rule.id
+    assert "Invoice Filename" in file_record.pipeline_assignment_reason
+
+
+@pytest.mark.unit
+@pytest.mark.requires_db
+def test_apply_pre_processing_routing_records_default_fallback(db_session):
+    """When no pre-processing rule matches, the default fallback reason is stored."""
+    from app.tasks.process_document import _apply_pre_processing_routing
+
+    file_record = FileRecord(
+        owner_id="user1",
+        filehash="default123",
+        original_filename="plain.pdf",
+        local_filename="/tmp/plain.pdf",
+        file_size=1024,
+        mime_type="application/pdf",
+        is_duplicate=False,
+    )
+    db_session.add(file_record)
+    db_session.commit()
+
+    _apply_pre_processing_routing(db_session, file_record, owner_id="user1", task_id="test-task")
+
+    assert file_record.pipeline_id is None
+    assert file_record.pipeline_assignment_source == "default"
+    assert file_record.pipeline_routing_rule_id is None
+    assert "No pre-processing routing rule matched" in file_record.pipeline_assignment_reason
+
+
+@pytest.mark.unit
+@pytest.mark.requires_db
+def test_apply_pre_processing_routing_preserves_explicit_profile(db_session):
+    """Existing file-level profile assignments are not overwritten by routing."""
+    from app.models import Pipeline
+    from app.tasks.process_document import _apply_pre_processing_routing
+
+    pipeline = Pipeline(owner_id="user1", name="Manual Profile", is_default=False, is_active=True)
+    db_session.add(pipeline)
+    db_session.commit()
+
+    file_record = FileRecord(
+        owner_id="user1",
+        filehash="manual123",
+        original_filename="invoice.pdf",
+        local_filename="/tmp/invoice.pdf",
+        file_size=1024,
+        mime_type="application/pdf",
+        is_duplicate=False,
+        pipeline_id=pipeline.id,
+    )
+    db_session.add(file_record)
+    db_session.commit()
+
+    _apply_pre_processing_routing(db_session, file_record, owner_id="user1", task_id="test-task")
+
+    assert file_record.pipeline_id == pipeline.id
+    assert file_record.pipeline_assignment_source == "manual"
+    assert file_record.pipeline_routing_rule_id is None
+
+
+@pytest.mark.unit
+@pytest.mark.requires_db
 def test_get_pipeline_ocr_language_returns_none_when_no_pipeline(db_session):
     """Returns None when no pipeline exists in the database."""
     from app.tasks.process_document import _get_pipeline_ocr_language

--- a/tests/test_routing_rules.py
+++ b/tests/test_routing_rules.py
@@ -16,6 +16,7 @@ from app.utils.routing_engine import (
     _resolve_field,
     _to_float,
     build_document_properties,
+    evaluate_pre_processing_routing_rules,
     evaluate_routing_rules,
 )
 
@@ -401,6 +402,69 @@ class TestEvaluateRoutingRules:
         result = evaluate_routing_rules(db_session, "testuser", doc)
         assert result is not None
         assert result.id == p.id
+
+
+@pytest.mark.unit
+class TestPreProcessingRoutingRules:
+    """Tests for routing fields available before OCR and metadata extraction."""
+
+    def test_filename_rule_returns_decision(self, db_session):
+        """Pre-processing routing returns both the pipeline and matched rule."""
+        pipeline = _make_pipeline(db_session, name="Invoice Profile")
+        rule = _make_rule(
+            db_session,
+            pipeline.id,
+            field="filename",
+            operator="contains",
+            value="invoice",
+            name="Invoice Filename",
+        )
+        file_record = _make_file_record(db_session, original_filename="invoice-2026.pdf")
+
+        decision = evaluate_pre_processing_routing_rules(db_session, "testuser", file_record)
+
+        assert decision is not None
+        assert decision.pipeline.id == pipeline.id
+        assert decision.rule.id == rule.id
+
+    def test_metadata_and_document_type_rules_are_skipped(self, db_session):
+        """Late-bound rules must not match against missing pre-processing values."""
+        metadata_pipeline = _make_pipeline(db_session, name="Metadata Profile")
+        filename_pipeline = _make_pipeline(db_session, name="Filename Profile")
+        _make_rule(
+            db_session,
+            metadata_pipeline.id,
+            position=0,
+            field="metadata.sender",
+            operator="not_equals",
+            value="acme",
+            name="Metadata Not Equals",
+        )
+        _make_rule(
+            db_session,
+            metadata_pipeline.id,
+            position=1,
+            field="document_type",
+            operator="not_equals",
+            value="Invoice",
+            name="Document Type Not Equals",
+        )
+        filename_rule = _make_rule(
+            db_session,
+            filename_pipeline.id,
+            position=2,
+            field="filename",
+            operator="contains",
+            value="receipt",
+            name="Receipt Filename",
+        )
+        file_record = _make_file_record(db_session, original_filename="receipt.pdf", ai_metadata=None)
+
+        decision = evaluate_pre_processing_routing_rules(db_session, "testuser", file_record)
+
+        assert decision is not None
+        assert decision.pipeline.id == filename_pipeline.id
+        assert decision.rule.id == filename_rule.id
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- apply pre-processing routing rules during document ingestion before OCR profile lookup
- persist pipeline assignment provenance for routing-rule, manual, and default fallback decisions
- limit initial routing to filename, file type, and size so late-bound metadata rules do not match missing values
- document the pre-processing vs post-classification routing boundary

Fixes #957

## Tests
- .venv312/bin/python -m pytest tests/test_routing_rules.py::TestPreProcessingRoutingRules tests/test_process_document.py::test_apply_pre_processing_routing_assigns_matching_profile tests/test_process_document.py::test_apply_pre_processing_routing_records_default_fallback tests/test_process_document.py::test_apply_pre_processing_routing_preserves_explicit_profile tests/test_api_pipelines.py::TestAssignPipelineToFile -q
- .venv312/bin/python -m ruff check app/utils/routing_engine.py app/tasks/process_document.py app/api/files.py app/models.py tests/test_routing_rules.py tests/test_process_document.py tests/test_api_pipelines.py migrations/versions/043_add_pipeline_assignment_provenance.py
- .venv312/bin/python -m ruff format --check app/utils/routing_engine.py app/tasks/process_document.py app/api/files.py app/models.py tests/test_routing_rules.py tests/test_process_document.py tests/test_api_pipelines.py migrations/versions/043_add_pipeline_assignment_provenance.py
- .venv312/bin/python -m py_compile app/utils/routing_engine.py app/tasks/process_document.py app/api/files.py app/models.py migrations/versions/043_add_pipeline_assignment_provenance.py
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,cr-at-eol diff --check