### PR TITLE
Align file status views with selected profile

### DIFF
--- a/app/utils/pipeline_stages.py
+++ b/app/utils/pipeline_stages.py
@@ -1,0 +1,37 @@
+"""Shared mapping between processing profile steps and status/log stages."""
+
+from collections.abc import Iterable
+
+PIPELINE_STEP_TO_STAGES: dict[str, list[str]] = {
+    "convert_to_pdf": ["convert_to_pdf"],
+    "check_duplicates": ["check_for_duplicates"],
+    "ocr": ["check_text", "extract_text", "process_with_ocr"],
+    "extract_metadata": ["extract_metadata_with_gpt"],
+    "embed_metadata": ["embed_metadata_into_pdf"],
+    "compute_embedding": ["compute_embedding"],
+    "send_to_destinations": ["finalize_document_storage", "send_to_all_destinations"],
+    "classify": ["classify_document"],
+}
+
+ALWAYS_SHOW_STAGES: frozenset[str] = frozenset({"create_file_record"})
+
+LEGACY_STAGE_ALIASES: dict[str, str] = {
+    "process_with_azure_document_intelligence": "process_with_ocr",
+}
+
+
+def normalize_stage_name(step_name: str) -> str:
+    """Return the current stage key for legacy log/status names."""
+    return LEGACY_STAGE_ALIASES.get(step_name, step_name)
+
+
+def stage_keys_for_pipeline_steps(pipeline_steps: Iterable | None) -> set[str] | None:
+    """Return expected status/log stages for enabled profile steps."""
+    if pipeline_steps is None:
+        return None
+
+    stage_keys: set[str] = set(ALWAYS_SHOW_STAGES)
+    for pipeline_step in pipeline_steps:
+        if getattr(pipeline_step, "enabled", False):
+            stage_keys.update(PIPELINE_STEP_TO_STAGES.get(pipeline_step.step_type, []))
+    return stage_keys

--- a/app/utils/step_manager.py
+++ b/app/utils/step_manager.py
@@ -5,6 +5,7 @@ This module provides functions to initialize, update, and query the status
 of file processing steps using the FileProcessingStep model.
 """
 
+from collections.abc import Iterable
 from datetime import datetime
 from typing import Dict, List, Optional
 
@@ -294,7 +295,7 @@ def get_file_overall_status(db: Session, file_id: int) -> Dict:
     }
 
 
-def get_step_summary(db: Session, file_id: int, pipeline_steps=None) -> Dict:
+def get_step_summary(db: Session, file_id: int, pipeline_steps: Iterable[object] | None = None) -> Dict:
     """
     Get a summary of main steps vs upload steps with status counts.
 

--- a/app/utils/step_manager.py
+++ b/app/utils/step_manager.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.models import FileProcessingStep, FileRecord
+from app.utils.pipeline_stages import normalize_stage_name, stage_keys_for_pipeline_steps
 
 # Define the expected processing steps for a standard file workflow
 # The "check_for_duplicates" step is conditionally included based on enable_deduplication setting
@@ -293,7 +294,7 @@ def get_file_overall_status(db: Session, file_id: int) -> Dict:
     }
 
 
-def get_step_summary(db: Session, file_id: int) -> Dict:
+def get_step_summary(db: Session, file_id: int, pipeline_steps=None) -> Dict:
     """
     Get a summary of main steps vs upload steps with status counts.
 
@@ -317,7 +318,7 @@ def get_step_summary(db: Session, file_id: int) -> Dict:
     # Only high-level logical steps, not implementation sub-steps
     # Both process_with_ocr (current) and process_with_azure_document_intelligence (legacy)
     # are included to correctly count steps for files processed before the OCR abstraction.
-    REAL_MAIN_STEPS = {
+    real_main_steps = {
         "create_file_record",
         "check_text",
         "extract_text",
@@ -332,7 +333,11 @@ def get_step_summary(db: Session, file_id: int) -> Dict:
 
     # Add check_for_duplicates if deduplication is enabled
     if settings.enable_deduplication:
-        REAL_MAIN_STEPS.add("check_for_duplicates")
+        real_main_steps.add("check_for_duplicates")
+
+    expected_steps = stage_keys_for_pipeline_steps(pipeline_steps)
+    if expected_steps is not None:
+        real_main_steps = {step_name for step_name in real_main_steps if step_name in expected_steps}
 
     steps = db.query(FileProcessingStep).filter(FileProcessingStep.file_id == file_id).all()
 
@@ -341,6 +346,7 @@ def get_step_summary(db: Session, file_id: int) -> Dict:
 
     main_steps_count = 0
     upload_steps_count = 0
+    counted_main_steps: set[str] = set()
 
     for step in steps:
         # Normalize status
@@ -348,11 +354,13 @@ def get_step_summary(db: Session, file_id: int) -> Dict:
         if status == "pending":
             status = "queued"
 
+        step_name = normalize_stage_name(step.step_name)
+
         # Check if it's an upload task (only count actual upload_to_* steps, not queue_* steps)
-        is_upload = step.step_name.startswith("upload_to_")
+        is_upload = step_name.startswith("upload_to_")
 
         # Only count "real" steps
-        is_real_step = step.step_name in REAL_MAIN_STEPS or is_upload or step.step_name.startswith("queue_")
+        is_real_step = step_name in real_main_steps or is_upload or step_name.startswith("queue_")
 
         if not is_real_step:
             # Skip diagnostic/internal steps like poll_task, upload_file, set_custom_fields, etc.
@@ -362,9 +370,15 @@ def get_step_summary(db: Session, file_id: int) -> Dict:
             if status in upload_counts:
                 upload_counts[status] += 1
             upload_steps_count += 1
-        elif step.step_name in REAL_MAIN_STEPS:
+        elif step_name in real_main_steps:
             if status in main_counts:
                 main_counts[status] += 1
+            main_steps_count += 1
+            counted_main_steps.add(step_name)
+
+    if expected_steps is not None:
+        for _step_name in real_main_steps - counted_main_steps:
+            main_counts["queued"] += 1
             main_steps_count += 1
 
     # Ensure the terminal step is always counted in total_main_steps.
@@ -374,7 +388,11 @@ def get_step_summary(db: Session, file_id: int) -> Dict:
     # Note: if TERMINAL_STEP already appears in `steps`, the loop above has
     # already incremented `main_steps_count` for it, so we only add here when
     # the step is absent from the DB entirely.
-    if not any(step.step_name == TERMINAL_STEP for step in steps):
+    if (
+        expected_steps is None
+        and TERMINAL_STEP in real_main_steps
+        and not any(normalize_stage_name(step.step_name) == TERMINAL_STEP for step in steps)
+    ):
         main_steps_count += 1
         main_counts["queued"] += 1
 

--- a/app/views/files.py
+++ b/app/views/files.py
@@ -586,7 +586,11 @@ def _pipeline_selection_details(file_record, pipeline) -> dict[str, str | None]:
     reason = getattr(file_record, "pipeline_assignment_reason", None)
 
     if source == "routing_rule":
-        return {"selection_source": source, "selection_label": "Routing Rule", "selection_reason": reason}
+        return {
+            "selection_source": source,
+            "selection_label": "Routing Rule",
+            "selection_reason": reason or "Processing profile was selected by a routing rule",
+        }
     if source == "manual" or file_record.pipeline_id:
         return {
             "selection_source": source or "manual",

--- a/app/views/files.py
+++ b/app/views/files.py
@@ -11,6 +11,11 @@ from sqlalchemy.orm import Session
 from app.utils.cache import cache_get, cache_set
 from app.utils.file_queries import apply_status_filter
 from app.utils.file_status import get_files_processing_status
+from app.utils.pipeline_stages import (
+    ALWAYS_SHOW_STAGES as _ALWAYS_SHOW_STAGES,
+    normalize_stage_name,
+    stage_keys_for_pipeline_steps,
+)
 from app.views.base import APIRouter, get_db, logger, require_login, templates
 
 router = APIRouter()
@@ -382,16 +387,19 @@ def file_view_page(request: Request, file_id: int, db: Session = Depends(get_db)
             except Exception as e:
                 logger.warning(f"Failed to parse ai_metadata for file {file_id}: {e}")
 
+        # Resolve the pipeline assigned to this file (explicit or inferred default)
+        pipeline_info = _resolve_pipeline(db, file_record)
+
         # Quick processing status (no logs needed)
         try:
             from app.utils.step_manager import get_step_summary as _get_step_summary
 
-            step_summary = _get_step_summary(db, file_id)
+            step_summary = _get_step_summary(
+                db, file_id, pipeline_steps=pipeline_info["steps"] if pipeline_info else None
+            )
         except Exception:
             step_summary = None
 
-        # Resolve the pipeline assigned to this file (explicit or system default)
-        pipeline_info = _resolve_pipeline(db, file_record)
         owner_ctx = _resolve_owner_context(request, file_record, db)
 
         return templates.TemplateResponse(
@@ -463,7 +471,7 @@ def file_detail_page(request: Request, file_id: int, db: Session = Depends(get_d
                 except Exception as e:
                     logger.warning(f"Failed to load metadata from {metadata_path}: {e}")
 
-        # Resolve the pipeline assigned to this file (explicit or system default)
+        # Resolve the pipeline assigned to this file (explicit or inferred default)
         pipeline_info = _resolve_pipeline(db, file_record)
 
         # Compute processing flow for visualization — filter to pipeline steps when available
@@ -473,10 +481,12 @@ def file_detail_page(request: Request, file_id: int, db: Session = Depends(get_d
         try:
             from app.utils.step_manager import get_step_summary as get_step_summary_from_table
 
-            step_summary = get_step_summary_from_table(db, file_id)
+            step_summary = get_step_summary_from_table(
+                db, file_id, pipeline_steps=pipeline_info["steps"] if pipeline_info else None
+            )
         except Exception:
             # Fallback to log-based computation if status table not available
-            step_summary = _compute_step_summary(logs)
+            step_summary = _compute_step_summary(logs, pipeline_steps=pipeline_info["steps"] if pipeline_info else None)
 
         return templates.TemplateResponse(
             "file_detail.html",
@@ -568,44 +578,46 @@ def file_comments_redirect(request: Request, file_id: int):
     return RedirectResponse(url=f"/files/{file_id}/annotations", status_code=302)
 
 
-# ---------------------------------------------------------------------------
-# Pipeline ↔ Celery-log stage mapping
-# ---------------------------------------------------------------------------
+def _pipeline_selection_details(file_record, pipeline) -> dict[str, str | None]:
+    """Return display metadata for why a processing profile was selected."""
+    source = getattr(file_record, "pipeline_assignment_source", None)
+    reason = getattr(file_record, "pipeline_assignment_reason", None)
 
-# Maps each pipeline step_type to the set of Celery task log stage keys that
-# implement it.  Used to filter the flow visualization when a pipeline is
-# assigned to a file.
-#
-# ⚠️  MAINTENANCE NOTE: When a new step type is added to PIPELINE_STEP_TYPES
-# in app/api/pipelines.py it MUST also be added here, otherwise the flow
-# visualization will silently skip its Celery-task stages for files using that
-# step type.  The test ``TestPipelineInfoInViews::test_step_type_mapping_is_complete``
-# enforces this invariant automatically.
-_STEP_TYPE_TO_STAGES: dict[str, list[str]] = {
-    "convert_to_pdf": ["convert_to_pdf"],
-    "check_duplicates": ["check_for_duplicates"],
-    "ocr": ["check_text", "extract_text", "process_with_ocr"],
-    "extract_metadata": ["extract_metadata_with_gpt"],
-    "embed_metadata": ["embed_metadata_into_pdf"],
-    "compute_embedding": ["compute_embedding"],
-    "send_to_destinations": ["finalize_document_storage", "send_to_all_destinations"],
-    "classify": ["classify_document"],
-}
+    if source == "routing_rule":
+        return {"selection_source": source, "selection_label": "Routing Rule", "selection_reason": reason}
+    if source == "manual" or file_record.pipeline_id:
+        return {
+            "selection_source": source or "manual",
+            "selection_label": "Manual",
+            "selection_reason": reason or "Processing profile was manually assigned to this file",
+        }
 
-# These internal bookkeeping stages are always shown in the flow regardless of
-# which pipeline steps are defined.
-_ALWAYS_SHOW_STAGES: frozenset[str] = frozenset({"create_file_record"})
+    if pipeline.owner_id is None:
+        return {
+            "selection_source": source or "system_default",
+            "selection_label": "System Default",
+            "selection_reason": reason or "No file profile matched; using the system default profile",
+        }
+
+    return {
+        "selection_source": source or "user_default",
+        "selection_label": "User Default",
+        "selection_reason": reason or "No file profile matched; using the owner's default profile",
+    }
 
 
 def _resolve_pipeline(db: Session, file_record) -> dict | None:
     """Resolve the pipeline information for a file.
 
-    If the file has an explicit ``pipeline_id``, load that pipeline.
-    Otherwise fall back to the active system-default pipeline
-    (``owner_id IS NULL``, ``is_default=True``).
+    Resolution order mirrors document processing:
+
+    1. Explicit file pipeline assignment.
+    2. Owner default pipeline.
+    3. Active system-default pipeline (``owner_id IS NULL``, ``is_default=True``).
 
     Returns a dict with keys:
-        id, name, description, is_default, is_system, is_explicit, steps
+        id, name, description, is_default, is_system, is_explicit, steps,
+        selection_source, selection_label, selection_reason
     or ``None`` when no pipeline exists in the database.
     """
     from app.models import Pipeline, PipelineStep
@@ -613,6 +625,17 @@ def _resolve_pipeline(db: Session, file_record) -> dict | None:
     pipeline = None
     if file_record.pipeline_id:
         pipeline = db.query(Pipeline).filter(Pipeline.id == file_record.pipeline_id).first()
+
+    if pipeline is None and file_record.owner_id:
+        pipeline = (
+            db.query(Pipeline)
+            .filter(
+                Pipeline.owner_id == file_record.owner_id,
+                Pipeline.is_default.is_(True),
+                Pipeline.is_active.is_(True),
+            )
+            .first()
+        )
 
     if pipeline is None:
         pipeline = (
@@ -629,6 +652,7 @@ def _resolve_pipeline(db: Session, file_record) -> dict | None:
         return None
 
     steps = db.query(PipelineStep).filter(PipelineStep.pipeline_id == pipeline.id).order_by(PipelineStep.position).all()
+    selection = _pipeline_selection_details(file_record, pipeline)
 
     return {
         "id": pipeline.id,
@@ -639,6 +663,7 @@ def _resolve_pipeline(db: Session, file_record) -> dict | None:
         # True when the file has a pipeline explicitly assigned (not inferred default)
         "is_explicit": bool(file_record.pipeline_id),
         "steps": steps,
+        **selection,
     }
 
 
@@ -693,15 +718,11 @@ def _compute_processing_flow(logs, pipeline_steps=None):
     # pipeline's enabled steps plus always-show bookkeeping stages and any stage
     # that actually produced log entries (so nothing already-run is hidden).
     if pipeline_steps is not None:
-        # Collect Celery stage keys that the pipeline's enabled steps map to
-        allowed: set[str] = set(_ALWAYS_SHOW_STAGES)
-        for ps in pipeline_steps:
-            if ps.enabled:
-                allowed.update(_STEP_TYPE_TO_STAGES.get(ps.step_type, []))
+        allowed = stage_keys_for_pipeline_steps(pipeline_steps) or set(_ALWAYS_SHOW_STAGES)
         # Pre-scan logs so we can also keep any stage that already ran
         ran_stages: set[str] = set()
         for log in logs:
-            ran_stages.add(log.step_name)
+            ran_stages.add(normalize_stage_name(log.step_name))
         allowed.update(ran_stages)
         stages = {k: v for k, v in stages.items() if k in allowed}
 
@@ -749,8 +770,7 @@ def _compute_processing_flow(logs, pipeline_steps=None):
             )
         else:
             # Normalize legacy OCR step name for backward compatibility with old log entries
-            if step_name == "process_with_azure_document_intelligence":
-                step_name = "process_with_ocr"
+            step_name = normalize_stage_name(step_name)
             # Regular processing step
             if step_name not in step_map:
                 step_map[step_name] = []
@@ -812,7 +832,7 @@ def _compute_processing_flow(logs, pipeline_steps=None):
     return flow
 
 
-def _compute_step_summary(logs):
+def _compute_step_summary(logs, pipeline_steps=None):
     """
     Compute a step-aligned summary from logs showing queued, success, and failure counts.
 
@@ -824,6 +844,7 @@ def _compute_step_summary(logs):
     from app.config import settings
 
     # Count statuses for main processing steps (not uploads)
+    expected_steps = stage_keys_for_pipeline_steps(pipeline_steps)
     main_steps = []
     if settings.enable_deduplication and settings.show_deduplication_step:
         main_steps.append("check_for_duplicates")
@@ -839,6 +860,8 @@ def _compute_step_summary(logs):
             "send_to_all_destinations",
         ]
     )
+    if expected_steps is not None:
+        main_steps = [step_name for step_name in main_steps if step_name in expected_steps]
 
     upload_prefixes = ["upload_to_", "queue_"]
 
@@ -857,9 +880,7 @@ def _compute_step_summary(logs):
         if status == "pending":
             status = "queued"
 
-        # Normalize legacy OCR step name for backward compatibility
-        if step_name == "process_with_azure_document_intelligence":
-            step_name = "process_with_ocr"
+        step_name = normalize_stage_name(step_name)
 
         # Check if it's an upload task
         is_upload = any(step_name.startswith(prefix) for prefix in upload_prefixes)
@@ -878,6 +899,11 @@ def _compute_step_summary(logs):
         if task_status in main_counts:
             main_counts[task_status] += 1
 
+    if expected_steps is not None:
+        for step_name in main_steps:
+            if step_name not in main_steps_seen:
+                main_counts["queued"] += 1
+
     # Count upload task statuses from latest status per task
     for _, task_status in upload_tasks_seen.values():
         if task_status in upload_counts:
@@ -886,7 +912,7 @@ def _compute_step_summary(logs):
     return {
         "main": main_counts,
         "uploads": upload_counts,
-        "total_main_steps": len(main_steps_seen),
+        "total_main_steps": len(main_steps) if expected_steps is not None else len(main_steps_seen),
         "total_upload_tasks": len(upload_tasks_seen),
     }
 

--- a/app/views/files.py
+++ b/app/views/files.py
@@ -13,6 +13,8 @@ from app.utils.file_queries import apply_status_filter
 from app.utils.file_status import get_files_processing_status
 from app.utils.pipeline_stages import (
     ALWAYS_SHOW_STAGES as _ALWAYS_SHOW_STAGES,
+)
+from app.utils.pipeline_stages import (
     normalize_stage_name,
     stage_keys_for_pipeline_steps,
 )

--- a/frontend/templates/file_detail.html
+++ b/frontend/templates/file_detail.html
@@ -1209,6 +1209,8 @@
           <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #ede9fe; color: #5b21b6;" title="{{ pipeline_info.selection_reason }}">{{ pipeline_info.selection_label }}</span>
           {% elif pipeline_info.selection_label == "User Default" %}
           <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #fef3c7; color: #92400e;" title="{{ pipeline_info.selection_reason }}">User Default</span>
+          {% elif pipeline_info.selection_label == "Manual" %}
+          <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #d1fae5; color: #065f46;" title="{{ pipeline_info.selection_reason }}">Manual</span>
           {% elif pipeline_info.is_system %}
           <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #dbeafe; color: #1e40af;" title="{{ pipeline_info.selection_reason }}">System</span>
           {% else %}

--- a/frontend/templates/file_detail.html
+++ b/frontend/templates/file_detail.html
@@ -1205,12 +1205,14 @@
         <span class="detail-value">
           {% if pipeline_info %}
           <a href="/pipelines" style="text-decoration: none; color: inherit; font-weight: 500;" aria-label="View pipeline management for {{ pipeline_info.name }}">{{ pipeline_info.name }}</a>
-          {% if not pipeline_info.is_explicit and pipeline_info.is_system %}
-          <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #ede9fe; color: #5b21b6;" title="No pipeline was explicitly assigned; the system default is applied">System Default</span>
+          {% if pipeline_info.selection_label in ["System Default", "Routing Rule"] %}
+          <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #ede9fe; color: #5b21b6;" title="{{ pipeline_info.selection_reason }}">{{ pipeline_info.selection_label }}</span>
+          {% elif pipeline_info.selection_label == "User Default" %}
+          <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #fef3c7; color: #92400e;" title="{{ pipeline_info.selection_reason }}">User Default</span>
           {% elif pipeline_info.is_system %}
-          <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #dbeafe; color: #1e40af;" title="This file uses a system-managed pipeline">System</span>
+          <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #dbeafe; color: #1e40af;" title="{{ pipeline_info.selection_reason }}">System</span>
           {% else %}
-          <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #d1fae5; color: #065f46;" title="This file uses a custom user-defined pipeline">Custom</span>
+          <span style="display: inline-block; margin-left: 0.4rem; padding: 0.1rem 0.45rem; font-size: 0.7rem; font-weight: 600; border-radius: 0.25rem; background: #d1fae5; color: #065f46;" title="{{ pipeline_info.selection_reason }}">Custom</span>
           {% endif %}
           {% else %}
           <span style="color: #9ca3af; font-style: italic;">Standard (legacy)</span>

--- a/frontend/templates/file_summary.html
+++ b/frontend/templates/file_summary.html
@@ -160,7 +160,7 @@
     <div class="info-row"><span class="info-key">Language</span><span class="info-val">{{ file.detected_language }}</span></div>
     {% endif %}
     {% if pipeline_info %}
-    <div class="info-row"><span class="info-key">Pipeline</span><span class="info-val">{{ pipeline_info.name }}</span></div>
+    <div class="info-row"><span class="info-key">Pipeline</span><span class="info-val">{{ pipeline_info.name }} <span title="{{ pipeline_info.selection_reason }}">({{ pipeline_info.selection_label | lower }})</span></span></div>
     {% endif %}
     {% if file.document_title %}
     <div class="info-row"><span class="info-key">Document Title</span><span class="info-val">{{ file.document_title }}</span></div>

--- a/frontend/templates/file_view.html
+++ b/frontend/templates/file_view.html
@@ -307,9 +307,9 @@
             {% if pipeline_info %}
             <a href="/pipelines" style="text-decoration:none;color:inherit;font-weight:500;" aria-label="View pipeline management for {{ pipeline_info.name }}">{{ pipeline_info.name }}</a>
             {% if not pipeline_info.is_explicit %}
-            <span style="font-size:0.7em;color:#7c3aed;" title="System default pipeline applied automatically">(default)</span>
+            <span style="font-size:0.7em;color:#7c3aed;" title="{{ pipeline_info.selection_reason }}">({{ pipeline_info.selection_label | lower }})</span>
             {% elif not pipeline_info.is_system %}
-            <span style="font-size:0.7em;color:#059669;" title="Custom user-defined pipeline">(custom)</span>
+            <span style="font-size:0.7em;color:#059669;" title="{{ pipeline_info.selection_reason }}">({{ pipeline_info.selection_label | lower }})</span>
             {% endif %}
             {% else %}
             <span style="color:#9ca3af;font-style:italic;">Standard</span>

--- a/frontend/templates/file_view.html
+++ b/frontend/templates/file_view.html
@@ -306,10 +306,9 @@
           <span class="info-val">
             {% if pipeline_info %}
             <a href="/pipelines" style="text-decoration:none;color:inherit;font-weight:500;" aria-label="View pipeline management for {{ pipeline_info.name }}">{{ pipeline_info.name }}</a>
-            {% if not pipeline_info.is_explicit %}
-            <span style="font-size:0.7em;color:#7c3aed;" title="{{ pipeline_info.selection_reason }}">({{ pipeline_info.selection_label | lower }})</span>
-            {% elif not pipeline_info.is_system %}
-            <span style="font-size:0.7em;color:#059669;" title="{{ pipeline_info.selection_reason }}">({{ pipeline_info.selection_label | lower }})</span>
+            {% if pipeline_info.selection_label %}
+            {% set pipeline_badge_color = "#059669" if pipeline_info.selection_label == "Manual" else "#7c3aed" %}
+            <span style="font-size:0.7em;color:{{ pipeline_badge_color }};" title="{{ pipeline_info.selection_reason }}">({{ pipeline_info.selection_label | lower }})</span>
             {% endif %}
             {% else %}
             <span style="color:#9ca3af;font-style:italic;">Standard</span>

--- a/tests/test_step_manager.py
+++ b/tests/test_step_manager.py
@@ -401,6 +401,30 @@ class TestStepManager:
         assert summary["total_main_steps"] == len(MAIN_PROCESSING_STEPS)
         assert summary["total_upload_tasks"] == 3  # 3 upload_to_* steps counted
 
+    def test_get_step_summary_uses_pipeline_steps_for_expected_main_count(self, db_session: Session):
+        """Selected profile steps determine expected main status totals."""
+        file_record = FileRecord(
+            filehash="profile-summary",
+            original_filename="profile-summary.pdf",
+            local_filename="/tmp/profile-summary.pdf",
+            file_size=2097152,
+        )
+        db_session.add(file_record)
+        db_session.commit()
+
+        update_step_status(db_session, file_record.id, "check_text", "success")
+        update_step_status(db_session, file_record.id, "send_to_all_destinations", "success")
+        pipeline_steps = [
+            type("Step", (), {"enabled": True, "step_type": "ocr"})(),
+            type("Step", (), {"enabled": False, "step_type": "send_to_destinations"})(),
+        ]
+
+        summary = get_step_summary(db_session, file_record.id, pipeline_steps=pipeline_steps)
+
+        assert summary["main"]["success"] == 1
+        assert summary["main"]["queued"] == 3
+        assert summary["total_main_steps"] == 4
+
     def test_get_file_overall_status_duplicate_file(self, db_session: Session):
         """Test overall status returns 'duplicate' immediately for duplicate files."""
         file_record = FileRecord(

--- a/tests/test_views_files_comprehensive.py
+++ b/tests/test_views_files_comprehensive.py
@@ -1951,7 +1951,7 @@ class TestPipelineInfoInViews:
 
         missing = set(PIPELINE_STEP_TYPES.keys()) - set(PIPELINE_STEP_TO_STAGES.keys())
         assert not missing, (
-            f"The following pipeline step types are missing from _STEP_TYPE_TO_STAGES "
+            f"The following pipeline step types are missing from PIPELINE_STEP_TO_STAGES "
             f"in app/utils/pipeline_stages.py: {missing}.  "
             "Add them with their corresponding status/log stage key(s) (use [] if none yet)."
         )

--- a/tests/test_views_files_comprehensive.py
+++ b/tests/test_views_files_comprehensive.py
@@ -427,6 +427,23 @@ class TestComputeStepSummary:
         assert summary["uploads"]["success"] >= 1
         assert summary["uploads"]["failure"] >= 1
 
+    def test_compute_step_summary_uses_profile_steps_for_expected_rows(self):
+        """Profile-aware fallback summary counts expected unstarted steps as queued."""
+        from app.views.files import _compute_step_summary
+
+        logs = [Mock(step_name="check_text", status="success", timestamp=Mock())]
+        pipeline_steps = [
+            Mock(enabled=True, step_type="ocr"),
+            Mock(enabled=True, step_type="extract_metadata"),
+            Mock(enabled=False, step_type="send_to_destinations"),
+        ]
+
+        summary = _compute_step_summary(logs, pipeline_steps=pipeline_steps)
+
+        assert summary["main"]["success"] == 1
+        assert summary["main"]["queued"] == 4
+        assert summary["total_main_steps"] == 5
+
     def test_compute_step_summary_normalizes_pending_status(self):
         """Test that 'pending' status is normalized to 'queued'."""
         from app.views.files import _compute_step_summary
@@ -1730,7 +1747,7 @@ class TestPipelineInfoInViews:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _make_file(db_session, pipeline_id=None):
+    def _make_file(db_session, pipeline_id=None, owner_id=None, **kwargs):
         from app.models import FileRecord
 
         f = FileRecord(
@@ -1740,6 +1757,8 @@ class TestPipelineInfoInViews:
             file_size=1024,
             mime_type="application/pdf",
             pipeline_id=pipeline_id,
+            owner_id=owner_id,
+            **kwargs,
         )
         db_session.add(f)
         db_session.commit()
@@ -1787,6 +1806,22 @@ class TestPipelineInfoInViews:
         db_session.commit()
         return p
 
+    @staticmethod
+    def _make_user_default_pipeline(db_session, owner_id="user1"):
+        from app.models import Pipeline, PipelineStep
+
+        p = Pipeline(
+            owner_id=owner_id,
+            name="User Default Profile",
+            is_default=True,
+            is_active=True,
+        )
+        db_session.add(p)
+        db_session.flush()
+        db_session.add(PipelineStep(pipeline_id=p.id, position=0, step_type="ocr", label="OCR", enabled=True))
+        db_session.commit()
+        return p
+
     # ------------------------------------------------------------------
     # _resolve_pipeline unit tests
     # ------------------------------------------------------------------
@@ -1819,6 +1854,24 @@ class TestPipelineInfoInViews:
         assert info["is_explicit"] is False
         assert info["is_system"] is True
         assert info["is_default"] is True
+        assert info["selection_label"] == "System Default"
+
+    def test_resolve_pipeline_fallback_to_owner_default_before_system_default(self, db_session):
+        """File detail uses the owner's default profile before the system default."""
+        from app.views.files import _resolve_pipeline
+
+        self._make_system_pipeline(db_session)
+        user_pipeline = self._make_user_default_pipeline(db_session, owner_id="user1")
+        file_rec = self._make_file(db_session, pipeline_id=None, owner_id="user1")
+
+        info = _resolve_pipeline(db_session, file_rec)
+
+        assert info is not None
+        assert info["id"] == user_pipeline.id
+        assert info["is_explicit"] is False
+        assert info["is_system"] is False
+        assert info["is_default"] is True
+        assert info["selection_label"] == "User Default"
 
     def test_resolve_pipeline_returns_none_when_no_pipeline_in_db(self, db_session):
         """Returns None when no pipeline exists (empty database)."""
@@ -1856,6 +1909,26 @@ class TestPipelineInfoInViews:
         assert info["name"] == "My Custom Pipeline"
         assert info["is_system"] is False
         assert info["is_explicit"] is True
+        assert info["selection_label"] == "Manual"
+
+    def test_resolve_pipeline_reports_routing_rule_selection(self, db_session):
+        """A routed file shows routing-rule provenance in pipeline info."""
+        from app.views.files import _resolve_pipeline
+
+        pipeline = self._make_custom_pipeline(db_session)
+        file_rec = self._make_file(
+            db_session,
+            pipeline_id=pipeline.id,
+            owner_id="user1",
+            pipeline_assignment_source="routing_rule",
+            pipeline_assignment_reason="Matched pre-processing routing rule 'Invoices'",
+        )
+
+        info = _resolve_pipeline(db_session, file_rec)
+
+        assert info is not None
+        assert info["selection_label"] == "Routing Rule"
+        assert info["selection_reason"] == "Matched pre-processing routing rule 'Invoices'"
 
     # ------------------------------------------------------------------
     # _compute_processing_flow pipeline filtering
@@ -1872,15 +1945,15 @@ class TestPipelineInfoInViews:
         assert "extract_metadata_with_gpt" in keys
 
     def test_step_type_mapping_is_complete(self):
-        """Every step type in PIPELINE_STEP_TYPES has an entry in _STEP_TYPE_TO_STAGES."""
+        """Every step type in PIPELINE_STEP_TYPES has a shared status-stage mapping."""
         from app.api.pipelines import PIPELINE_STEP_TYPES
-        from app.views.files import _STEP_TYPE_TO_STAGES
+        from app.utils.pipeline_stages import PIPELINE_STEP_TO_STAGES
 
-        missing = set(PIPELINE_STEP_TYPES.keys()) - set(_STEP_TYPE_TO_STAGES.keys())
+        missing = set(PIPELINE_STEP_TYPES.keys()) - set(PIPELINE_STEP_TO_STAGES.keys())
         assert not missing, (
             f"The following pipeline step types are missing from _STEP_TYPE_TO_STAGES "
-            f"in app/views/files.py: {missing}.  "
-            "Add them with their corresponding Celery log stage key(s) (use [] if none yet)."
+            f"in app/utils/pipeline_stages.py: {missing}.  "
+            "Add them with their corresponding status/log stage key(s) (use [] if none yet)."
         )
 
     def test_compute_flow_with_pipeline_filters_stages(self, db_session):
@@ -1951,6 +2024,18 @@ class TestPipelineInfoInViews:
 
         assert response.status_code == 200
         assert b"System Default" in response.content
+
+    def test_file_detail_page_shows_user_default_badge(self, client, db_session):
+        """File owned by a user shows that user's default profile when selected."""
+        self._make_system_pipeline(db_session)
+        self._make_user_default_pipeline(db_session, owner_id="user1")
+        file_rec = self._make_file(db_session, pipeline_id=None, owner_id="user1")
+
+        response = client.get(f"/files/{file_rec.id}/process")
+
+        assert response.status_code == 200
+        assert b"User Default Profile" in response.content
+        assert b"User Default" in response.content
 
     def test_file_detail_page_shows_custom_badge_for_custom_pipeline(self, client, db_session):
         """File with a custom (non-system) pipeline shows 'Custom' badge."""


### PR DESCRIPTION
## Summary
- resolve file profile display in the same order used by processing: explicit assignment, user default, then system default
- show profile selection provenance in file detail, summary, and quick file views
- share profile-step-to-status-stage mapping between flow rendering and status summaries so expected rows follow the selected profile
- add regressions for user-default fallback, routing/manual/default selection labels, and profile-driven status totals

Fixes #958

## Testing
- .venv312/bin/python -m pytest tests/test_views_files_comprehensive.py tests/test_step_manager.py -q
- .venv312/bin/python -m ruff check app/views/files.py app/utils/step_manager.py app/utils/pipeline_stages.py tests/test_views_files_comprehensive.py tests/test_step_manager.py
- .venv312/bin/python -m ruff format --check app/views/files.py app/utils/step_manager.py app/utils/pipeline_stages.py tests/test_views_files_comprehensive.py tests/test_step_manager.py
- .venv312/bin/python -m djlint frontend/templates/file_detail.html frontend/templates/file_view.html frontend/templates/file_summary.html --lint
- python3 -m py_compile app/views/files.py app/utils/step_manager.py app/utils/pipeline_stages.py tests/test_views_files_comprehensive.py tests/test_step_manager.py
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,cr-at-eol diff --check