### PR TITLE
fix: make runtime image builds fail safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,13 +224,13 @@ jobs:
         with:
           cmd: |
             yq -i '(.. | select(tag == "!!str") | select(test("^(ghcr\\.io/christianlouis/docuelevate|christianlouis/docuelevate):"))) = strenv(IMAGE)' \
-              k8s-cluster-state/apps/docuelevate/preprod/docuelevate-stack.yaml
+              k8s-cluster-state/apps/docuelevate/greenfield-preprod/docuelevate-stack.yaml
       - name: Commit and push
         run: |
           cd k8s-cluster-state
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add apps/docuelevate/preprod/docuelevate-stack.yaml
+          git add apps/docuelevate/greenfield-preprod/docuelevate-stack.yaml
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,13 @@ ENV PATH="/opt/venv/bin:$PATH" \
     PIP_NO_CACHE_DIR=1
 
 COPY requirements.txt /build/
+# Keep dependency failures fatal and verify the entry points used by Kubernetes.
+# Only cache cleanup is best-effort.
 RUN pip install --no-cache-dir -r requirements.txt \
-    # Remove bytecode and cache to keep the venv lean
+    && command -v uvicorn \
+    && command -v celery \
     && find /opt/venv -type f -name "*.pyc" -delete \
-    && find /opt/venv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+    && (find /opt/venv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true)
 
 # ── Stage 2: Frontend asset builder ─────────────────────────────────────────
 # Compiles Tailwind CSS (a devDependency) into the minified styles.css.


### PR DESCRIPTION
## What changed

- keeps Python dependency-install failures fatal during Docker builds
- verifies the Kubernetes runtime entry points (`uvicorn` and `celery`) exist before publishing
- updates the deployment workflow to write to the active Argo CD preproduction path

## Root cause

The cache-cleanup `|| true` applied to the entire Docker RUN chain, so a failed dependency installation could still produce and publish an image with an empty virtual environment. The deployment workflow also updated an inactive legacy manifest path.

## Validation

- reproduced the missing `uvicorn` and `celery` entry points in `main-64e92a7`
- restored preproduction to the last healthy image before applying this fix
- `git diff --check` passed
