### PR TITLE
fix: use a supported Python runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Use the same slim variant as the runtime to keep Python versions in sync.
 # build-essential + libffi-dev cover the few packages (e.g. cryptography) that
 # need a C compiler; they are discarded after this stage.
-FROM python:3.14.3-slim AS builder
+FROM python:3.13.11-slim AS builder
 
 WORKDIR /build
 
@@ -45,7 +45,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # ── Stage 4: Documentation builder ──────────────────────────────────────────
-FROM python:3.14.3-slim AS docs-builder
+FROM python:3.13.11-slim AS docs-builder
 
 WORKDIR /docs
 
@@ -61,7 +61,7 @@ COPY mkdocs.yml /docs/mkdocs.yml
 RUN mkdocs build --config-file /docs/mkdocs.yml --site-dir /docs/docs_build
 
 # ── Stage 5: Runtime image ───────────────────────────────────────────────────
-FROM python:3.14.3-slim
+FROM python:3.13.11-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## What changed

- builds dependency, documentation, and runtime stages on Python 3.13.11
- retains the fatal dependency-install and runtime-entry-point checks from #1017

## Root cause

LiteLLM currently declares Python `<3.14`, while the Docker image had moved to Python 3.14.3. Pip therefore could not resolve `litellm>=1.90.0`, and the old cleanup expression masked that failure until #1017.

## Validation

- GitHub build log confirms the incompatible Python requirement is the dependency-resolution blocker
- Python 3.13 remains supported by the pinned runtime dependency range
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s underlying Python runtime environment to version 3.13.11.
  * Applied the runtime update consistently across dependency, documentation, and production build stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->