### PR TITLE
fix: widen legacy Alembic revision storage

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -140,9 +140,34 @@ def _run_alembic_upgrade(engine: Any) -> None:
             command.stamp(alembic_cfg, "head")
         else:
             # Existing database with Alembic version tracking — apply pending migrations.
+            _ensure_alembic_version_capacity(connection)
             logger.info("Running pending Alembic migrations…")
             command.upgrade(alembic_cfg, "head")
             logger.info("Alembic migration check complete.")
+
+
+def _ensure_alembic_version_capacity(connection: Any) -> None:
+    """Widen legacy Alembic revision storage before applying long revision IDs."""
+    from sqlalchemy import inspect, text
+
+    dialect = connection.dialect.name
+    if dialect not in {"postgresql", "mysql", "mariadb"}:
+        return
+
+    columns = inspect(connection).get_columns("alembic_version")
+    version_column = next(
+        (column for column in columns if column["name"] == "version_num"),
+        None,
+    )
+    current_length = getattr(version_column["type"], "length", None) if version_column else None
+    if current_length is None or current_length >= 255:
+        return
+
+    if dialect == "postgresql":
+        connection.execute(text("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(255)"))
+    else:
+        connection.execute(text("ALTER TABLE alembic_version MODIFY COLUMN version_num VARCHAR(255) NOT NULL"))
+    logger.info("Expanded alembic_version.version_num from %s to 255 characters.", current_length)
 
 
 def _run_schema_migrations(engine: Any) -> None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -780,6 +780,34 @@ class TestMultiVersionMigrations:
 class TestAlembicUpgrade:
     """Tests for Alembic-based migration management."""
 
+    def test_widens_legacy_postgresql_version_column(self):
+        """Long revision IDs fit databases created with Alembic's legacy VARCHAR(32)."""
+        from sqlalchemy import String
+
+        from app.database import _ensure_alembic_version_capacity
+
+        connection = MagicMock()
+        connection.dialect.name = "postgresql"
+        inspector = MagicMock()
+        inspector.get_columns.return_value = [{"name": "version_num", "type": String(32)}]
+
+        with patch("sqlalchemy.inspect", return_value=inspector):
+            _ensure_alembic_version_capacity(connection)
+
+        statement = str(connection.execute.call_args.args[0])
+        assert statement == "ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(255)"
+
+    def test_version_capacity_is_noop_for_sqlite(self):
+        """SQLite does not enforce the declared VARCHAR length."""
+        from app.database import _ensure_alembic_version_capacity
+
+        connection = MagicMock()
+        connection.dialect.name = "sqlite"
+
+        _ensure_alembic_version_capacity(connection)
+
+        connection.execute.assert_not_called()
+
     def test_alembic_upgrade_stamps_fresh_database(self, tmp_path):
         """Test that _run_alembic_upgrade stamps a fresh database to head."""
         from pathlib import Path


### PR DESCRIPTION
## What changed

- widens legacy PostgreSQL/MySQL Alembic revision storage from 32 to 255 characters before upgrades
- leaves SQLite unchanged
- adds focused regression tests for PostgreSQL and SQLite behavior

## Root cause

The preproduction database still had Alembic’s legacy `VARCHAR(32)` version column. Migration `043_add_pipeline_assignment_provenance` is 38 characters, so startup failed while Alembic tried to record the revision.

## Validation

- reproduced the PostgreSQL truncation failure in the live preproduction rollout
- 7 focused Alembic upgrade tests passed
- Ruff lint and formatting passed
- diff whitespace check passed
