### PR TITLE
Align bulk operation response contract tests

### DIFF
--- a/tests/test_api_files_comprehensive.py
+++ b/tests/test_api_files_comprehensive.py
@@ -2993,7 +2993,9 @@ class TestBulkAssignPipelineToFiles:
             "state": "completed",
             "updated_count": 2,
             "updated_ids": [file.id for file in files],
+            "operation_id": data["bulk_action"]["operation_id"],
         }
+        assert data["bulk_action"]["operation_id"]
         assert data["pipeline_id"] == pipeline.id
         for file in files:
             db_session.refresh(file)
@@ -3079,7 +3081,9 @@ class TestBulkTagFiles:
             "state": "completed",
             "updated_count": 2,
             "updated_ids": [file.id for file in files],
+            "operation_id": data["bulk_action"]["operation_id"],
         }
+        assert data["bulk_action"]["operation_id"]
         assert data["tags"] == ["Finance", "urgent"]
         for file in files:
             db_session.refresh(file)


### PR DESCRIPTION
Updates the two comprehensive API assertions to include the durable bulk operation ID introduced by #1020. No production behavior changes.\n\nValidation: focused tests pass; Ruff clean.