### PR TITLE
Add semantic workflow and review foundations

### DIFF
--- a/app/api/pipelines.py
+++ b/app/api/pipelines.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import Session
 from app.auth import get_current_user, get_current_user_id, require_login
 from app.config import settings
 from app.database import get_db
-from app.models import Pipeline, PipelineStep
+from app.models import Pipeline, PipelineStep, PipelineVersion
 from app.pipeline_templates import (
     export_pipeline_template,
     get_builtin_template,
@@ -272,6 +272,8 @@ def _serialize_pipeline(
         "description": pipeline.description,
         "is_default": pipeline.is_default,
         "is_active": pipeline.is_active,
+        "lifecycle_state": pipeline.lifecycle_state,
+        "published_version": pipeline.published_version,
         "created_at": pipeline.created_at.isoformat() if pipeline.created_at else None,
         "updated_at": pipeline.updated_at.isoformat() if pipeline.updated_at else None,
     }
@@ -795,6 +797,7 @@ def update_pipeline(pipeline_id: int, request: Request, db: DbSession, body: Pip
         pipeline.is_default = body.is_default
 
     try:
+        pipeline.lifecycle_state = "draft"
         db.commit()
         db.refresh(pipeline)
     except IntegrityError:
@@ -992,6 +995,7 @@ def add_step(pipeline_id: int, request: Request, db: DbSession, body: PipelineSt
     )
     try:
         db.add(step)
+        pipeline.lifecycle_state = "draft"
         db.commit()
         db.refresh(step)
     except Exception as exc:
@@ -1053,6 +1057,7 @@ def reorder_steps(
         step_map[sid].position = pos
 
     try:
+        pipeline.lifecycle_state = "draft"
         db.commit()
     except Exception as exc:
         db.rollback()
@@ -1135,6 +1140,7 @@ def update_step(
         step.position = new_pos
 
     try:
+        pipeline.lifecycle_state = "draft"
         db.commit()
         db.refresh(step)
     except Exception as exc:
@@ -1179,6 +1185,7 @@ def delete_step(pipeline_id: int, step_id: int, request: Request, db: DbSession)
             PipelineStep.pipeline_id == pipeline_id,
             PipelineStep.position > deleted_pos,
         ).update({"position": PipelineStep.position - 1})
+        pipeline.lifecycle_state = "draft"
         db.commit()
     except Exception as exc:
         db.rollback()
@@ -1206,6 +1213,110 @@ def _unset_default(db: Session, owner_id: str | None) -> None:
         db.query(Pipeline).filter(Pipeline.owner_id == owner_id, Pipeline.is_default.is_(True)).update(
             {"is_default": False}
         )
+
+
+def _version_snapshot(pipeline: Pipeline, steps: list[PipelineStep]) -> dict[str, Any]:
+    return {
+        "name": pipeline.name,
+        "description": pipeline.description,
+        "is_active": pipeline.is_active,
+        "steps": [_serialize_step(step) for step in steps],
+    }
+
+
+@router.get("/{pipeline_id}/versions", summary="List published workflow versions")
+@require_login
+def list_pipeline_versions(pipeline_id: int, request: Request, db: DbSession) -> list[dict[str, Any]]:
+    pipeline = db.query(Pipeline).filter(Pipeline.id == pipeline_id).first()
+    if not pipeline or not _can_access_pipeline(pipeline, _get_user_id(request), _is_admin(request)):
+        raise HTTPException(status_code=404, detail="Pipeline not found")
+    versions = (
+        db.query(PipelineVersion)
+        .filter(PipelineVersion.pipeline_id == pipeline_id)
+        .order_by(PipelineVersion.version.desc())
+        .all()
+    )
+    return [
+        {
+            "version": item.version,
+            "published_by": item.published_by,
+            "created_at": item.created_at,
+            "is_current": pipeline.published_version == item.version,
+        }
+        for item in versions
+    ]
+
+
+@router.post("/{pipeline_id}/publish", summary="Validate and publish a workflow version")
+@require_login
+def publish_pipeline(pipeline_id: int, request: Request, db: DbSession) -> dict[str, Any]:
+    pipeline = db.query(Pipeline).filter(Pipeline.id == pipeline_id).first()
+    if not pipeline or not _can_write_pipeline(pipeline, _get_user_id(request), _is_admin(request)):
+        raise HTTPException(status_code=404, detail="Pipeline not found")
+    steps = (
+        db.query(PipelineStep)
+        .filter(PipelineStep.pipeline_id == pipeline_id, PipelineStep.enabled.is_(True))
+        .order_by(PipelineStep.position, PipelineStep.id)
+        .all()
+    )
+    if not steps:
+        raise HTTPException(status_code=422, detail="A workflow must contain at least one enabled step")
+    unknown = sorted({step.step_type for step in steps if step.step_type not in PIPELINE_STEP_TYPES})
+    if unknown:
+        raise HTTPException(status_code=422, detail=f"Unknown workflow step types: {', '.join(unknown)}")
+    latest = (
+        db.query(PipelineVersion)
+        .filter(PipelineVersion.pipeline_id == pipeline_id)
+        .order_by(PipelineVersion.version.desc())
+        .first()
+    )
+    version_number = (latest.version if latest else 0) + 1
+    db.add(
+        PipelineVersion(
+            pipeline_id=pipeline_id,
+            version=version_number,
+            snapshot=json.dumps(_version_snapshot(pipeline, steps), ensure_ascii=False),
+            published_by=_get_user_id(request),
+        )
+    )
+    pipeline.lifecycle_state = "published"
+    pipeline.published_version = version_number
+    db.commit()
+    return {"pipeline_id": pipeline_id, "state": "published", "version": version_number}
+
+
+@router.post("/{pipeline_id}/versions/{version_number}/rollback", summary="Restore a published workflow version")
+@require_login
+def rollback_pipeline_version(pipeline_id: int, version_number: int, request: Request, db: DbSession) -> dict[str, Any]:
+    pipeline = db.query(Pipeline).filter(Pipeline.id == pipeline_id).first()
+    if not pipeline or not _can_write_pipeline(pipeline, _get_user_id(request), _is_admin(request)):
+        raise HTTPException(status_code=404, detail="Pipeline not found")
+    version = (
+        db.query(PipelineVersion)
+        .filter(PipelineVersion.pipeline_id == pipeline_id, PipelineVersion.version == version_number)
+        .first()
+    )
+    if not version:
+        raise HTTPException(status_code=404, detail="Pipeline version not found")
+    snapshot = json.loads(version.snapshot)
+    pipeline.name = snapshot["name"]
+    pipeline.description = snapshot.get("description")
+    pipeline.is_active = snapshot.get("is_active", True)
+    db.query(PipelineStep).filter(PipelineStep.pipeline_id == pipeline_id).delete(synchronize_session=False)
+    for position, step in enumerate(snapshot["steps"]):
+        db.add(
+            PipelineStep(
+                pipeline_id=pipeline_id,
+                position=position,
+                step_type=step["step_type"],
+                label=step.get("label"),
+                config=json.dumps(step.get("config") or {}),
+                enabled=step.get("enabled", True),
+            )
+        )
+    pipeline.lifecycle_state = "draft"
+    db.commit()
+    return {"pipeline_id": pipeline_id, "state": "draft", "restored_from_version": version_number}
 
 
 # ---------------------------------------------------------------------------

--- a/app/api/review_queue.py
+++ b/app/api/review_queue.py
@@ -1,11 +1,14 @@
 """API endpoints for human review queue items."""
 
-from typing import Annotated, Any
+import json
+from datetime import datetime, timezone
+from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from app.auth import require_login
+from app.auth import get_current_user_id, require_login
 from app.database import get_db
 from app.models import DocumentReviewItem, FileRecord
 from app.utils.user_scope import apply_owner_filter
@@ -13,6 +16,12 @@ from app.utils.user_scope import apply_owner_filter
 router = APIRouter(prefix="/review-queue", tags=["review-queue"])
 
 DbSession = Annotated[Session, Depends(get_db)]
+
+
+class ReviewResolution(BaseModel):
+    status: Literal["resolved", "dismissed"] = "resolved"
+    metadata: dict[str, Any] | None = None
+    note: str | None = Field(default=None, max_length=2000)
 
 
 def _to_review_response(item: DocumentReviewItem, file_record: FileRecord) -> dict[str, Any]:
@@ -52,3 +61,58 @@ def list_review_queue(
     rows = query.order_by(DocumentReviewItem.created_at.desc(), DocumentReviewItem.id.desc()).limit(limit).all()
     items = [_to_review_response(item, file_record) for item, file_record in rows]
     return {"items": items, "total": len(items), "status": status}
+
+
+@router.post("/{item_id}/resolve", summary="Edit metadata and resolve a review item")
+@require_login
+def resolve_review_item(item_id: int, body: ReviewResolution, request: Request, db: DbSession) -> dict[str, Any]:
+    row = (
+        db.query(DocumentReviewItem, FileRecord)
+        .join(FileRecord, DocumentReviewItem.file_id == FileRecord.id)
+        .filter(DocumentReviewItem.id == item_id)
+    )
+    row = apply_owner_filter(row, request).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Review item not found")
+    item, file_record = row
+    if item.status != "pending":
+        raise HTTPException(status_code=409, detail="Review item has already been resolved")
+    if body.metadata is not None:
+        current = json.loads(file_record.ai_metadata or "{}")
+        current.update(body.metadata)
+        file_record.ai_metadata = json.dumps(current, ensure_ascii=False)
+    item.status = body.status
+    item.resolved_by = get_current_user_id(request)
+    item.resolution_note = body.note
+    item.resolved_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(item)
+    return _to_review_response(item, file_record)
+
+
+def enqueue_low_confidence_review(
+    db: Session, file_record: FileRecord, metadata: dict[str, Any], threshold: int
+) -> DocumentReviewItem | None:
+    """Queue a document once when extraction confidence is below the threshold."""
+    try:
+        confidence = int(metadata.get("confidence_score"))
+    except (TypeError, ValueError):
+        return None
+    if confidence >= threshold:
+        return None
+    existing = (
+        db.query(DocumentReviewItem)
+        .filter(DocumentReviewItem.file_id == file_record.id, DocumentReviewItem.status == "pending")
+        .first()
+    )
+    if existing:
+        return existing
+    item = DocumentReviewItem(
+        file_id=file_record.id,
+        reason=f"Extraction confidence {confidence} is below threshold {threshold}",
+        confidence_score=confidence,
+        status="pending",
+        created_by="system",
+    )
+    db.add(item)
+    return item

--- a/app/api/search.py
+++ b/app/api/search.py
@@ -11,9 +11,12 @@ for RAG (Retrieval Augmented Generation) chatbot workflows.
 import logging
 from typing import Literal, Optional
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.orm import Session
 
 from app.auth import require_login
+from app.database import get_db
+from app.utils.hybrid_search import hybrid_rank, semantic_candidates
 from app.utils.meilisearch_client import search_documents
 
 logger = logging.getLogger(__name__)
@@ -43,6 +46,9 @@ def search_api(
     sort_order: Literal["asc", "desc"] = Query("desc", description="Result sort direction"),
     page: int = Query(1, ge=1, description="Page number (1-based)"),
     per_page: int = Query(20, ge=1, le=100, description="Results per page"),
+    mode: Literal["keyword", "semantic", "hybrid"] = Query("keyword", description="Ranking strategy"),
+    debug_ranking: bool = Query(False, description="Include ranking score components"),
+    db: Session = Depends(get_db),
 ):
     """Search documents by full text, metadata, and tags.
 
@@ -114,4 +120,20 @@ def search_api(
         per_page=per_page,
     )
 
-    return result
+    if mode == "keyword":
+        return result
+
+    semantic = semantic_candidates(db, request, q, mime_type=mime_type)
+    ranked = semantic if mode == "semantic" else hybrid_rank(result["results"], semantic)
+    start = (page - 1) * per_page
+    page_results = ranked[start : start + per_page]
+    if not debug_ranking:
+        for item in page_results:
+            item.pop("ranking_components", None)
+    return {
+        **result,
+        "results": page_results,
+        "total": len(ranked),
+        "pages": (len(ranked) + per_page - 1) // per_page,
+        "mode": mode,
+    }

--- a/app/config.py
+++ b/app/config.py
@@ -1070,6 +1070,12 @@ class Settings(BaseSettings):
             "backfill run.  Keeps the worker and embedding API load bounded."
         ),
     )
+    confidence_review_threshold: int = Field(
+        default=70,
+        ge=0,
+        le=100,
+        description="Queue extracted documents below this confidence score for human review.",
+    )
 
     # Text quality check - AI-based assessment of embedded PDF text
     enable_text_quality_check: bool = Field(

--- a/app/models.py
+++ b/app/models.py
@@ -489,6 +489,8 @@ class Pipeline(Base):
 
     # Soft-disable without deleting
     is_active = Column(Boolean, nullable=False, default=True)
+    lifecycle_state = Column(String(20), nullable=False, default="draft", server_default="draft")
+    published_version = Column(Integer, nullable=True)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
@@ -524,6 +526,20 @@ class PipelineStep(Base):
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class PipelineVersion(Base):
+    """Immutable published snapshot of a processing profile."""
+
+    __tablename__ = "pipeline_versions"
+    __table_args__ = (UniqueConstraint("pipeline_id", "version", name="uq_pipeline_versions_number"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    pipeline_id = Column(Integer, ForeignKey(_PIPELINES_ID_FK), nullable=False, index=True)
+    version = Column(Integer, nullable=False)
+    snapshot = Column(Text, nullable=False)
+    published_by = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
 
 
 class ImapIngestionProfile(Base):

--- a/app/tasks/embed_metadata_into_pdf.py
+++ b/app/tasks/embed_metadata_into_pdf.py
@@ -228,6 +228,14 @@ def embed_metadata_into_pdf(self, local_file_path: str, extracted_text: str, met
                         file_record.document_title = (
                             metadata.get("title") or metadata.get("filename") or file_record.original_filename
                         )
+                        from app.api.review_queue import enqueue_low_confidence_review
+
+                        enqueue_low_confidence_review(
+                            db,
+                            file_record,
+                            metadata,
+                            settings.confidence_review_threshold,
+                        )
                     db.commit()
                     logger.info(f"[{task_id}] Updated database with processed_file_path and search fields")
 

--- a/app/utils/extraction_evaluation.py
+++ b/app/utils/extraction_evaluation.py
@@ -1,0 +1,52 @@
+"""CI-friendly extraction evaluation metrics and report generation."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def evaluate_examples(examples: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute field exact-match accuracy and example completeness."""
+    expected_fields = 0
+    matching_fields = 0
+    complete_examples = 0
+    rows: list[dict[str, Any]] = []
+    for example in examples:
+        expected = example.get("expected", {})
+        actual = example.get("actual", {})
+        matches = {
+            key: str(actual.get(key, "")).strip().casefold() == str(value).strip().casefold()
+            for key, value in expected.items()
+        }
+        expected_fields += len(matches)
+        matching_fields += sum(matches.values())
+        complete = bool(matches) and all(matches.values())
+        complete_examples += int(complete)
+        rows.append({"id": example.get("id"), "matches": matches, "complete": complete})
+    count = len(examples)
+    return {
+        "examples": count,
+        "field_exact_match": matching_fields / expected_fields if expected_fields else 0.0,
+        "complete_example_rate": complete_examples / count if count else 0.0,
+        "details": rows,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Evaluate DocuElevate extraction fixtures")
+    parser.add_argument("dataset", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    examples = json.loads(args.dataset.read_text(encoding="utf-8"))
+    report = evaluate_examples(examples)
+    rendered = json.dumps(report, indent=2)
+    if args.output:
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/utils/hybrid_search.py
+++ b/app/utils/hybrid_search.py
@@ -1,0 +1,74 @@
+"""Semantic and hybrid ranking over cached document embeddings."""
+
+import json
+from typing import Any
+
+from fastapi import Request
+from sqlalchemy.orm import Session
+
+from app.models import FileRecord
+from app.utils.similarity import cosine_similarity, generate_embedding
+from app.utils.user_scope import apply_owner_filter
+
+
+def semantic_candidates(
+    db: Session,
+    request: Request,
+    query: str,
+    *,
+    mime_type: str | None = None,
+    limit: int = 200,
+) -> list[dict[str, Any]]:
+    """Rank accessible documents using their cached embeddings."""
+    query_vector = generate_embedding(query)
+    rows = db.query(FileRecord).filter(FileRecord.embedding.isnot(None), FileRecord.embedding != "")
+    rows = apply_owner_filter(rows, request)
+    if mime_type:
+        rows = rows.filter(FileRecord.mime_type == mime_type)
+    ranked: list[dict[str, Any]] = []
+    for file_record in rows.limit(limit).all():
+        try:
+            score = cosine_similarity(query_vector, json.loads(file_record.embedding))
+        except (TypeError, json.JSONDecodeError):
+            continue
+        metadata = json.loads(file_record.ai_metadata or "{}")
+        ranked.append(
+            {
+                "file_id": file_record.id,
+                "original_filename": file_record.original_filename,
+                "document_title": file_record.document_title,
+                "document_type": metadata.get("document_type"),
+                "tags": metadata.get("tags", []),
+                "semantic_score": round(score, 6),
+                "ranking_explanation": {
+                    "source": "embedding",
+                    "summary": "Cosine similarity between the query and cached document embedding.",
+                },
+            }
+        )
+    return sorted(ranked, key=lambda item: item["semantic_score"], reverse=True)
+
+
+def hybrid_rank(keyword_results: list[dict[str, Any]], semantic_results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Combine keyword and semantic ranks using weighted reciprocal rank fusion."""
+    combined: dict[int, dict[str, Any]] = {}
+    for source, weight, results in (("keyword", 0.55, keyword_results), ("semantic", 0.45, semantic_results)):
+        for rank, item in enumerate(results, start=1):
+            file_id = int(item["file_id"])
+            entry = combined.setdefault(file_id, dict(item))
+            entry["hybrid_score"] = entry.get("hybrid_score", 0.0) + weight / (60 + rank)
+            entry.setdefault("ranking_components", {})[source] = {
+                "rank": rank,
+                "raw_score": item.get("ranking_score", item.get("semantic_score")),
+            }
+            for key, value in item.items():
+                entry.setdefault(key, value)
+    ranked = sorted(combined.values(), key=lambda item: item["hybrid_score"], reverse=True)
+    for item in ranked:
+        item["hybrid_score"] = round(item["hybrid_score"], 8)
+        item["ranking_explanation"] = {
+            "source": "hybrid",
+            "summary": "Weighted reciprocal-rank fusion: 55% keyword and 45% semantic.",
+            "components": item["ranking_components"],
+        }
+    return ranked

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -2702,6 +2702,17 @@ SETTING_METADATA = {
         "required": False,
         "restart_required": False,
     },
+    "confidence_review_threshold": {
+        "category": "AI Services",
+        "description": "Queue extracted documents below this confidence score for human review. Default: 70.",
+        "type": "slider",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+        "min": 0,
+        "max": 100,
+        "step": 1,
+    },
     # File upload size limits
     "max_upload_size": {
         "category": "Core",

--- a/docs/API.md
+++ b/docs/API.md
@@ -1990,6 +1990,12 @@ Current runtime contract:
 - Step order and non-OCR step entries do not currently orchestrate the worker chain.
 - The system-managed processing flow still controls conversion, duplicate handling, metadata extraction, embedding, storage uploads, and classification.
 
+Workflow profiles support a draft/publish lifecycle. `POST /api/pipelines/{id}/publish`
+validates enabled step types and creates an immutable numbered snapshot. Published
+versions are listed at `GET /api/pipelines/{id}/versions`; restore one into a new
+draft with `POST /api/pipelines/{id}/versions/{version}/rollback`. Editing a profile
+after publication automatically returns it to draft state.
+
 ### Step-types catalogue
 
 ```bash

--- a/docs/ExtractionEvaluation.md
+++ b/docs/ExtractionEvaluation.md
@@ -1,0 +1,29 @@
+# Extraction evaluation
+
+Extraction fixtures are JSON arrays. Each entry has a stable `id`, an
+`expected` object containing the gold fields, and an `actual` object containing
+the extractor output being evaluated.
+
+```json
+[
+  {
+    "id": "invoice-001",
+    "expected": {"document_type": "Invoice", "sender": "Example GmbH"},
+    "actual": {"document_type": "Invoice", "sender": "Example GmbH"}
+  }
+]
+```
+
+Run the evaluator with:
+
+```bash
+python -m app.utils.extraction_evaluation dataset.json --output report.json
+```
+
+The report includes two baseline metrics:
+
+- `field_exact_match`: fraction of expected fields matched after trimming and case normalization.
+- `complete_example_rate`: fraction of examples where every expected field matched.
+
+Fixtures should contain synthetic or explicitly licensed documents and must not
+include production document contents or personal information.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -352,6 +352,11 @@ For a more focused content-finding experience, use the **Search** page accessibl
    - **Content preview** with highlighted matching terms
 5. Use pagination to browse through large result sets
 
+API clients can choose `mode=keyword`, `mode=semantic`, or `mode=hybrid` on
+`GET /api/search`. Hybrid mode combines Meilisearch relevance with cached
+document-embedding similarity. Administrators can request `debug_ranking=true`
+to inspect the keyword and semantic rank components behind each result.
+
 Search results also support bulk actions. Select individual documents on the current page, or use **Select all matching** to select every document returned by the current query and filters across all result pages. You can then reprocess or delete the selection in one action. Reprocessing progress is saved in the browser and restored when you return to or reload the Search page, so a long-running operation is not lost when the page is closed.
 
 ### Saved Searches
@@ -582,6 +587,20 @@ Other step entries, ordering, and enabled flags determine the saved status/retry
 2. Click **New Pipeline** to create a profile, give it a name and optional description.
 3. Expand the profile card and add an OCR setting when you need per-profile OCR behavior.
 4. Mark a profile as **Default** so new documents use it automatically.
+
+Profiles begin as drafts. Publishing validates the enabled steps and saves an
+immutable numbered version. Later edits return the profile to draft without
+changing files already using a saved execution plan. Published versions can be
+restored when a configuration change needs to be rolled back.
+
+### Confidence review
+
+AI metadata includes an extraction confidence score. Documents below
+`CONFIDENCE_REVIEW_THRESHOLD` (70 by default) are queued once for human review.
+The review API lets an authorized user correct metadata, approve or dismiss the
+item, record a note, and prevents an already resolved item from being queued or
+resolved twice. See `docs/ExtractionEvaluation.md` for the CI-friendly quality
+dataset and baseline metrics.
 
 ### Available step types
 

--- a/frontend/templates/pipelines.html
+++ b/frontend/templates/pipelines.html
@@ -208,10 +208,21 @@
               <template x-if="!pipeline.is_active">
                 <span class="text-xs font-semibold text-gray-500 bg-gray-100 border border-gray-200 rounded px-1.5 py-0.5">{{ _("pipelines.inactive_label") }}</span>
               </template>
+              <span class="text-xs font-semibold rounded px-1.5 py-0.5 border"
+                    :class="pipeline.lifecycle_state === 'published' ? 'text-green-700 bg-green-50 border-green-200' : 'text-amber-700 bg-amber-50 border-amber-200'"
+                    x-text="pipeline.lifecycle_state === 'published' ? `Published v${pipeline.published_version}` : 'Draft'"></span>
             </div>
 
             <!-- Actions -->
             <div class="flex items-center gap-2 flex-shrink-0">
+              <button
+                type="button"
+                @click="publishPipeline(pipeline)"
+                class="inline-flex items-center px-3 py-1.5 text-xs font-medium text-green-700 bg-green-50 hover:bg-green-100 rounded-md"
+                style="min-height:36px;"
+              >
+                <i class="fas fa-upload mr-1" aria-hidden="true"></i> Publish
+              </button>
               <button
                 type="button"
                 @click="toggleSteps(pipeline)"
@@ -747,6 +758,19 @@ function pipelinesApp() {
       const r = await fetch(`/api/pipelines/${id}`);
       if (!r.ok) throw new Error(`Pipeline ${id} not found`);
       return r.json();
+    },
+
+    async publishPipeline(pipeline) {
+      try {
+        const r = await fetch(`/api/pipelines/${pipeline.id}/publish`, { method: 'POST' });
+        if (!r.ok) throw new Error((await r.json()).detail || 'Publish failed');
+        const result = await r.json();
+        pipeline.lifecycle_state = result.state;
+        pipeline.published_version = result.version;
+        this.showAlert('success', 'Workflow published', `${pipeline.name} version ${result.version} is active.`);
+      } catch (err) {
+        this.showAlert('error', 'Publish failed', err.message || String(err));
+      }
     },
 
     // ── Helpers ───────────────────────────────────────────────────────────

--- a/migrations/versions/050_pipeline_versions.py
+++ b/migrations/versions/050_pipeline_versions.py
@@ -1,0 +1,36 @@
+"""Add pipeline publishing and immutable versions.
+
+Revision ID: 050_pipeline_versions
+Revises: 049_workflow_bulk_operations
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "050_pipeline_versions"
+down_revision = "049_workflow_bulk_operations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("pipelines", sa.Column("lifecycle_state", sa.String(20), nullable=False, server_default="draft"))
+    op.add_column("pipelines", sa.Column("published_version", sa.Integer(), nullable=True))
+    op.create_table(
+        "pipeline_versions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("pipeline_id", sa.Integer(), sa.ForeignKey("pipelines.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("snapshot", sa.Text(), nullable=False),
+        sa.Column("published_by", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint("pipeline_id", "version", name="uq_pipeline_versions_number"),
+    )
+    op.create_index("ix_pipeline_versions_pipeline_id", "pipeline_versions", ["pipeline_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pipeline_versions_pipeline_id", table_name="pipeline_versions")
+    op.drop_table("pipeline_versions")
+    op.drop_column("pipelines", "published_version")
+    op.drop_column("pipelines", "lifecycle_state")

--- a/migrations/versions/050_pipeline_versions.py
+++ b/migrations/versions/050_pipeline_versions.py
@@ -14,6 +14,8 @@ depends_on = None
 
 
 def upgrade() -> None:
+    if "pipelines" not in sa.inspect(op.get_bind()).get_table_names():
+        return
     op.add_column("pipelines", sa.Column("lifecycle_state", sa.String(20), nullable=False, server_default="draft"))
     op.add_column("pipelines", sa.Column("published_version", sa.Integer(), nullable=True))
     op.create_table(
@@ -30,6 +32,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    if "pipelines" not in sa.inspect(op.get_bind()).get_table_names():
+        return
     op.drop_index("ix_pipeline_versions_pipeline_id", table_name="pipeline_versions")
     op.drop_table("pipeline_versions")
     op.drop_column("pipelines", "published_version")

--- a/tests/test_api_pipelines.py
+++ b/tests/test_api_pipelines.py
@@ -964,3 +964,25 @@ class TestSeedDefaultPipeline:
         default_pipelines = [p for p in r.json() if p["name"] == DEFAULT_PIPELINE_NAME]
         assert len(default_pipelines) == 1
         assert default_pipelines[0]["is_default"] is True
+
+
+class TestPipelinePublishing:
+    def test_publish_versions_and_rollback_restore_steps(self, client, db_session):
+        pipeline = client.post("/api/pipelines", json={"name": "Versioned workflow"}).json()
+        pipeline_id = pipeline["id"]
+        client.post(f"/api/pipelines/{pipeline_id}/steps", json={"step_type": "ocr", "label": "Original OCR"})
+
+        published = client.post(f"/api/pipelines/{pipeline_id}/publish")
+
+        assert published.status_code == 200
+        assert published.json()["version"] == 1
+        versions = client.get(f"/api/pipelines/{pipeline_id}/versions").json()
+        assert versions[0]["is_current"] is True
+
+        pipeline_data = client.get(f"/api/pipelines/{pipeline_id}").json()
+        step_id = pipeline_data["steps"][0]["id"]
+        client.put(f"/api/pipelines/{pipeline_id}/steps/{step_id}", json={"label": "Changed OCR"})
+        restored = client.post(f"/api/pipelines/{pipeline_id}/versions/1/rollback")
+
+        assert restored.status_code == 200
+        assert client.get(f"/api/pipelines/{pipeline_id}").json()["steps"][0]["label"] == "Original OCR"

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -430,3 +430,18 @@ class TestSearchAPIEndpoint:
 
         assert response.status_code == 200
         assert mock_search.call_args[1]["text_quality"] == "high"
+
+    def test_search_endpoint_hybrid_mode_returns_fused_results(self, client):
+        keyword = {"results": [{"file_id": 1, "ranking_score": 0.8}], "total": 1, "page": 1, "pages": 1, "query": "car"}
+        semantic = [{"file_id": 1, "semantic_score": 0.9}, {"file_id": 2, "semantic_score": 0.85}]
+        with (
+            patch("app.api.search.search_documents", return_value=keyword),
+            patch("app.api.search.semantic_candidates", return_value=semantic),
+        ):
+            response = client.get("/api/search?q=car&mode=hybrid&debug_ranking=true")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["mode"] == "hybrid"
+        assert data["results"][0]["file_id"] == 1
+        assert set(data["results"][0]["ranking_components"]) == {"keyword", "semantic"}

--- a/tests/test_extraction_evaluation.py
+++ b/tests/test_extraction_evaluation.py
@@ -1,0 +1,23 @@
+"""Tests for extraction quality metrics."""
+
+from app.utils.extraction_evaluation import evaluate_examples
+
+
+def test_evaluation_reports_field_and_complete_example_metrics():
+    report = evaluate_examples(
+        [
+            {
+                "id": "one",
+                "expected": {"type": "Invoice", "sender": "ACME"},
+                "actual": {"type": "invoice", "sender": "ACME"},
+            },
+            {
+                "id": "two",
+                "expected": {"type": "Contract", "sender": "Beta"},
+                "actual": {"type": "Invoice", "sender": "Beta"},
+            },
+        ]
+    )
+
+    assert report["field_exact_match"] == 0.75
+    assert report["complete_example_rate"] == 0.5

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -1,0 +1,14 @@
+"""Tests for hybrid search ranking."""
+
+from app.utils.hybrid_search import hybrid_rank
+
+
+def test_hybrid_rank_combines_keyword_and_semantic_signals():
+    keyword = [{"file_id": 1, "ranking_score": 0.9}, {"file_id": 2, "ranking_score": 0.8}]
+    semantic = [{"file_id": 2, "semantic_score": 0.95}, {"file_id": 3, "semantic_score": 0.7}]
+
+    ranked = hybrid_rank(keyword, semantic)
+
+    assert ranked[0]["file_id"] == 2
+    assert ranked[0]["ranking_explanation"]["source"] == "hybrid"
+    assert set(ranked[0]["ranking_components"]) == {"keyword", "semantic"}

--- a/tests/test_review_queue_api.py
+++ b/tests/test_review_queue_api.py
@@ -68,3 +68,28 @@ class TestReviewQueueAPI:
         assert data["total"] == 1
         assert data["status"] == "all"
         assert data["items"][0]["status"] == "resolved"
+
+    def test_resolve_review_updates_metadata_and_prevents_second_resolution(self, client: TestClient, db_session):
+        file_record = FileRecord(
+            filehash="review-edit",
+            original_filename="edit.pdf",
+            local_filename="/tmp/edit.pdf",
+            file_size=10,
+            mime_type="application/pdf",
+            ai_metadata='{"sender":"Old"}',
+        )
+        db_session.add(file_record)
+        db_session.commit()
+        item = DocumentReviewItem(file_id=file_record.id, reason="Low confidence", confidence_score=30)
+        db_session.add(item)
+        db_session.commit()
+
+        response = client.post(
+            f"/api/review-queue/{item.id}/resolve", json={"metadata": {"sender": "Correct"}, "note": "Checked"}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "resolved"
+        db_session.refresh(file_record)
+        assert "Correct" in file_record.ai_metadata
+        assert client.post(f"/api/review-queue/{item.id}/resolve", json={}).status_code == 409


### PR DESCRIPTION
## Summary

- add semantic and hybrid document ranking with inspectable score components
- add draft, publish, immutable version, and rollback support for workflow profiles
- add confidence-driven human review resolution and metadata correction
- add a CI-friendly extraction evaluation dataset format and baseline metrics
- add migration `050_pipeline_versions` and align user/API documentation

## Impact

This turns the existing embedding, pipeline editor, confidence, and review foundations into working slices for roadmap tracks 3–5 while keeping the larger external vector-store and full orchestration work explicitly open.

## Validation

- Ruff clean
- 156 focused tests passed
- Alembic reports `050_pipeline_versions` as the single head


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draft/published workflow lifecycle with version history, publishing, and rollback.
  * Added keyword, semantic, and hybrid search modes with optional ranking details.
  * Added human review resolution for low-confidence document extraction results.
  * Added configurable confidence thresholds and automatic review queueing.
  * Added extraction evaluation metrics for field accuracy and complete examples.
* **Documentation**
  * Updated pipeline, search, confidence review, and extraction evaluation guidance.
* **Bug Fixes**
  * Editing a published workflow now correctly returns it to draft status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->