### PR TITLE
fix: escape quotes in comment mentions

### DIFF
--- a/frontend/static/js/comments.js
+++ b/frontend/static/js/comments.js
@@ -202,8 +202,8 @@
 
   function _renderMentions(text) {
     if (!text) return '';
-    // Escape HTML first
-    var escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    // Use the shared sanitizer so quotes are escaped before HTML insertion.
+    var escaped = window.escapeHtml(text);
     // Highlight @mentions
     return escaped.replace(/@([\w.\-]+)/g, '<span class="comment-mention">@$1</span>');
   }

--- a/tests/test_comments_ui.py
+++ b/tests/test_comments_ui.py
@@ -1,5 +1,7 @@
 """Tests for the comments and annotations UI on the file annotations page."""
 
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -27,6 +29,11 @@ def _create_file(db_session, tmp_path) -> FileRecord:
 @pytest.mark.unit
 class TestCommentsUIRendering:
     """Verify the file annotations page includes the comments panel HTML."""
+
+    def test_comments_use_shared_html_escaper_for_mentions(self):
+        """Mention rendering must escape quotes as well as tag delimiters."""
+        source = (Path(__file__).parents[1] / "frontend/static/js/comments.js").read_text()
+        assert "var escaped = window.escapeHtml(text);" in source
 
     def test_annotations_page_contains_comments_section(self, client: TestClient, db_session, tmp_path):
         """The annotations page should render the comments panel container."""


### PR DESCRIPTION
## What changed
- Reuse the shared `window.escapeHtml` sanitizer when rendering comment mentions.
- Add a regression test that prevents reverting to the incomplete local escaper.

## Why
The old local escaping only handled ampersands and angle brackets. Quote characters must also be escaped before insertion into `innerHTML`.

## Validation
- `node --check frontend/static/js/comments.js`
- `python3 -m py_compile tests/test_comments_ui.py`
- targeted source assertion and `git diff --check`
- Full pytest suite will run in GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment mention rendering by consistently escaping HTML-sensitive characters.
  * Helps prevent malformed markup and reduces the risk of unsafe content being inserted into comments.

* **Tests**
  * Added coverage to verify secure mention text handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->