### PR TITLE
Fix Dropbox operator OAuth for user corpus imports

### DIFF
--- a/app/api/integrations.py
+++ b/app/api/integrations.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models import IntegrationDirection, IntegrationType, UserIntegration
+from app.utils.dropbox_credentials import resolve_dropbox_oauth_credentials
 from app.utils.encryption import decrypt_value, encrypt_value
 from app.utils.subscription import get_tier, get_user_tier_id
 from app.utils.user_scope import get_current_owner_id
@@ -555,14 +556,10 @@ def _test_dropbox_connection(config: dict[str, Any] | None, credentials: dict[st
         return {"success": False, "message": "dropbox package is not installed"}  # pragma: no cover
 
     creds = credentials or {}
-    app_key = creds.get("app_key", "")
-    app_secret = creds.get("app_secret", "")
-    refresh_token = creds.get("refresh_token", "")
-
-    if not refresh_token:
-        return {"success": False, "message": "Missing required credential: refresh_token"}
-    if not app_key or not app_secret:
-        return {"success": False, "message": "Missing required credentials: app_key and app_secret"}
+    try:
+        app_key, app_secret, refresh_token = resolve_dropbox_oauth_credentials(creds)
+    except ValueError as exc:
+        return {"success": False, "message": str(exc)}
 
     try:
         dbx = dbx_lib.Dropbox(

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -11,6 +11,7 @@ from app.database import SessionLocal
 from app.models import DocumentIntake, DropboxImportJob, DropboxImportObject, UserIntegration
 from app.tasks.retry_config import BaseTaskWithRetry
 from app.utils.allowed_types import ALLOWED_EXTENSIONS
+from app.utils.dropbox_credentials import resolve_dropbox_oauth_credentials
 from app.utils.encryption import decrypt_value
 from app.utils.filename_utils import sanitize_filename
 
@@ -32,13 +33,14 @@ def _dropbox_client(integration: UserIntegration):
     import dropbox
 
     credentials = _decode(integration.credentials)
-    required = ("refresh_token", "app_key", "app_secret")
-    if not all(credentials.get(key) for key in required):
-        raise RuntimeError("Dropbox source credentials are incomplete")
+    try:
+        app_key, app_secret, refresh_token = resolve_dropbox_oauth_credentials(credentials)
+    except ValueError as exc:
+        raise RuntimeError("Dropbox source credentials are incomplete") from exc
     return dropbox.Dropbox(
-        oauth2_refresh_token=credentials["refresh_token"],
-        app_key=credentials["app_key"],
-        app_secret=credentials["app_secret"],
+        oauth2_refresh_token=refresh_token,
+        app_key=app_key,
+        app_secret=app_secret,
     )
 
 

--- a/app/tasks/upload_to_user_integration.py
+++ b/app/tasks/upload_to_user_integration.py
@@ -63,6 +63,7 @@ from app.config import settings
 from app.database import SessionLocal
 from app.models import IntegrationType, UserIntegration
 from app.tasks.retry_config import UploadTaskWithRetry
+from app.utils.dropbox_credentials import resolve_dropbox_oauth_credentials
 from app.utils.encryption import decrypt_value
 from app.utils.logging import log_task_progress
 
@@ -81,12 +82,7 @@ def _upload_dropbox(file_path: str, cfg: dict[str, Any], creds: dict[str, Any], 
     """Upload *file_path* to Dropbox using per-user OAuth credentials."""
     import dropbox
 
-    app_key = creds.get("app_key") or ""
-    app_secret = creds.get("app_secret") or ""
-    refresh_token = creds.get("refresh_token") or ""
-
-    if not (app_key and app_secret and refresh_token):
-        raise ValueError("Dropbox integration is missing app_key, app_secret or refresh_token in credentials")
+    app_key, app_secret, refresh_token = resolve_dropbox_oauth_credentials(creds)
 
     dbx = dropbox.Dropbox(app_key=app_key, app_secret=app_secret, oauth2_refresh_token=refresh_token)
 

--- a/app/utils/dropbox_credentials.py
+++ b/app/utils/dropbox_credentials.py
@@ -1,0 +1,33 @@
+"""Resolve Dropbox OAuth credentials without copying operator secrets to users."""
+
+from typing import Any
+
+from app.config import settings
+
+
+def resolve_dropbox_oauth_credentials(credentials: dict[str, Any]) -> tuple[str, str, str]:
+    """Return ``(app_key, app_secret, refresh_token)`` for a user integration.
+
+    Personal OAuth grants may reference the operator-managed Dropbox application.
+    In that mode only the refresh token is stored in the encrypted user record;
+    the application credentials remain in the operator configuration.
+    """
+    uses_operator_app = bool(credentials.get("use_global_app_secret")) or credentials.get("auth_mode") == "operator"
+    refresh_token = str(credentials.get("refresh_token") or "")
+    if not refresh_token:
+        if uses_operator_app:
+            raise ValueError("Dropbox integration is missing refresh_token in credentials")
+        raise ValueError("Dropbox integration is missing app_key, app_secret or refresh_token in credentials")
+
+    if uses_operator_app:
+        if not settings.dropbox_allow_global_credentials_for_integrations:
+            raise ValueError("Dropbox operator application credentials are not enabled for user integrations")
+        app_key = settings.dropbox_app_key or ""
+        app_secret = settings.dropbox_app_secret or ""
+    else:
+        app_key = str(credentials.get("app_key") or "")
+        app_secret = str(credentials.get("app_secret") or "")
+
+    if not app_key or not app_secret:
+        raise ValueError("Dropbox integration is missing app_key or app_secret in application credentials")
+    return app_key, app_secret, refresh_token

--- a/docs/DropboxSetup.md
+++ b/docs/DropboxSetup.md
@@ -8,8 +8,9 @@ This guide explains how to set up the Dropbox integration for DocuElevate.
 |-------------------------|--------------------------------------------------|
 | `DROPBOX_APP_KEY`       | Dropbox API app key                              |
 | `DROPBOX_APP_SECRET`    | Dropbox API app secret                           |
-| `DROPBOX_REFRESH_TOKEN` | OAuth2 refresh token for Dropbox                 |
+| `DROPBOX_REFRESH_TOKEN` | Optional OAuth2 grant for the system-level connection |
 | `DROPBOX_FOLDER`        | Default folder path for Dropbox uploads          |
+| `DROPBOX_ALLOW_GLOBAL_CREDENTIALS_FOR_INTEGRATIONS` | Let users authorize against the operator-managed Dropbox app |
 
 For a complete list of configuration options, see the [Configuration Guide](ConfigurationGuide.md).
 
@@ -28,12 +29,12 @@ End users authorize their own Dropbox integration from the **Integrations** dash
 1. Navigate to `/integrations` and click **+ Add Destination** (or **+ Add Source** for Watch Folder).
 2. Create a Dropbox destination integration (or a Watch Folder with `source_type = dropbox`).
 3. Click the **Authorize** button next to the integration — it links directly to the OAuth wizard pre-loaded with your integration's configuration.
-4. If the administrator has configured system-wide Dropbox app credentials (`DROPBOX_APP_KEY` / `DROPBOX_APP_SECRET`), the wizard defaults to using them — no need to register your own Dropbox app. Uncheck the toggle to use custom credentials if needed.
+4. If the administrator has configured system-wide Dropbox app credentials (`DROPBOX_APP_KEY` / `DROPBOX_APP_SECRET`) and enabled `DROPBOX_ALLOW_GLOBAL_CREDENTIALS_FOR_INTEGRATIONS`, the wizard uses that app — no need to register a Dropbox app per user.
 5. Click **Start Authentication Flow**, authorize access in Dropbox, and the refresh token is automatically saved to your personal integration record.
 6. After authorization, an interactive **folder browser** lets you select the target folder directly from your Dropbox — no need to manually type folder paths.
 7. The page redirects to `/integrations` on success. Re-authorization is available at any time via the **Re-Authorize** button.
 
-> **Note:** Your credentials are stored encrypted per-integration and are never mixed with other users' data. Each user can have multiple Dropbox integrations with independent tokens.
+> **Note:** The renewable user grant is stored encrypted per integration. In shared-app mode, the operator App Key and App Secret remain in operator configuration and are not copied into the user's database record. Workers resolve both parts at execution time, so authorization changes do not require a restart.
 
 ## Using the System-Level Setup Wizard (Admin)
 

--- a/frontend/templates/dropbox_callback.html
+++ b/frontend/templates/dropbox_callback.html
@@ -187,9 +187,8 @@ document.addEventListener('DOMContentLoaded', function() {
         if (integrationId) {
           const creds = {
             refresh_token: data.refresh_token,
-            // Store public app_key with the integration (no secret stored browser-side)
-            app_key: resolvedAppKey,
-            // Flag so the backend knows to use global app_secret for future operations
+            // The user's encrypted record contains only their renewable grant.
+            // Operator app credentials remain outside the user record.
             use_global_app_secret: true,
           };
 

--- a/tests/test_dropbox_operator_credentials.py
+++ b/tests/test_dropbox_operator_credentials.py
@@ -1,0 +1,56 @@
+"""Dropbox user grants can reuse operator app credentials without copying secrets."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.utils.dropbox_credentials import resolve_dropbox_oauth_credentials
+
+
+def test_resolves_operator_app_credentials(monkeypatch):
+    monkeypatch.setattr(
+        "app.utils.dropbox_credentials.settings.dropbox_allow_global_credentials_for_integrations", True
+    )
+    monkeypatch.setattr("app.utils.dropbox_credentials.settings.dropbox_app_key", "operator-key")
+    monkeypatch.setattr("app.utils.dropbox_credentials.settings.dropbox_app_secret", "operator-secret")
+
+    resolved = resolve_dropbox_oauth_credentials({"refresh_token": "user-grant", "use_global_app_secret": True})
+
+    assert resolved == ("operator-key", "operator-secret", "user-grant")
+
+
+def test_rejects_operator_mode_when_disabled(monkeypatch):
+    monkeypatch.setattr(
+        "app.utils.dropbox_credentials.settings.dropbox_allow_global_credentials_for_integrations", False
+    )
+
+    with pytest.raises(ValueError, match="not enabled"):
+        resolve_dropbox_oauth_credentials({"refresh_token": "user-grant", "use_global_app_secret": True})
+
+
+def test_corpus_client_uses_operator_app_credentials(monkeypatch):
+    monkeypatch.setattr(
+        "app.utils.dropbox_credentials.settings.dropbox_allow_global_credentials_for_integrations", True
+    )
+    monkeypatch.setattr("app.utils.dropbox_credentials.settings.dropbox_app_key", "operator-key")
+    monkeypatch.setattr("app.utils.dropbox_credentials.settings.dropbox_app_secret", "operator-secret")
+    integration = SimpleNamespace(credentials="encrypted")
+    client = MagicMock()
+
+    with (
+        patch(
+            "app.tasks.dropbox_corpus_import._decode",
+            return_value={"refresh_token": "grant", "use_global_app_secret": True},
+        ),
+        patch("dropbox.Dropbox", return_value=client) as dropbox_client,
+    ):
+        from app.tasks.dropbox_corpus_import import _dropbox_client
+
+        assert _dropbox_client(integration) is client
+
+    dropbox_client.assert_called_once_with(
+        oauth2_refresh_token="grant",
+        app_key="operator-key",
+        app_secret="operator-secret",
+    )


### PR DESCRIPTION
## Summary
- keep Dropbox operator app credentials out of encrypted user integration records
- resolve operator credentials at API/worker execution time for tests, uploads, and corpus imports
- document renewable per-user grants and no-restart behavior

## Validation
- 97 targeted tests passed
- Ruff passed
- git diff --check passed

## Deployment boundary
DocuElevate preprod only. Production remains pinned to the legacy release.