### PR TITLE
Add Qdrant destination and Dropbox Watch Folder true-up

### DIFF
--- a/app/api/dropbox.py
+++ b/app/api/dropbox.py
@@ -395,6 +395,76 @@ async def list_dropbox_folders(
         )
 
 
+@router.post("/dropbox/create-folder")
+@require_login
+async def create_dropbox_folder(
+    request: Request,
+    access_token: Annotated[str, Form(...)],
+    parent_path: Annotated[str, Form()] = "",
+    name: Annotated[str, Form()] = "",
+):
+    """Create a Dropbox folder below the currently browsed parent path."""
+    folder_name = name.strip()
+    if not folder_name or folder_name in {".", ".."} or any(char in folder_name for char in ("/", "\\", "\x00")):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Folder name must not be empty or contain path separators",
+        )
+
+    parent = parent_path.strip().rstrip("/")
+    if parent == "/":
+        parent = ""
+    elif parent and not parent.startswith("/"):
+        parent = f"/{parent}"
+    path = f"{parent}/{folder_name}"
+
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+    payload = {"path": path, "autorename": False}
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://api.dropboxapi.com/2/files/create_folder_v2",
+                headers=headers,
+                json=payload,
+                timeout=settings.http_request_timeout,
+            )
+        if response.status_code == 401:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Access token is invalid or expired. Please re-authorize.",
+            )
+        if response.status_code == 409:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A folder with this name already exists at the selected location",
+            )
+        if response.status_code != 200:
+            logger.warning("Dropbox create_folder failed with status %s", response.status_code)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Dropbox could not create the folder",
+            )
+
+        metadata = response.json().get("metadata", {})
+        return {
+            "name": metadata.get("name", folder_name),
+            "path": metadata.get("path_display", path),
+            "id": metadata.get("id", ""),
+        }
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Error creating Dropbox folder: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create Dropbox folder",
+        ) from exc
+
+
 @router.post("/dropbox/save-settings")
 async def save_dropbox_settings(
     request: Request,

--- a/app/api/integrations.py
+++ b/app/api/integrations.py
@@ -681,6 +681,28 @@ def _test_google_drive_connection(config: dict[str, Any] | None, credentials: di
         return {"success": False, "message": "Google Drive connection failed — re-authorize the integration"}
 
 
+def _test_vector_database_connection(
+    config: dict[str, Any] | None, credentials: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Test the operator-managed Qdrant destination without exposing credentials."""
+    from app.config import settings
+
+    provider = str((config or {}).get("provider") or "qdrant").lower()
+    if provider != "qdrant":
+        return {"success": False, "message": f"Unsupported vector database provider: {provider}"}
+    if not settings.vector_index_enabled:
+        return {"success": False, "message": "Vector indexing is disabled by the operator"}
+    try:
+        from app.utils.vector_index import QdrantVectorIndex
+
+        status_result = QdrantVectorIndex().status()
+        collection = status_result.get("collection") or settings.vector_index_collection
+        return {"success": True, "message": f"Qdrant collection '{collection}' is ready"}
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Qdrant destination test failed: %s", exc)
+        return {"success": False, "message": "Qdrant connection failed — check operator configuration"}
+
+
 _CONNECTION_TESTERS: dict[str, Any] = {
     IntegrationType.DROPBOX: _test_dropbox_connection,
     IntegrationType.IMAP: _test_imap_connection,
@@ -688,6 +710,7 @@ _CONNECTION_TESTERS: dict[str, Any] = {
     IntegrationType.GOOGLE_DRIVE: _test_google_drive_connection,
     IntegrationType.WEBDAV: _test_webdav_connection,
     IntegrationType.NEXTCLOUD: _test_webdav_connection,
+    IntegrationType.VECTOR_DATABASE: _test_vector_database_connection,
 }
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -781,6 +781,7 @@ class IntegrationType:
     RCLONE = "RCLONE"
     SHAREPOINT = "SHAREPOINT"
     ICLOUD = "ICLOUD"
+    VECTOR_DATABASE = "VECTOR_DATABASE"
 
     ALL = {
         IMAP,
@@ -799,6 +800,7 @@ class IntegrationType:
         RCLONE,
         SHAREPOINT,
         ICLOUD,
+        VECTOR_DATABASE,
     }
 
 
@@ -884,6 +886,10 @@ class UserIntegration(Base):
     GOOGLE_DRIVE:
       config      = {"folder_id": "1abc…"}
       credentials = {"credentials_json": "{…service-account or OAuth…}"}
+
+    VECTOR_DATABASE:
+      config      = {"provider": "qdrant"}
+      credentials = null  # operator-managed Qdrant connection
 
     WEBDAV / NEXTCLOUD:
       config      = {"url": "https://cloud.example.com/dav/",

--- a/app/tasks/compute_embedding.py
+++ b/app/tasks/compute_embedding.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from app.celery_app import celery
 from app.config import settings
 from app.database import SessionLocal
-from app.models import FileRecord
+from app.models import FileRecord, IntegrationDirection, IntegrationType, UserIntegration
 from app.tasks.retry_config import BaseTaskWithRetry
 from app.utils import log_task_progress
 from app.utils.step_manager import update_step_status
@@ -22,6 +22,25 @@ logger = logging.getLogger(__name__)
 def _queue_vector_index(file_id: int) -> None:
     if not settings.vector_index_enabled:
         return
+    # When a user configured Qdrant as a destination, that destination owns
+    # indexing and its visible processing status. Keep the legacy automatic
+    # index path only as a backwards-compatible fallback.
+    with SessionLocal() as db:
+        record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+        if record and record.owner_id:
+            has_vector_destination = (
+                db.query(UserIntegration.id)
+                .filter(
+                    UserIntegration.owner_id == record.owner_id,
+                    UserIntegration.direction == IntegrationDirection.DESTINATION,
+                    UserIntegration.integration_type == IntegrationType.VECTOR_DATABASE,
+                    UserIntegration.is_active.is_(True),
+                )
+                .first()
+                is not None
+            )
+            if has_vector_destination:
+                return
     from app.tasks.vector_index import index_document_vectors
 
     index_document_vectors.delay(file_id)

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -18,6 +18,64 @@ from app.utils.filename_utils import sanitize_filename
 logger = logging.getLogger(__name__)
 
 
+def queue_dropbox_watch_sync(integration_id: int, db_session=None) -> dict:
+    """Queue the initial true-up or the next cursor-based delta for a watch source."""
+    owns_session = db_session is None
+    db = db_session or SessionLocal()
+    try:
+        integration = db.query(UserIntegration).filter(UserIntegration.id == integration_id).first()
+        if not integration or not integration.is_active:
+            return {"status": "skipped", "detail": "Dropbox watch integration is inactive"}
+        try:
+            config = json.loads(integration.config or "{}")
+        except (json.JSONDecodeError, TypeError):
+            return {"status": "skipped", "detail": "Integration configuration is invalid"}
+        if config.get("source_type") != "dropbox" or not config.get("true_up_existing"):
+            return {"status": "skipped", "detail": "Dropbox true-up is disabled"}
+
+        active = (
+            db.query(DropboxImportJob)
+            .filter(
+                DropboxImportJob.integration_id == integration.id,
+                DropboxImportJob.state.in_(("queued", "running")),
+            )
+            .first()
+        )
+        if active:
+            return {"status": "running", "job_id": active.id}
+
+        root_path = str(config.get("folder_path") or "")
+        previous = (
+            db.query(DropboxImportJob)
+            .filter(
+                DropboxImportJob.integration_id == integration.id,
+                DropboxImportJob.root_path == root_path,
+                DropboxImportJob.state == "completed",
+            )
+            .order_by(DropboxImportJob.created_at.desc())
+            .first()
+        )
+        job = DropboxImportJob(
+            id=str(uuid.uuid4()),
+            integration_id=integration.id,
+            owner_id=integration.owner_id,
+            root_path=root_path,
+            # A completed recursive listing cursor becomes an incremental
+            # Dropbox change cursor for the next watch cycle.
+            cursor=previous.cursor if previous else None,
+        )
+        db.add(job)
+        db.commit()
+        job_id = job.id
+        mode = "incremental" if job.cursor else "true-up"
+    finally:
+        if owns_session:
+            db.close()
+
+    run_dropbox_corpus_import.delay(job_id)
+    return {"status": "queued", "job_id": job_id, "mode": mode}
+
+
 def _decode(stored: str | None) -> dict:
     if not stored:
         return {}

--- a/app/tasks/upload_to_user_integration.py
+++ b/app/tasks/upload_to_user_integration.py
@@ -708,6 +708,42 @@ def _upload_icloud(file_path: str, cfg: dict[str, Any], creds: dict[str, Any], t
     return {"status": "Completed", "icloud_folder": folder or "/"}
 
 
+def _upload_vector_database(
+    file_path: str,
+    cfg: dict[str, Any],
+    creds: dict[str, Any],
+    task_id: str,
+    *,
+    file_id: int | None,
+) -> dict[str, Any]:
+    """Index one processed document in the operator-managed Qdrant collection."""
+    provider = str(cfg.get("provider") or "qdrant").lower()
+    if provider != "qdrant":
+        raise ValueError(f"Unsupported vector database provider: {provider}")
+    if not settings.vector_index_enabled:
+        raise ValueError("Vector indexing is disabled by the operator")
+    if file_id is None:
+        raise ValueError("Vector database destination requires a file_id")
+
+    from app.models import FileRecord
+    from app.utils.vector_index import QdrantVectorIndex
+
+    with SessionLocal() as db:
+        record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+        if record is None:
+            raise ValueError(f"FileRecord {file_id} not found")
+        count = QdrantVectorIndex().index_document(record)
+
+    logger.info("[%s] Indexed %d Qdrant chunks for file %s", task_id, count, file_id)
+    return {
+        "status": "Completed",
+        "provider": "qdrant",
+        "collection": settings.vector_index_collection,
+        "file_id": file_id,
+        "chunks_indexed": count,
+    }
+
+
 # Map IntegrationType → upload helper
 _UPLOAD_HANDLERS = {
     IntegrationType.DROPBOX: _upload_dropbox,
@@ -723,6 +759,7 @@ _UPLOAD_HANDLERS = {
     IntegrationType.RCLONE: _upload_rclone,
     IntegrationType.SHAREPOINT: _upload_sharepoint,
     IntegrationType.ICLOUD: _upload_icloud,
+    IntegrationType.VECTOR_DATABASE: _upload_vector_database,
 }
 
 
@@ -819,7 +856,10 @@ def upload_to_user_integration(self, file_path: str, integration_id: int, file_i
     )
 
     try:
-        result = handler(file_path, cfg, creds, task_id)
+        if itype == IntegrationType.VECTOR_DATABASE:
+            result = handler(file_path, cfg, creds, task_id, file_id=file_id)
+        else:
+            result = handler(file_path, cfg, creds, task_id)
 
         # Update last_used_at on success
         with SessionLocal() as db:

--- a/app/tasks/watch_folder_tasks.py
+++ b/app/tasks/watch_folder_tasks.py
@@ -2173,6 +2173,15 @@ _USER_WF_CLOUD_HANDLERS.update(
 )
 
 
+def _watch_source_delete_enabled(config: dict) -> bool:
+    """Require an explicit two-step opt-in before deleting source files.
+
+    Missing ``preserve_source_files`` is treated as protected so older or
+    hand-written integrations fail closed after this safety feature ships.
+    """
+    return config.get("preserve_source_files", True) is False and config.get("delete_after_process", False) is True
+
+
 def _pull_user_integration_watch_folders() -> dict:
     """Iterate over all active WATCH_FOLDER UserIntegrations and scan their sources.
 
@@ -2214,7 +2223,7 @@ def _pull_user_integration_watch_folders() -> dict:
             for integ in integrations:
                 try:
                     cfg = _json.loads(integ.config) if integ.config else {}
-                    delete_after = cfg.get("delete_after_process", False)
+                    delete_after = _watch_source_delete_enabled(cfg)
                     source_type = cfg.get("source_type", "local")
 
                     cache_file = f"{_USER_WF_CACHE_PREFIX}{integ.id}.json"

--- a/app/tasks/watch_folder_tasks.py
+++ b/app/tasks/watch_folder_tasks.py
@@ -1571,10 +1571,11 @@ def _scan_user_dropbox_folder(
         logger.error("User Dropbox watch folder: dropbox SDK not installed: %s", exc)
         return 0
 
-    refresh_token = creds.get("refresh_token", "")
-    app_key = creds.get("app_key", "")
-    app_secret = creds.get("app_secret", "")
-    if not (refresh_token and app_key and app_secret):
+    from app.utils.dropbox_credentials import resolve_dropbox_oauth_credentials
+
+    try:
+        app_key, app_secret, refresh_token = resolve_dropbox_oauth_credentials(creds)
+    except ValueError:
         logger.warning("User Dropbox watch folder: credentials incomplete.")
         return 0
 
@@ -1595,7 +1596,7 @@ def _scan_user_dropbox_folder(
 
     count = 0
     try:
-        result = dbx.files_list_folder(folder_path)
+        result = dbx.files_list_folder(folder_path, recursive=bool(cfg.get("recursive", False)))
         entries = list(result.entries)
         while result.has_more:
             result = dbx.files_list_folder_continue(result.cursor)
@@ -2243,6 +2244,14 @@ def _pull_user_integration_watch_folders() -> dict:
                             continue
 
                         n = _scan_user_watch_folder(folder_path, cache, delete_after, integ.owner_id)
+                    elif source_type == "dropbox" and cfg.get("true_up_existing"):
+                        # The durable corpus importer performs the initial
+                        # recursive true-up and then reuses Dropbox's cursor
+                        # for cheap incremental watch cycles.
+                        from app.tasks.dropbox_corpus_import import queue_dropbox_watch_sync
+
+                        queue_dropbox_watch_sync(integ.id, db)
+                        n = 0
                     elif source_type in _USER_WF_CLOUD_HANDLERS:
                         # Cloud source — decrypt per-user credentials and delegate
                         raw_creds = decrypt_value(integ.credentials) if integ.credentials else None

--- a/docs/API.md
+++ b/docs/API.md
@@ -179,6 +179,15 @@ curl -X POST "https://<preprod-host>/api/dropbox-imports/" \
 Poll `GET /api/dropbox-imports/{job_id}` for `discovered`, `downloaded`, `queued`,
 `skipped`, `failed`, and checkpoint state.
 
+The regular integration model can drive the same process. Create a `WATCH_FOLDER`
+source with `source_type: "dropbox"`, `folder_path`, `recursive: true`, and
+`true_up_existing: true`. The first watch cycle queues a durable recursive true-up;
+later cycles reuse the completed Dropbox cursor and fetch only changes.
+
+Qdrant is available as the `VECTOR_DATABASE` destination type. It uses the
+operator-managed vector-index connection, so the user integration needs only
+`{"provider":"qdrant"}` and no credentials.
+
 #### Source-backed semantic retrieval
 
 Vector retrieval is available only when `VECTOR_INDEX_ENABLED=true`. Qdrant results

--- a/docs/DearConciergeKnowledgeBridge.md
+++ b/docs/DearConciergeKnowledgeBridge.md
@@ -29,6 +29,13 @@ a derived index that can be deleted and rebuilt. Search results are never truste
 authorization: document IDs returned by Qdrant are checked against the relational
 owner/share model before any text is returned.
 
+Qdrant is configured as a normal `VECTOR_DATABASE` destination on the user's
+integration dashboard. The connection remains operator-managed, while destination
+selection, processing status, retries, and errors follow the same per-user flow as
+Google Drive or Dropbox. A Dropbox corpus is represented by a `WATCH_FOLDER` source
+with `true_up_existing=true`; the initial recursive import includes subfolders and
+subsequent polls continue from Dropbox's change cursor.
+
 ## Delivery slices and acceptance criteria
 
 ### KB-1: Authenticated preprod intake

--- a/docs/DropboxSetup.md
+++ b/docs/DropboxSetup.md
@@ -34,6 +34,12 @@ End users authorize their own Dropbox integration from the **Integrations** dash
 6. After authorization, an interactive **folder browser** lets you select the target folder directly from your Dropbox — no need to manually type folder paths.
 7. The page redirects to `/integrations` on success. Re-authorization is available at any time via the **Re-Authorize** button.
 
+For an existing archive, enable **True up existing corpus** on the Dropbox-backed
+Watch Folder. DocuElevate performs one recursive import of the selected folder and
+all subfolders, records Dropbox file IDs and revisions, then reuses Dropbox's change
+cursor for later watch cycles. Sources are never deleted unless
+`delete_after_process` is explicitly enabled.
+
 > **Note:** The renewable user grant is stored encrypted per integration. In shared-app mode, the operator App Key and App Secret remain in operator configuration and are not copied into the user's database record. Workers resolve both parts at execution time, so authorization changes do not require a restart.
 
 ## Using the System-Level Setup Wizard (Admin)

--- a/docs/DropboxSetup.md
+++ b/docs/DropboxSetup.md
@@ -26,19 +26,21 @@ DocuElevate supports two distinct Dropbox OAuth flows:
 
 End users authorize their own Dropbox integration from the **Integrations** dashboard:
 
-1. Navigate to `/integrations` and click **+ Add Destination** (or **+ Add Source** for Watch Folder).
-2. Create a Dropbox destination integration (or a Watch Folder with `source_type = dropbox`).
-3. Click the **Authorize** button next to the integration — it links directly to the OAuth wizard pre-loaded with your integration's configuration.
+1. Navigate to `/integrations` and add a Dropbox destination (or a Watch Folder with `source_type = dropbox`).
+2. Enter the non-secret integration settings and choose **Save & connect Dropbox**.
 4. If the administrator has configured system-wide Dropbox app credentials (`DROPBOX_APP_KEY` / `DROPBOX_APP_SECRET`) and enabled `DROPBOX_ALLOW_GLOBAL_CREDENTIALS_FOR_INTEGRATIONS`, the wizard uses that app — no need to register a Dropbox app per user.
-5. Click **Start Authentication Flow**, authorize access in Dropbox, and the refresh token is automatically saved to your personal integration record.
-6. After authorization, an interactive **folder browser** lets you select the target folder directly from your Dropbox — no need to manually type folder paths.
-7. The page redirects to `/integrations` on success. Re-authorization is available at any time via the **Re-Authorize** button.
+5. Authorize access in Dropbox; the refresh token is automatically saved to your personal integration record.
+6. Use the interactive **folder browser** to navigate through any subpath and select the source or target folder. You can create a new folder in the currently open location and select it immediately; no path memorization is required.
+7. Save the folder selection to return to `/integrations`. Re-authorization remains available via **Re-Authorize**.
 
 For an existing archive, enable **True up existing corpus** on the Dropbox-backed
 Watch Folder. DocuElevate performs one recursive import of the selected folder and
 all subfolders, records Dropbox file IDs and revisions, then reuses Dropbox's change
-cursor for later watch cycles. Sources are never deleted unless
-`delete_after_process` is explicitly enabled.
+cursor for later watch cycles. Watch Folder sources fail closed: source deletion is
+possible only when `preserve_source_files=false` **and**
+`delete_after_process=true`. Missing `preserve_source_files` is treated as protected.
+The UI defaults to **Quelldateien NICHT LÖSCHEN!** and shows a prominent red alarm
+on every source card where deletion is actually enabled.
 
 > **Note:** The renewable user grant is stored encrypted per integration. In shared-app mode, the operator App Key and App Secret remain in operator configuration and are not copied into the user's database record. Workers resolve both parts at execution time, so authorization changes do not require a restart.
 

--- a/frontend/templates/dropbox_callback.html
+++ b/frontend/templates/dropbox_callback.html
@@ -74,6 +74,16 @@
           <div id="folder-breadcrumb" class="flex items-center text-sm text-gray-500 mb-2">
             <button type="button" class="folder-nav-btn text-indigo-600 hover:text-indigo-800 font-medium" data-path="" aria-label="Navigate to root folder">/ Root</button>
           </div>
+          <button id="new-folder-btn" type="button" class="inline-flex items-center px-3 py-2 text-sm font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            <span class="mr-1" aria-hidden="true">+</span> New folder here
+          </button>
+          <div id="new-folder-form" class="hidden mt-2 flex items-center gap-2">
+            <label for="new-folder-name" class="sr-only">New folder name</label>
+            <input id="new-folder-name" type="text" class="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm" placeholder="Folder name" maxlength="255" />
+            <button id="create-folder-btn" type="button" class="px-3 py-2 text-sm font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-700">Create</button>
+            <button id="cancel-folder-btn" type="button" class="px-3 py-2 text-sm font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50">Cancel</button>
+          </div>
+          <p id="new-folder-status" class="hidden mt-2 text-sm" aria-live="polite"></p>
         </div>
 
         <div id="folder-list" class="border border-gray-200 rounded-md max-h-64 overflow-y-auto">
@@ -93,7 +103,7 @@
         <p id="folder-save-status" class="mt-2 text-sm hidden" aria-live="polite"></p>
       </div>
 
-      <div class="mt-6 p-4 bg-gray-100 rounded-md">
+      <div id="worker-config-block" class="mt-6 p-4 bg-gray-100 rounded-md">
         <h3 class="font-medium text-lg mb-2">Configuration for Worker Nodes</h3>
         <p class="text-sm text-gray-600 mb-3">
           Copy these environment variables to configure all worker nodes:
@@ -113,7 +123,7 @@
       </div>
 
       <div class="mt-4 text-center">
-        <a href="/status" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+        <a id="oauth-return-link" href="/status" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
           Go to Status Page
         </a>
       </div>
@@ -209,15 +219,19 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             return response.json();
           }).then(() => {
-            // Clean up
+            // The renewable user grant is saved. Keep the short-lived access
+            // token only in this callback page so the user can browse folders.
             sessionStorage.removeItem('dropbox_use_global_creds');
             sessionStorage.removeItem('oauth_integration_id');
 
-            document.getElementById('processing-message').innerHTML =
-              '<p class="text-green-600 font-semibold">✓ Dropbox authorized successfully!</p>' +
-              '<p class="text-sm text-gray-500 mt-2">Redirecting to Integrations…</p>';
+            document.getElementById('processing-message').classList.add('hidden');
             document.querySelector('.animate-spin').parentNode.classList.add('hidden');
-            setTimeout(() => { window.location.href = '/integrations'; }, 2000);
+            document.getElementById('success-container').classList.remove('hidden');
+            document.getElementById('worker-config-block').classList.add('hidden');
+            const returnLink = document.getElementById('oauth-return-link');
+            returnLink.href = '/integrations';
+            returnLink.textContent = 'Back to Integrations';
+            initFolderBrowser(data.access_token, integrationId);
           });
         }
         // Global admin flow — the exchange-token-global endpoint is intended for
@@ -299,6 +313,10 @@ document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('processing-message').innerHTML =
               '<p class="text-green-600 font-semibold">✓ Dropbox authorized successfully!</p>';
             document.getElementById('success-container').classList.remove('hidden');
+            document.getElementById('worker-config-block').classList.add('hidden');
+            const returnLink = document.getElementById('oauth-return-link');
+            returnLink.href = '/integrations';
+            returnLink.textContent = 'Back to Integrations';
 
             // Show folder browser with the access token
             initFolderBrowser(data.access_token, integrationId);
@@ -411,6 +429,12 @@ DROPBOX_FOLDER=${folderPath || '/Documents/Uploads'}`;
     const selectedInput = document.getElementById('selected-folder-path');
     const saveBtn = document.getElementById('save-folder-btn');
     const saveStatus = document.getElementById('folder-save-status');
+    const newFolderBtn = document.getElementById('new-folder-btn');
+    const newFolderForm = document.getElementById('new-folder-form');
+    const newFolderName = document.getElementById('new-folder-name');
+    const createFolderBtn = document.getElementById('create-folder-btn');
+    const cancelFolderBtn = document.getElementById('cancel-folder-btn');
+    const newFolderStatus = document.getElementById('new-folder-status');
 
     function loadFolders(path) {
       currentPath = path;
@@ -466,6 +490,50 @@ DROPBOX_FOLDER=${folderPath || '/Documents/Uploads'}`;
         });
       });
     }
+
+    newFolderBtn.addEventListener('click', () => {
+      newFolderForm.classList.remove('hidden');
+      newFolderStatus.classList.add('hidden');
+      newFolderName.value = '';
+      newFolderName.focus();
+    });
+
+    cancelFolderBtn.addEventListener('click', () => {
+      newFolderForm.classList.add('hidden');
+      newFolderStatus.classList.add('hidden');
+    });
+
+    createFolderBtn.addEventListener('click', () => {
+      const name = newFolderName.value.trim();
+      if (!name) {
+        newFolderStatus.textContent = 'Enter a folder name.';
+        newFolderStatus.className = 'mt-2 text-sm text-red-600';
+        return;
+      }
+      createFolderBtn.disabled = true;
+      createFolderBtn.textContent = 'Creating…';
+      const formData = new FormData();
+      formData.append('access_token', accessToken);
+      formData.append('parent_path', currentPath);
+      formData.append('name', name);
+      fetch('/api/dropbox/create-folder', { method: 'POST', body: formData })
+        .then(r => r.ok ? r.json() : r.json().then(err => { throw new Error(err.detail || 'Failed to create folder'); }))
+        .then(data => {
+          selectedInput.value = data.path;
+          newFolderForm.classList.add('hidden');
+          newFolderStatus.textContent = `✓ Created ${data.path}`;
+          newFolderStatus.className = 'mt-2 text-sm text-green-600';
+          loadFolders(data.path);
+        })
+        .catch(err => {
+          newFolderStatus.textContent = 'Error: ' + err.message;
+          newFolderStatus.className = 'mt-2 text-sm text-red-600';
+        })
+        .finally(() => {
+          createFolderBtn.disabled = false;
+          createFolderBtn.textContent = 'Create';
+        });
+    });
 
     // Save selected folder to integration config
     saveBtn.addEventListener('click', () => {

--- a/frontend/templates/integrations_dashboard.html
+++ b/frontend/templates/integrations_dashboard.html
@@ -1251,7 +1251,7 @@ function integrationsDashboard() {
         this.form.config = { source_type: st, bucket: '', region: 'us-east-1', prefix: '', endpoint_url: '', delete_after_process: dap };
         this.form.credentials = { access_key_id: '', secret_access_key: '' };
       } else if (st === 'dropbox') {
-        this.form.config = { source_type: st, folder_path: '/Posteingang', delete_after_process: dap, true_up_existing: true, recursive: true };
+        this.form.config = { source_type: st, folder_path: '', delete_after_process: dap, true_up_existing: false, recursive: true };
         this.form.credentials = {};
       } else if (st === 'google_drive') {
         this.form.config = { source_type: st, folder_id: '', delete_after_process: dap };

--- a/frontend/templates/integrations_dashboard.html
+++ b/frontend/templates/integrations_dashboard.html
@@ -183,7 +183,10 @@
       </h2>
       <div class="space-y-3">
         <template x-for="intg in sources" :key="intg.id">
-          <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-100 dark:border-gray-700">
+          <div
+            class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border"
+            :class="sourceDeletionEnabled(intg) ? 'border-red-600 ring-2 ring-red-500' : (sourceDeletionProtectionDisabled(intg) ? 'border-amber-500' : 'border-gray-100 dark:border-gray-700')"
+          >
             <div class="p-5 flex flex-col sm:flex-row sm:items-center gap-4">
               <div class="flex items-start gap-3 flex-1 min-w-0">
                 <div class="mt-0.5 flex-shrink-0">
@@ -201,6 +204,18 @@
                   </p>
                   <template x-if="intg.last_error">
                     <p class="mt-1.5 text-xs text-red-600 bg-red-50 rounded px-2 py-1 break-words" x-text="intg.last_error"></p>
+                  </template>
+                  <template x-if="sourceDeletionEnabled(intg)">
+                    <div class="mt-2 flex items-center gap-2 rounded-md border-2 border-red-700 bg-red-100 px-3 py-2 text-sm font-extrabold uppercase tracking-wide text-red-900" role="alert">
+                      <i class="fas fa-exclamation-triangle text-xl" aria-hidden="true"></i>
+                      <span>ACHTUNG: QUELLDATEIEN WERDEN NACH DEM IMPORT GELÖSCHT</span>
+                    </div>
+                  </template>
+                  <template x-if="sourceDeletionProtectionDisabled(intg) && !sourceDeletionEnabled(intg)">
+                    <div class="mt-2 flex items-center gap-2 rounded-md border border-amber-500 bg-amber-50 px-3 py-2 text-xs font-bold text-amber-900" role="status">
+                      <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                      <span>Löschschutz deaktiviert; automatisches Löschen ist derzeit nicht aktiv.</span>
+                    </div>
                   </template>
                 </div>
               </div>
@@ -793,11 +808,20 @@
             </template>
 
             <!-- Common watch folder options -->
-            <div class="flex flex-wrap items-center gap-4 pt-2">
-              <label class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200 cursor-pointer">
-                <input type="checkbox" x-model="form.config.delete_after_process" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
-                {{ _("integrations.delete_files_label") }}
+            <div class="space-y-3 pt-2">
+              <label class="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200 cursor-pointer">
+                <input type="checkbox" x-model="form.config.preserve_source_files" class="mt-0.5 rounded border-gray-300 text-amber-600 focus:ring-amber-500" />
+                <span>
+                  <strong>Quelldateien NICHT LÖSCHEN!</strong><br />
+                  <span class="text-xs">Globaler Sicherheitsschalter für lokale und Cloud-Watch-Folder. Standard: aktiv.</span>
+                </span>
               </label>
+              <template x-if="form.config.preserve_source_files === false">
+                <label class="inline-flex items-center gap-2 text-sm text-red-700 dark:text-red-300 cursor-pointer">
+                  <input type="checkbox" x-model="form.config.delete_after_process" class="rounded border-gray-300 text-red-600 focus:ring-red-500" />
+                  {{ _("integrations.delete_files_label") }}
+                </label>
+              </template>
               <template x-if="form.config.source_type !== 'local'">
                 <label class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200 cursor-pointer">
                   <input type="checkbox" x-model="showPassword" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
@@ -1164,6 +1188,16 @@ function integrationsDashboard() {
       );
     },
 
+    sourceDeletionProtectionDisabled(intg) {
+      return intg.integration_type === 'WATCH_FOLDER' &&
+        intg.config && intg.config.preserve_source_files === false;
+    },
+
+    sourceDeletionEnabled(intg) {
+      return this.sourceDeletionProtectionDisabled(intg) &&
+        intg.config.delete_after_process === true;
+    },
+
     needsDropboxAuthorization() {
       return this.isDropboxBackedForm() && !(this.editingIntegration && this.editingIntegration.has_credentials);
     },
@@ -1242,7 +1276,7 @@ function integrationsDashboard() {
         this.form.config = { recipient: '' };
         this.form.credentials = {};
       } else if (this.form.integration_type === 'WATCH_FOLDER') {
-        this.form.config = { source_type: 'local', folder_path: PREPROD_PATH, delete_after_process: false };
+        this.form.config = { source_type: 'local', folder_path: PREPROD_PATH, preserve_source_files: true, delete_after_process: false };
         this.form.credentials = {};
       } else if (this.form.integration_type === 'PAPERLESS') {
         this.form.config = { url: '' };
@@ -1256,26 +1290,27 @@ function integrationsDashboard() {
     onWatchFolderSourceTypeChange() {
       const st = this.form.config.source_type;
       const dap = this.form.config.delete_after_process || false;
+      const preserve = this.form.config.preserve_source_files !== false;
       this.form.credentials = {};
       if (st === 'local') {
-        this.form.config = { source_type: st, folder_path: PREPROD_PATH, delete_after_process: dap };
+        this.form.config = { source_type: st, folder_path: PREPROD_PATH, preserve_source_files: preserve, delete_after_process: dap };
       } else if (st === 's3') {
-        this.form.config = { source_type: st, bucket: '', region: 'us-east-1', prefix: '', endpoint_url: '', delete_after_process: dap };
+        this.form.config = { source_type: st, bucket: '', region: 'us-east-1', prefix: '', endpoint_url: '', preserve_source_files: preserve, delete_after_process: dap };
         this.form.credentials = { access_key_id: '', secret_access_key: '' };
       } else if (st === 'dropbox') {
-        this.form.config = { source_type: st, folder_path: '', delete_after_process: dap, true_up_existing: false, recursive: true };
+        this.form.config = { source_type: st, folder_path: '', preserve_source_files: preserve, delete_after_process: dap, true_up_existing: false, recursive: true };
         this.form.credentials = {};
       } else if (st === 'google_drive') {
-        this.form.config = { source_type: st, folder_id: '', delete_after_process: dap };
+        this.form.config = { source_type: st, folder_id: '', preserve_source_files: preserve, delete_after_process: dap };
         this.form.credentials = { credentials_json: '' };
       } else if (st === 'onedrive') {
-        this.form.config = { source_type: st, folder_path: PREPROD_PATH, delete_after_process: dap };
+        this.form.config = { source_type: st, folder_path: PREPROD_PATH, preserve_source_files: preserve, delete_after_process: dap };
         this.form.credentials = { refresh_token: '', client_id: '', client_secret: '' };
       } else if (st === 'nextcloud') {
-        this.form.config = { source_type: st, url: '', folder_path: PREPROD_PATH, delete_after_process: dap };
+        this.form.config = { source_type: st, url: '', folder_path: PREPROD_PATH, preserve_source_files: preserve, delete_after_process: dap };
         this.form.credentials = { username: '', password: '' };
       } else if (st === 'webdav') {
-        this.form.config = { source_type: st, url: '', folder_path: PREPROD_PATH, delete_after_process: dap };
+        this.form.config = { source_type: st, url: '', folder_path: PREPROD_PATH, preserve_source_files: preserve, delete_after_process: dap };
         this.form.credentials = { username: '', password: '' };
       }
     },
@@ -1298,11 +1333,15 @@ function integrationsDashboard() {
 
     openEditModal(intg) {
       this.editingIntegration = intg;
+      const config = intg.config ? JSON.parse(JSON.stringify(intg.config)) : {};
+      if (intg.integration_type === 'WATCH_FOLDER' && config.preserve_source_files === undefined) {
+        config.preserve_source_files = true;
+      }
       this.form = {
         direction: intg.direction,
         integration_type: intg.integration_type,
         name: intg.name,
-        config: intg.config ? JSON.parse(JSON.stringify(intg.config)) : {},
+        config,
         credentials: {},
         is_active: intg.is_active,
       };

--- a/frontend/templates/integrations_dashboard.html
+++ b/frontend/templates/integrations_dashboard.html
@@ -599,7 +599,7 @@
             </div>
             <div class="bg-blue-50 dark:bg-blue-900/30 rounded-md p-3 text-sm text-blue-700 dark:text-blue-300">
               <i class="fas fa-info-circle mr-1" aria-hidden="true"></i>
-              {{ _("integrations.oauth_hint") }}
+              Saving opens Dropbox so you can authorize this integration with your own account. The renewable grant is stored in your personal integration record; app credentials remain operator-managed.
             </div>
           </div>
         </template>
@@ -701,7 +701,7 @@
                 </label>
                 <div class="bg-blue-50 dark:bg-blue-900/30 rounded-md p-3 text-sm text-blue-700 dark:text-blue-300">
                   <i class="fas fa-key mr-1" aria-hidden="true"></i>
-                  Save this source, then use <strong>Authorize</strong> on its card. Only your renewable Dropbox grant is stored; App Key and App Secret remain operator-managed.
+                  Saving opens Dropbox so you can authorize this source with your own account. Only your renewable grant is stored; App Key and App Secret remain operator-managed.
                 </div>
               </div>
             </template>
@@ -950,6 +950,7 @@ print(response.json())</code></pre>
         <!-- Actions -->
         <div class="flex justify-between items-center pt-2 border-t border-gray-200 dark:border-gray-700">
           <button
+            x-show="!needsDropboxAuthorization()"
             type="button"
             @click="testFromForm()"
             :disabled="testing || !form.integration_type"
@@ -982,7 +983,7 @@ print(response.json())</code></pre>
               <template x-if="saving">
                 <i class="fas fa-spinner fa-spin mr-2" aria-hidden="true"></i>
               </template>
-              <span x-text="editingIntegration ? '{{ _('common.update') }}' : '{{ _('common.save') }}'"></span>
+              <span x-text="needsDropboxAuthorization() ? 'Save & connect Dropbox' : (editingIntegration ? '{{ _('common.update') }}' : '{{ _('common.save') }}')"></span>
             </button>
           </div>
         </div>
@@ -1154,6 +1155,17 @@ function integrationsDashboard() {
       if (OAUTH_TYPES.has(intg.integration_type)) return true;
       // WATCH_FOLDER with an OAuth-backed source type
       return this._watchFolderOAuthSource(intg) !== null;
+    },
+
+    isDropboxBackedForm() {
+      return this.form.integration_type === 'DROPBOX' || (
+        this.form.integration_type === 'WATCH_FOLDER' &&
+        ((this.form.config || {}).source_type || '').toLowerCase() === 'dropbox'
+      );
+    },
+
+    needsDropboxAuthorization() {
+      return this.isDropboxBackedForm() && !(this.editingIntegration && this.editingIntegration.has_credentials);
     },
 
     oauthLink(intg) {
@@ -1356,6 +1368,7 @@ function integrationsDashboard() {
           this.formError = data.detail || 'Failed to save integration.';
           return;
         }
+        const shouldAuthorizeDropbox = this.needsDropboxAuthorization();
         // Update local list
         if (this.editingIntegration) {
           const idx = this.integrations.findIndex(i => i.id === data.id);
@@ -1364,8 +1377,13 @@ function integrationsDashboard() {
           this.integrations.push(data);
           this._recalcQuota();
         }
+        if (shouldAuthorizeDropbox) {
+          window.location.href = `/dropbox-setup?integration_id=${encodeURIComponent(data.id)}`;
+          return;
+        }
+        const wasEditing = Boolean(this.editingIntegration);
         this.closeModal();
-        this.showAlert('success', 'Saved', this.editingIntegration ? 'Integration updated.' : 'Integration added successfully.');
+        this.showAlert('success', 'Saved', wasEditing ? 'Integration updated.' : 'Integration added successfully.');
       } catch (err) {
         this.formError = `Network error: ${err.message || 'Unknown error'}. Please try again.`;
       } finally {

--- a/frontend/templates/integrations_dashboard.html
+++ b/frontend/templates/integrations_dashboard.html
@@ -604,6 +604,17 @@
           </div>
         </template>
 
+        <!-- Vector database (operator-managed Qdrant) -->
+        <template x-if="form.integration_type === 'VECTOR_DATABASE'">
+          <div class="space-y-3 border-t border-gray-200 dark:border-gray-700 pt-3">
+            <p class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Vector Database</p>
+            <div class="bg-blue-50 dark:bg-blue-900/30 rounded-md p-3 text-sm text-blue-700 dark:text-blue-300">
+              <i class="fas fa-database mr-1" aria-hidden="true"></i>
+              Documents are chunked and indexed in the operator-managed Qdrant collection. No user credentials are required.
+            </div>
+          </div>
+        </template>
+
         <!-- Email (destination) fields -->
         <template x-if="form.integration_type === 'EMAIL'">
           <div class="space-y-3 border-t border-gray-200 dark:border-gray-700 pt-3">
@@ -681,19 +692,16 @@
                   <label for="wf-dbx-folder" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ _("integrations.folder_path_label") }} <span class="text-red-500" aria-hidden="true">*</span></label>
                   <input id="wf-dbx-folder" type="text" x-model="form.config.folder_path" placeholder="/Inbox/Scanner" required class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm" aria-required="true" />
                 </div>
-                <div>
-                  <label for="wf-dbx-token" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Refresh Token <span class="text-red-500" aria-hidden="true">*</span></label>
-                  <input id="wf-dbx-token" :type="showPassword ? 'text' : 'password'" x-model="form.credentials.refresh_token" :placeholder="editingIntegration ? '(unchanged if blank)' : ''" :required="!editingIntegration" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm" />
-                </div>
-                <div class="grid grid-cols-2 gap-3">
-                  <div>
-                    <label for="wf-dbx-key" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">App Key <span class="text-red-500" aria-hidden="true">*</span></label>
-                    <input id="wf-dbx-key" type="text" x-model="form.credentials.app_key" :required="!editingIntegration" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm" aria-required="true" />
-                  </div>
-                  <div>
-                    <label for="wf-dbx-secret" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">App Secret <span class="text-red-500" aria-hidden="true">*</span></label>
-                    <input id="wf-dbx-secret" :type="showPassword ? 'text' : 'password'" x-model="form.credentials.app_secret" :placeholder="editingIntegration ? '(unchanged if blank)' : ''" :required="!editingIntegration" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm" />
-                  </div>
+                <label class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-200 cursor-pointer">
+                  <input type="checkbox" x-model="form.config.true_up_existing" class="mt-0.5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+                  <span>
+                    <strong>True up existing corpus</strong><br />
+                    <span class="text-xs text-gray-500 dark:text-gray-400">Import every existing document recursively, including subfolders, then continue from Dropbox's change cursor.</span>
+                  </span>
+                </label>
+                <div class="bg-blue-50 dark:bg-blue-900/30 rounded-md p-3 text-sm text-blue-700 dark:text-blue-300">
+                  <i class="fas fa-key mr-1" aria-hidden="true"></i>
+                  Save this source, then use <strong>Authorize</strong> on its card. Only your renewable Dropbox grant is stored; App Key and App Secret remain operator-managed.
                 </div>
               </div>
             </template>
@@ -1033,8 +1041,8 @@ print(response.json())</code></pre>
 function integrationsDashboard() {
   const PREPROD_PATH = {{ ('/DocuElevate Preprod' if is_preprod else '/DocuElevate') | tojson }};
   const SOURCE_TYPES = ['IMAP', 'WATCH_FOLDER', 'WEBHOOK'];
-  const DEST_TYPES = ['S3', 'DROPBOX', 'GOOGLE_DRIVE', 'ONEDRIVE', 'WEBDAV', 'NEXTCLOUD', 'FTP', 'SFTP', 'EMAIL', 'PAPERLESS', 'RCLONE'];
-  const TYPES_WITH_FORM_FIELDS = new Set(['IMAP', 'S3', 'WEBDAV', 'NEXTCLOUD', 'FTP', 'SFTP', 'DROPBOX', 'GOOGLE_DRIVE', 'ONEDRIVE', 'EMAIL', 'WATCH_FOLDER', 'PAPERLESS']);
+  const DEST_TYPES = ['VECTOR_DATABASE', 'S3', 'DROPBOX', 'GOOGLE_DRIVE', 'ONEDRIVE', 'WEBDAV', 'NEXTCLOUD', 'FTP', 'SFTP', 'EMAIL', 'PAPERLESS', 'RCLONE'];
+  const TYPES_WITH_FORM_FIELDS = new Set(['IMAP', 'VECTOR_DATABASE', 'S3', 'WEBDAV', 'NEXTCLOUD', 'FTP', 'SFTP', 'DROPBOX', 'GOOGLE_DRIVE', 'ONEDRIVE', 'EMAIL', 'WATCH_FOLDER', 'PAPERLESS']);
   const OAUTH_TYPES = new Set(['DROPBOX', 'GOOGLE_DRIVE', 'ONEDRIVE']);
 
   const TYPE_LABELS = {
@@ -1052,6 +1060,7 @@ function integrationsDashboard() {
     EMAIL: 'Email Forward',
     PAPERLESS: 'Paperless NGX',
     RCLONE: 'Rclone',
+    VECTOR_DATABASE: 'Qdrant / Vector Database',
   };
 
   const TYPE_ICONS = {
@@ -1069,6 +1078,7 @@ function integrationsDashboard() {
     EMAIL: 'fa-paper-plane text-indigo-500',
     PAPERLESS: 'fa-file-pdf text-red-500',
     RCLONE: 'fa-sync text-teal-500',
+    VECTOR_DATABASE: 'fa-database text-purple-500',
   };
 
   return {
@@ -1225,6 +1235,9 @@ function integrationsDashboard() {
       } else if (this.form.integration_type === 'PAPERLESS') {
         this.form.config = { url: '' };
         this.form.credentials = { api_token: '' };
+      } else if (this.form.integration_type === 'VECTOR_DATABASE') {
+        this.form.config = { provider: 'qdrant' };
+        this.form.credentials = {};
       }
     },
 
@@ -1238,8 +1251,8 @@ function integrationsDashboard() {
         this.form.config = { source_type: st, bucket: '', region: 'us-east-1', prefix: '', endpoint_url: '', delete_after_process: dap };
         this.form.credentials = { access_key_id: '', secret_access_key: '' };
       } else if (st === 'dropbox') {
-        this.form.config = { source_type: st, folder_path: PREPROD_PATH, delete_after_process: dap };
-        this.form.credentials = { refresh_token: '', app_key: '', app_secret: '' };
+        this.form.config = { source_type: st, folder_path: '/Posteingang', delete_after_process: dap, true_up_existing: true, recursive: true };
+        this.form.credentials = {};
       } else if (st === 'google_drive') {
         this.form.config = { source_type: st, folder_id: '', delete_after_process: dap };
         this.form.credentials = { credentials_json: '' };

--- a/tests/test_api_dropbox.py
+++ b/tests/test_api_dropbox.py
@@ -571,6 +571,60 @@ class TestListDropboxFolders:
         assert names == ["Alpha", "middle", "Zebra"]
 
 
+@pytest.mark.unit
+class TestCreateDropboxFolder:
+    """Tests for creating a folder from the OAuth folder picker."""
+
+    @patch("httpx.AsyncClient.post")
+    def test_create_folder_in_selected_subpath(self, mock_post, client):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "metadata": {
+                "name": "DocuElevate Preprod",
+                "path_display": "/Posteingang/DocuElevate Preprod",
+                "id": "id:new",
+            }
+        }
+        mock_post.return_value = mock_response
+
+        response = client.post(
+            "/api/dropbox/create-folder",
+            data={
+                "access_token": "test-token",
+                "parent_path": "/Posteingang",
+                "name": "DocuElevate Preprod",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["path"] == "/Posteingang/DocuElevate Preprod"
+        assert mock_post.call_args.kwargs["json"] == {
+            "path": "/Posteingang/DocuElevate Preprod",
+            "autorename": False,
+        }
+
+    @pytest.mark.parametrize("name", ["", ".", "..", "child/name", "child\\name"])
+    def test_rejects_invalid_folder_names(self, name, client):
+        response = client.post(
+            "/api/dropbox/create-folder",
+            data={"access_token": "test-token", "parent_path": "/Posteingang", "name": name},
+        )
+        assert response.status_code == 422
+
+    @patch("httpx.AsyncClient.post")
+    def test_existing_folder_returns_conflict(self, mock_post, client):
+        mock_response = Mock()
+        mock_response.status_code = 409
+        mock_post.return_value = mock_response
+
+        response = client.post(
+            "/api/dropbox/create-folder",
+            data={"access_token": "test-token", "parent_path": "/", "name": "Existing"},
+        )
+        assert response.status_code == 409
+
+
 class TestBuildDropboxRedirectUri:
     """Tests for the _build_dropbox_redirect_uri helper."""
 

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -37,6 +37,38 @@ def test_dropbox_import_start_queues_owned_source(client, db_session):
     delay.assert_called_once()
 
 
+def test_watch_true_up_reuses_completed_cursor(db_session):
+    integration = _integration(db_session)
+    integration.config = json.dumps(
+        {
+            "source_type": "dropbox",
+            "folder_path": "/Posteingang",
+            "true_up_existing": True,
+            "recursive": True,
+        }
+    )
+    previous = DropboxImportJob(
+        id="completed-job",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Posteingang",
+        cursor="cursor-after-true-up",
+        state="completed",
+    )
+    db_session.add(previous)
+    db_session.commit()
+
+    with patch("app.tasks.dropbox_corpus_import.run_dropbox_corpus_import.delay") as delay:
+        from app.tasks.dropbox_corpus_import import queue_dropbox_watch_sync
+
+        result = queue_dropbox_watch_sync(integration.id, db_session)
+
+    queued = db_session.query(DropboxImportJob).filter(DropboxImportJob.id == result["job_id"]).one()
+    assert result["mode"] == "incremental"
+    assert queued.cursor == "cursor-after-true-up"
+    delay.assert_called_once_with(queued.id)
+
+
 @pytest.mark.integration
 def test_dropbox_import_rejects_invalid_integration_config(client, db_session):
     integration = _integration(db_session)

--- a/tests/test_vector_destination.py
+++ b/tests/test_vector_destination.py
@@ -1,0 +1,66 @@
+"""Qdrant behaves like a first-class per-user destination."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.models import IntegrationType
+
+
+def test_vector_database_is_supported_integration_type():
+    assert IntegrationType.VECTOR_DATABASE in IntegrationType.ALL
+
+
+def test_vector_connection_uses_operator_qdrant(monkeypatch):
+    monkeypatch.setattr("app.config.settings.vector_index_enabled", True)
+    monkeypatch.setattr("app.config.settings.vector_index_collection", "DocuElevate Preprod")
+
+    with patch("app.utils.vector_index.QdrantVectorIndex.status", return_value={"collection": "DocuElevate Preprod"}):
+        from app.api.integrations import _test_vector_database_connection
+
+        result = _test_vector_database_connection({"provider": "qdrant"}, None)
+
+    assert result == {"success": True, "message": "Qdrant collection 'DocuElevate Preprod' is ready"}
+
+
+def test_vector_upload_indexes_file_record(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.tasks.upload_to_user_integration.settings.vector_index_enabled", True)
+    monkeypatch.setattr("app.tasks.upload_to_user_integration.settings.vector_index_collection", "DocuElevate Preprod")
+    record = SimpleNamespace(id=42, ocr_text="project plan")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = record
+    db_context = MagicMock()
+    db_context.__enter__.return_value = db
+    file_path = tmp_path / "document.pdf"
+    file_path.write_bytes(b"%PDF")
+
+    with (
+        patch("app.tasks.upload_to_user_integration.SessionLocal", return_value=db_context),
+        patch("app.utils.vector_index.QdrantVectorIndex.index_document", return_value=3) as index_document,
+    ):
+        from app.tasks.upload_to_user_integration import _upload_vector_database
+
+        result = _upload_vector_database(str(file_path), {"provider": "qdrant"}, {}, "task-1", file_id=42)
+
+    index_document.assert_called_once_with(record)
+    assert result["status"] == "Completed"
+    assert result["chunks_indexed"] == 3
+    assert result["collection"] == "DocuElevate Preprod"
+
+
+def test_automatic_index_defers_to_vector_destination(monkeypatch):
+    monkeypatch.setattr("app.tasks.compute_embedding.settings.vector_index_enabled", True)
+    record = SimpleNamespace(id=42, owner_id="owner-1")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.side_effect = [record, (7,)]
+    db_context = MagicMock()
+    db_context.__enter__.return_value = db
+
+    with (
+        patch("app.tasks.compute_embedding.SessionLocal", return_value=db_context),
+        patch("app.tasks.vector_index.index_document_vectors.delay") as delay,
+    ):
+        from app.tasks.compute_embedding import _queue_vector_index
+
+        _queue_vector_index(record.id)
+
+    delay.assert_not_called()

--- a/tests/test_views_dropbox.py
+++ b/tests/test_views_dropbox.py
@@ -31,6 +31,11 @@ class TestDropboxViews:
         """Test the Dropbox OAuth callback with auth code."""
         response = client.get("/dropbox-callback?code=test_code")
         assert response.status_code == 200
+        body = response.text
+        assert "Select Folder" in body
+        assert "New folder here" in body
+        assert "/api/dropbox/create-folder" in body
+        assert "initFolderBrowser(data.access_token, integrationId)" in body
 
     def test_dropbox_setup_page_with_integration_id(self, client):
         """Test the Dropbox setup page accepts integration_id query param."""

--- a/tests/test_views_integrations.py
+++ b/tests/test_views_integrations.py
@@ -96,11 +96,14 @@ class TestIntegrationsDashboardView:
         assert "'ONEDRIVE'" in body
 
     def test_integrations_page_modal_info_box_per_user(self, client):
-        """The create modal info box instructs to save first then authorize."""
+        """Dropbox forms continue directly into personal OAuth after saving."""
         response = client.get("/integrations")
         assert response.status_code == 200
         body = response.text
-        assert "Save this integration first" in body
+        assert "Save & connect Dropbox" in body
+        assert "needsDropboxAuthorization" in body
+        assert "/dropbox-setup?integration_id=" in body
+        assert "app credentials remain operator-managed" in body
         assert "personal integration record" in body
 
     def test_integrations_page_contains_quota_indicators(self, client):

--- a/tests/test_views_integrations.py
+++ b/tests/test_views_integrations.py
@@ -106,6 +106,14 @@ class TestIntegrationsDashboardView:
         assert "app credentials remain operator-managed" in body
         assert "personal integration record" in body
 
+    def test_watch_folder_deletion_guard_is_prominent(self, client):
+        response = client.get("/integrations")
+        assert response.status_code == 200
+        body = response.text
+        assert "Quelldateien NICHT LÖSCHEN!" in body
+        assert "sourceDeletionEnabled" in body
+        assert "ACHTUNG: QUELLDATEIEN WERDEN NACH DEM IMPORT GELÖSCHT" in body
+
     def test_integrations_page_contains_quota_indicators(self, client):
         """GET /integrations page includes quota labels."""
         response = client.get("/integrations")

--- a/tests/test_watch_folder_tasks.py
+++ b/tests/test_watch_folder_tasks.py
@@ -3756,6 +3756,21 @@ class TestScanUserWatchFolder:
 class TestPullUserIntegrationWatchFolders:
     """Tests for _pull_user_integration_watch_folders."""
 
+    @pytest.mark.parametrize(
+        ("config", "expected"),
+        [
+            ({}, False),
+            ({"delete_after_process": True}, False),
+            ({"preserve_source_files": True, "delete_after_process": True}, False),
+            ({"preserve_source_files": False, "delete_after_process": False}, False),
+            ({"preserve_source_files": False, "delete_after_process": True}, True),
+        ],
+    )
+    def test_source_deletion_requires_explicit_double_opt_in(self, config, expected):
+        from app.tasks.watch_folder_tasks import _watch_source_delete_enabled
+
+        assert _watch_source_delete_enabled(config) is expected
+
     @patch("app.tasks.watch_folder_tasks._get_db_session")
     @patch("app.tasks.watch_folder_tasks._scan_user_watch_folder", return_value=2)
     @patch("app.tasks.watch_folder_tasks._load_cache", return_value={})


### PR DESCRIPTION
## Summary
- add operator-managed Qdrant as a first-class per-user `VECTOR_DATABASE` destination
- report vector indexing through the normal destination processing flow and avoid invisible duplicate indexing
- add optional Dropbox Watch Folder true-up with recursive subfolder import and cursor-based incremental polling
- keep source root, true-up, and destination activation as user configuration; the image contains no `/Posteingang` instance default
- give Dropbox sources and destinations one Save & Connect OAuth journey using operator app credentials and a renewable per-user grant
- show a post-OAuth folder browser, support arbitrary subpaths, and create/select new Dropbox folders
- make Watch Folder deletion fail closed behind an explicit two-step opt-in, with prominent source-card warnings
- align API, Dropbox, and DearConcierge bridge documentation

## Validation
- 352 focused Dropbox, OAuth, Watch Folder, integration UI, corpus-import, and vector-destination tests passed
- prior 362-test feature slice passed
- Ruff passed across app and changed tests
- targeted mypy passed
- git diff check passed

## Deployment boundary
DocuElevate preprod only. Production remains pinned to the legacy release.

Closes #1041
Closes #1042
Closes #1043

