### PR TITLE
Fix Dropbox OAuth true-up race before folder selection

### DIFF
--- a/app/api/integrations.py
+++ b/app/api/integrations.py
@@ -422,6 +422,15 @@ def update_integration(
     if not integration:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Integration not found")
 
+    try:
+        previous_config = json.loads(integration.config or "{}")
+    except (json.JSONDecodeError, TypeError):
+        previous_config = {}
+    if not isinstance(previous_config, dict):
+        previous_config = {}
+    previous_folder_path = str(previous_config.get("folder_path") or "").strip()
+    credentials_changed = body.credentials is not None
+
     if body.name is not None:
         integration.name = body.name
     if body.config is not None:
@@ -442,7 +451,24 @@ def update_integration(
         raise
 
     logger.info("User %s updated integration %d", owner_id, integration_id)
-    return _to_response(integration)
+    response = _to_response(integration)
+
+    current_config = response.get("config") or {}
+    current_folder_path = str(current_config.get("folder_path") or "").strip()
+    is_dropbox_true_up = (
+        integration.direction == IntegrationDirection.SOURCE
+        and integration.integration_type == IntegrationType.WATCH_FOLDER
+        and current_config.get("source_type") == "dropbox"
+        and bool(current_config.get("true_up_existing"))
+    )
+    folder_selected_now = current_folder_path and current_folder_path != previous_folder_path
+    if is_dropbox_true_up and (folder_selected_now or credentials_changed):
+        from app.tasks.dropbox_corpus_import import queue_dropbox_watch_sync
+
+        queue_result = queue_dropbox_watch_sync(integration.id, db)
+        logger.info("Dropbox true-up scheduling result for integration %d: %s", integration.id, queue_result)
+
+    return response
 
 
 @router.delete("/{integration_id}", status_code=status.HTTP_204_NO_CONTENT, summary="Delete an integration")

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -33,6 +33,16 @@ def queue_dropbox_watch_sync(integration_id: int, db_session=None) -> dict:
         if config.get("source_type") != "dropbox" or not config.get("true_up_existing"):
             return {"status": "skipped", "detail": "Dropbox true-up is disabled"}
 
+        root_path = str(config.get("folder_path") or "").strip()
+        if not root_path:
+            return {"status": "skipped", "detail": "Dropbox folder has not been selected"}
+
+        credentials = _decode(integration.credentials)
+        try:
+            resolve_dropbox_oauth_credentials(credentials)
+        except ValueError:
+            return {"status": "skipped", "detail": "Dropbox authorization is incomplete"}
+
         active = (
             db.query(DropboxImportJob)
             .filter(
@@ -44,7 +54,6 @@ def queue_dropbox_watch_sync(integration_id: int, db_session=None) -> dict:
         if active:
             return {"status": "running", "job_id": active.id}
 
-        root_path = str(config.get("folder_path") or "")
         previous = (
             db.query(DropboxImportJob)
             .filter(

--- a/frontend/templates/integrations_dashboard.html
+++ b/frontend/templates/integrations_dashboard.html
@@ -704,8 +704,9 @@
             <template x-if="form.config.source_type === 'dropbox'">
               <div class="space-y-3">
                 <div>
-                  <label for="wf-dbx-folder" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ _("integrations.folder_path_label") }} <span class="text-red-500" aria-hidden="true">*</span></label>
-                  <input id="wf-dbx-folder" type="text" x-model="form.config.folder_path" placeholder="/Inbox/Scanner" required class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm" aria-required="true" />
+                  <label for="wf-dbx-folder" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ _("integrations.folder_path_label") }}</label>
+                  <input id="wf-dbx-folder" type="text" x-model="form.config.folder_path" placeholder="Select after Dropbox authorization" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm" />
+                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Optional before sign-in. After Dropbox authorization, browse your account and select the source folder.</p>
                 </div>
                 <label class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-200 cursor-pointer">
                   <input type="checkbox" x-model="form.config.true_up_existing" class="mt-0.5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />

--- a/tests/test_api_integrations.py
+++ b/tests/test_api_integrations.py
@@ -335,6 +335,32 @@ class TestUpdateIntegration:
         assert resp.status_code == 200
         assert resp.json()["config"]["host"] == "imap.new.com"
 
+    def test_selecting_dropbox_watch_folder_schedules_true_up(self, int_client):
+        source = {
+            "direction": "SOURCE",
+            "integration_type": "WATCH_FOLDER",
+            "name": "Preprod Dropbox",
+            "config": {
+                "source_type": "dropbox",
+                "folder_path": "",
+                "true_up_existing": True,
+                "preserve_source_files": True,
+            },
+            "is_active": True,
+        }
+        created = int_client.post("/api/integrations/", json=source).json()
+        selected = dict(source["config"], folder_path="/Posteingang")
+
+        with unittest.mock.patch(
+            "app.tasks.dropbox_corpus_import.queue_dropbox_watch_sync",
+            return_value={"status": "queued", "job_id": "job-1", "mode": "true-up"},
+        ) as queue:
+            response = int_client.put(f"/api/integrations/{created['id']}", json={"config": selected})
+
+        assert response.status_code == 200
+        queue.assert_called_once()
+        assert queue.call_args.args[0] == created["id"]
+
     def test_update_credentials_re_encrypts(self, int_client, int_session):
         """Updating credentials stores the new value encrypted."""
         created = int_client.post("/api/integrations/", json=_IMAP_SOURCE).json()

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from app.models import DropboxImportJob, IntegrationDirection, IntegrationType, UserIntegration
+from app.utils.encryption import encrypt_value
 
 
 def _integration(db_session) -> UserIntegration:
@@ -16,7 +17,9 @@ def _integration(db_session) -> UserIntegration:
         integration_type=IntegrationType.WATCH_FOLDER,
         name="Dropbox archive",
         config=json.dumps({"source_type": "dropbox", "folder_path": "/Documents"}),
-        credentials="{}",
+        credentials=encrypt_value(
+            json.dumps({"app_key": "app-key", "app_secret": "app-secret", "refresh_token": "refresh-token"})
+        ),
         is_active=True,
     )
     db_session.add(integration)
@@ -67,6 +70,39 @@ def test_watch_true_up_reuses_completed_cursor(db_session):
     assert result["mode"] == "incremental"
     assert queued.cursor == "cursor-after-true-up"
     delay.assert_called_once_with(queued.id)
+
+
+def test_watch_true_up_waits_for_folder_selection(db_session):
+    integration = _integration(db_session)
+    integration.config = json.dumps(
+        {"source_type": "dropbox", "folder_path": "", "true_up_existing": True, "recursive": True}
+    )
+    db_session.commit()
+
+    with patch("app.tasks.dropbox_corpus_import.run_dropbox_corpus_import.delay") as delay:
+        from app.tasks.dropbox_corpus_import import queue_dropbox_watch_sync
+
+        result = queue_dropbox_watch_sync(integration.id, db_session)
+
+    assert result == {"status": "skipped", "detail": "Dropbox folder has not been selected"}
+    delay.assert_not_called()
+
+
+def test_watch_true_up_waits_for_oauth_grant(db_session):
+    integration = _integration(db_session)
+    integration.config = json.dumps(
+        {"source_type": "dropbox", "folder_path": "/Posteingang", "true_up_existing": True, "recursive": True}
+    )
+    integration.credentials = None
+    db_session.commit()
+
+    with patch("app.tasks.dropbox_corpus_import.run_dropbox_corpus_import.delay") as delay:
+        from app.tasks.dropbox_corpus_import import queue_dropbox_watch_sync
+
+        result = queue_dropbox_watch_sync(integration.id, db_session)
+
+    assert result == {"status": "skipped", "detail": "Dropbox authorization is incomplete"}
+    delay.assert_not_called()
 
 
 @pytest.mark.integration

--- a/tests/test_views_dropbox.py
+++ b/tests/test_views_dropbox.py
@@ -1,6 +1,7 @@
 """Tests for app/views/dropbox.py module."""
 
 import json
+import re
 from unittest.mock import patch
 
 import pytest
@@ -36,6 +37,15 @@ class TestDropboxViews:
         assert "New folder here" in body
         assert "/api/dropbox/create-folder" in body
         assert "initFolderBrowser(data.access_token, integrationId)" in body
+
+    def test_dropbox_watch_folder_path_is_optional_before_oauth(self, client):
+        response = client.get("/integrations")
+        assert response.status_code == 200
+        tag = re.search(r'<input id="wf-dbx-folder"[^>]+>', response.text)
+        assert tag is not None
+        assert " required" not in tag.group(0)
+        assert 'aria-required="true"' not in tag.group(0)
+        assert "Optional before sign-in" in response.text
 
     def test_dropbox_setup_page_with_integration_id(self, client):
         """Test the Dropbox setup page accepts integration_id query param."""


### PR DESCRIPTION
## Summary

- allow Dropbox Watch Folder setup to enter OAuth without guessing a path
- defer true-up until both the renewable grant and a selected folder exist
- schedule the initial true-up immediately after the picker saves the folder
- preserve the fail-closed source-file protection

## Verification

- 107 focused integration and upload tests passed
- 22 targeted OAuth, picker and true-up tests passed
- Ruff check and format passed
- diff check passed

Closes #1044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dropbox Watch Folder updates now automatically schedule a sync when the selected folder or authorization details change.
  * Folder paths can be selected after Dropbox authorization and are optional beforehand.

* **Bug Fixes**
  * Prevented sync jobs from being scheduled when no folder is selected or Dropbox authorization is incomplete.
  * Improved handling of invalid or incomplete folder and credential settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->