### PR TITLE
Throttle corpus backfills and protect interactive uploads

### DIFF
--- a/app/api/dropbox_imports.py
+++ b/app/api/dropbox_imports.py
@@ -91,9 +91,9 @@ def start_dropbox_import(request: Request, body: DropboxImportCreate, db: DbSess
     db.commit()
     db.refresh(job)
 
-    from app.tasks.dropbox_corpus_import import run_dropbox_corpus_import
+    from app.tasks.dropbox_corpus_import import schedule_dropbox_corpus_import
 
-    task = run_dropbox_corpus_import.delay(job.id)
+    task = schedule_dropbox_corpus_import(job.id)
     response = _job_response(job)
     response["task_id"] = task.id
     return response

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -20,6 +20,14 @@ celery = Celery(
 # Optionally add this line to retain connection retry behavior at startup:
 celery.conf.broker_connection_retry_on_startup = True
 
+# Redis emulates priorities with separate lists.  Explicitly enable priority
+# ordering so normal priority-0 uploads are consumed before priority-9 corpus
+# backfills on the shared document queue.
+celery.conf.broker_transport_options = {
+    "queue_order_strategy": "priority",
+    "priority_steps": list(range(10)),
+}
+
 # Set the default queue and routing so that tasks are enqueued on "document_processor"
 celery.conf.task_default_queue = "document_processor"
 celery.conf.task_routes = {

--- a/app/config.py
+++ b/app/config.py
@@ -901,6 +901,33 @@ class Settings(BaseSettings):
         default=3,
         description="Delay in seconds between each task submission when throttling in /processall",
     )
+    corpus_backfill_batch_size: int = Field(
+        default=10,
+        ge=1,
+        le=2000,
+        description="Maximum provider entries requested per corpus backfill page. Default: 10.",
+    )
+    corpus_backfill_queue_high_watermark: int = Field(
+        default=50,
+        ge=1,
+        description=(
+            "Pause corpus backfills when the total pending Celery queue depth reaches this value. Default: 50."
+        ),
+    )
+    corpus_backfill_resume_delay_seconds: int = Field(
+        default=30,
+        ge=1,
+        description="Delay before a queue-limited corpus backfill checks for capacity again. Default: 30 seconds.",
+    )
+    corpus_backfill_task_priority: int = Field(
+        default=9,
+        ge=0,
+        le=9,
+        description=(
+            "Celery priority for corpus backfill coordinator tasks. Redis consumes lower numeric priorities first, "
+            "so the default 9 keeps backfills behind interactive work."
+        ),
+    )
 
     # Client-side upload throttling settings (applied when uploading files via the web UI)
     upload_concurrency: int = Field(
@@ -1063,6 +1090,14 @@ class Settings(BaseSettings):
             " Set this below the model's context window (e.g. 8000 for an 8192-token model)."
         ),
     )
+    metadata_max_input_tokens: int = Field(
+        default=8000,
+        ge=1000,
+        description=(
+            "Maximum document-text tokens sent to metadata extraction. Longer documents retain the beginning "
+            "and a short ending before the LLM call. Default: 8000."
+        ),
+    )
     embedding_backfill_batch_size: int = Field(
         default=50,
         description=(
@@ -1101,6 +1136,15 @@ class Settings(BaseSettings):
         ge=0,
         le=1000,
         description="Number of tokens repeated between adjacent chunks to preserve context.",
+    )
+    vector_embedding_batch_tokens: int = Field(
+        default=200000,
+        ge=1000,
+        le=250000,
+        description=(
+            "Maximum aggregate token count sent in one chunk-embedding request. "
+            "Large documents are split across multiple requests to stay below provider request limits."
+        ),
     )
     vector_index_timeout_seconds: float = Field(
         default=30.0,

--- a/app/tasks/convert_to_pdf.py
+++ b/app/tasks/convert_to_pdf.py
@@ -16,6 +16,18 @@ from app.utils import log_task_progress
 logger = logging.getLogger(__name__)
 
 
+def _normalise_magic_match(matches) -> tuple[Optional[str], Optional[str]]:
+    """Normalise puremagic return shapes across supported library versions."""
+    if not matches:
+        return None, None
+    if isinstance(matches, str):
+        return (matches, None) if "/" in matches else (None, matches)
+    match = matches[0]
+    if isinstance(match, str):
+        return (match, None) if "/" in match else (None, match)
+    return getattr(match, "mime_type", None), getattr(match, "extension", None)
+
+
 def _detect_mime_type_from_magic(file_path: str) -> Optional[str]:
     """
     Detect MIME type from file headers using platform-agnostic libraries.
@@ -28,8 +40,9 @@ def _detect_mime_type_from_magic(file_path: str) -> Optional[str]:
     """
     try:
         matches = puremagic.from_file(file_path)
-        if matches:
-            return matches[0].mime_type
+        mime_type, _extension = _normalise_magic_match(matches)
+        if mime_type:
+            return mime_type
     except puremagic.PureError:
         pass
 
@@ -89,8 +102,9 @@ def _detect_extension(file_path: str, original_filename: Optional[str], mime_typ
 
     try:
         matches = puremagic.from_file(file_path)
-        if matches and matches[0].extension:
-            return f".{matches[0].extension.lstrip('.')}"
+        _mime_type, extension = _normalise_magic_match(matches)
+        if extension:
+            return f".{extension.lstrip('.')}"
     except puremagic.PureError:
         pass
 

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -5,6 +5,9 @@ import logging
 import os
 import uuid
 
+import redis
+from celery.result import AsyncResult
+
 from app.celery_app import celery
 from app.config import settings
 from app.database import SessionLocal
@@ -16,6 +19,50 @@ from app.utils.encryption import decrypt_value
 from app.utils.filename_utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
+
+_CELERY_QUEUES = ("document_processor", "default", "celery")
+
+
+def _pending_queue_depth() -> int | None:
+    """Return pending interactive pipeline work, failing open if Redis is unavailable."""
+    try:
+        client = redis.Redis.from_url(
+            settings.redis_url,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+        return sum(int(client.llen(queue)) for queue in _CELERY_QUEUES)
+    except Exception:  # noqa: BLE001
+        logger.warning("Could not inspect queue depth before corpus backfill", exc_info=True)
+        return None
+
+
+def schedule_dropbox_corpus_import(job_id: str, *, countdown: int = 0) -> AsyncResult:
+    """Schedule low-priority corpus coordination without blocking interactive uploads."""
+    return run_dropbox_corpus_import.apply_async(
+        args=[job_id],
+        countdown=countdown,
+        priority=settings.corpus_backfill_task_priority,
+    )
+
+
+def _bounded_config_int(
+    config: dict,
+    key: str,
+    default: int,
+    *,
+    minimum: int,
+    maximum: int | None = None,
+) -> int:
+    """Return a validated integer integration override or the global default."""
+    raw_value = config.get(key)
+    try:
+        value = int(raw_value) if raw_value not in (None, "") else default
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid %s integration override: %r", key, raw_value)
+        value = default
+    value = max(minimum, value)
+    return min(value, maximum) if maximum is not None else value
 
 
 def queue_dropbox_watch_sync(integration_id: int, db_session=None) -> dict:
@@ -81,7 +128,7 @@ def queue_dropbox_watch_sync(integration_id: int, db_session=None) -> dict:
         if owns_session:
             db.close()
 
-    run_dropbox_corpus_import.delay(job_id)
+    schedule_dropbox_corpus_import(job_id)
     return {"status": "queued", "job_id": job_id, "mode": mode}
 
 
@@ -228,14 +275,53 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
         if not integration or not integration.is_active:
             raise RuntimeError("Dropbox source integration is missing or inactive")
 
+        try:
+            config = json.loads(integration.config or "{}")
+        except (json.JSONDecodeError, TypeError):
+            config = {}
+        if not isinstance(config, dict):
+            config = {}
+        high_watermark = _bounded_config_int(
+            config,
+            "backfill_queue_high_watermark",
+            settings.corpus_backfill_queue_high_watermark,
+            minimum=1,
+        )
+        queue_depth = _pending_queue_depth()
+        if queue_depth is not None and queue_depth >= high_watermark:
+            job.state = "queued"
+            job.error = f"Paused for queue backpressure at depth {queue_depth}"
+            db.commit()
+            delay = _bounded_config_int(
+                config,
+                "backfill_resume_delay_seconds",
+                settings.corpus_backfill_resume_delay_seconds,
+                minimum=1,
+            )
+            schedule_dropbox_corpus_import(job.id, countdown=delay)
+            return {
+                "status": "paused",
+                "job_id": job.id,
+                "queue_depth": queue_depth,
+                "resume_in_seconds": delay,
+            }
+
         job.state = "running"
+        job.error = None
         db.commit()
         client = _dropbox_client(integration)
         if job.cursor:
             page = client.files_list_folder_continue(job.cursor)
         else:
             root = "" if job.root_path in {"", "/"} else job.root_path
-            page = client.files_list_folder(root, recursive=True, include_deleted=False, limit=2000)
+            batch_size = _bounded_config_int(
+                config,
+                "backfill_batch_size",
+                settings.corpus_backfill_batch_size,
+                minimum=1,
+                maximum=2000,
+            )
+            page = client.files_list_folder(root, recursive=True, include_deleted=False, limit=batch_size)
 
         for entry in page.entries:
             if not isinstance(entry, dropbox.files.FileMetadata):
@@ -253,6 +339,10 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
                 job.skipped += 1
             else:
                 job.failed += 1
+            # Persist each enqueued document before moving on. If the worker is
+            # interrupted, Dropbox returns the same page and idempotency skips
+            # the already committed entries instead of creating orphan tasks.
+            db.commit()
 
         job.cursor = page.cursor
         job.state = "running" if page.has_more else "completed"
@@ -267,5 +357,5 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
         }
 
     if page.has_more:
-        run_dropbox_corpus_import.delay(job_id)
+        schedule_dropbox_corpus_import(job_id)
     return result

--- a/app/tasks/extract_metadata_with_gpt.py
+++ b/app/tasks/extract_metadata_with_gpt.py
@@ -19,6 +19,45 @@ from app.utils.filename_utils import VALID_FILENAME_RE
 logger = logging.getLogger(__name__)
 
 
+def _sample_text_for_metadata(text: str, model: str, max_tokens: int) -> tuple[str, int, int]:
+    """Fit long documents into the metadata prompt while retaining coverage."""
+    if not text:
+        return text, 0, 0
+    max_tokens = max(1000, int(max_tokens))
+    try:
+        import tiktoken
+
+        try:
+            encoding = tiktoken.encoding_for_model(model)
+        except KeyError:
+            encoding = tiktoken.get_encoding("cl100k_base")
+        tokens = encoding.encode(text)
+        original_count = len(tokens)
+        if original_count <= max_tokens:
+            return text, original_count, original_count
+
+        marker_budget = 32
+        content_budget = max_tokens - marker_budget
+        head_size = int(content_budget * 0.88)
+        tail_size = content_budget - head_size
+        parts = [encoding.decode(tokens[:head_size])]
+        parts.append("\n\n[Document ending]\n" + encoding.decode(tokens[-tail_size:]))
+        sampled_tokens = encoding.encode("".join(parts))[:max_tokens]
+        return encoding.decode(sampled_tokens), original_count, len(sampled_tokens)
+    except Exception:  # noqa: BLE001
+        # A conservative character fallback keeps the LLM request bounded even
+        # when the optional tokenizer is unavailable.
+        char_limit = max_tokens * 3
+        if len(text) <= char_limit:
+            estimated = (len(text) + 2) // 3
+            return text, estimated, estimated
+        tail_size = char_limit // 8
+        marker = "\n\n[Document ending]\n"
+        head_size = char_limit - tail_size - len(marker)
+        sampled = text[:head_size] + marker + text[-tail_size:]
+        return sampled, (len(text) + 2) // 3, (len(sampled) + 2) // 3
+
+
 def extract_json_from_text(text):
     """
     Try to extract a JSON object from the text.
@@ -71,6 +110,28 @@ def extract_metadata_with_gpt(self, filename: str, cleaned_text: str, file_id: i
                 if file_record:
                     file_id = file_record.id
 
+    model = settings.ai_model or settings.openai_model
+    metadata_text, original_tokens, sampled_tokens = _sample_text_for_metadata(
+        cleaned_text,
+        model,
+        settings.metadata_max_input_tokens,
+    )
+    if sampled_tokens < original_tokens:
+        logger.info(
+            "[%s] Sampled metadata input from %d to %d tokens for %s",
+            task_id,
+            original_tokens,
+            sampled_tokens,
+            filename,
+        )
+        log_task_progress(
+            task_id,
+            "metadata_input_sampling",
+            "success",
+            f"Sampled metadata input from {original_tokens} to {sampled_tokens} tokens",
+            file_id=file_id,
+        )
+
     prompt = (
         "You are a specialized document analyzer trained to extract structured metadata from documents.\n"
         "Your task is to analyze the given text and return a well-structured JSON object.\n\n"
@@ -98,9 +159,14 @@ def extract_metadata_with_gpt(self, filename: str, cleaned_text: str, file_id: i
         "- **OCR Correction**: Assume the text has been corrected for OCR errors.\n"
         "- **Tagging**: Max 4 tags, avoiding generic or overly specific terms.\n"
         "- **Title**: Concise, no addresses, and contains key identifying features.\n"
-        "- **Date Selection**: Use the most relevant date if multiple are found.\n"
+        "- **Date Selection**: Prefer an explicit document-level date in the header "
+        "(such as report date, invoice date, or letter date) over line-item, due, completion, "
+        "or historical dates. Infer ambiguous numeric date order from unambiguous dates elsewhere "
+        "in the same document.\n"
+        "- **Document Parties**: Extract sender and recipient only from document-level authorship or "
+        "addressing. Do not use a report title, scope, or arbitrary person from a table as a party.\n"
         "- **Output Language**: Maintain the document's original language.\n\n"
-        f"Extracted text:\n{cleaned_text}\n\n"
+        f"Extracted text:\n{metadata_text}\n\n"
         "Return only valid JSON with no additional commentary.\n"
     )
 
@@ -108,7 +174,6 @@ def extract_metadata_with_gpt(self, filename: str, cleaned_text: str, file_id: i
         logger.info(f"[{task_id}] Sending classification request for {filename}...")
         log_task_progress(task_id, "call_ai_provider", "in_progress", "Calling AI provider API", file_id=file_id)
         provider = get_ai_provider()
-        model = settings.ai_model or settings.openai_model
         content = provider.chat_completion(
             messages=[
                 {"role": "system", "content": "You are an intelligent document classifier."},

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -2161,6 +2161,49 @@ SETTING_METADATA = {
         "required": False,
         "restart_required": False,
     },
+    "corpus_backfill_batch_size": {
+        "category": "Processing",
+        "description": "Maximum provider entries requested per corpus backfill page (default: 10)",
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
+    "corpus_backfill_queue_high_watermark": {
+        "category": "Processing",
+        "description": "Pause corpus backfills at this total pending Celery queue depth (default: 50)",
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
+    "corpus_backfill_resume_delay_seconds": {
+        "category": "Processing",
+        "description": "Seconds before a queue-limited corpus backfill checks capacity again (default: 30)",
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
+    "corpus_backfill_task_priority": {
+        "category": "Processing",
+        "description": "Celery priority for corpus backfill coordinator tasks (default: 0)",
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
+    "metadata_max_input_tokens": {
+        "category": "Processing",
+        "description": (
+            "Maximum document-text tokens sent to metadata extraction. Longer documents retain the beginning "
+            "and a short ending (default: 8000)."
+        ),
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
     "upload_concurrency": {
         "category": "Processing",
         "description": (
@@ -3377,6 +3420,14 @@ SETTING_METADATA = {
         "sensitive": False,
         "required": False,
         "restart_required": True,
+    },
+    "vector_embedding_batch_tokens": {
+        "category": "Knowledge Bridge",
+        "description": "Maximum aggregate token count sent in one chunk-embedding request.",
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
     },
     "vector_index_timeout_seconds": {
         "category": "Knowledge Bridge",

--- a/app/utils/vector_index.py
+++ b/app/utils/vector_index.py
@@ -111,6 +111,22 @@ def chunk_text(
         return _character_chunks(normalized, size, overlap)
 
 
+def _embedding_batches(chunks: list[TextChunk], token_budget: int) -> Iterable[list[TextChunk]]:
+    """Group ordered chunks below a provider's aggregate request-token limit."""
+    batch: list[TextChunk] = []
+    batch_tokens = 0
+    for chunk in chunks:
+        chunk_tokens = max(1, chunk.token_end - chunk.token_start)
+        if batch and batch_tokens + chunk_tokens > token_budget:
+            yield batch
+            batch = []
+            batch_tokens = 0
+        batch.append(chunk)
+        batch_tokens += chunk_tokens
+    if batch:
+        yield batch
+
+
 class QdrantVectorIndex:
     """Small HTTP client covering the Qdrant operations DocuElevate needs."""
 
@@ -175,7 +191,19 @@ class QdrantVectorIndex:
         if not chunks:
             return 0
 
-        vectors = generate_embeddings([chunk.text for chunk in chunks])
+        vectors: list[list[float]] = []
+        for batch_number, batch in enumerate(
+            _embedding_batches(chunks, settings.vector_embedding_batch_tokens),
+            start=1,
+        ):
+            logger.info(
+                "Embedding vector-index batch %d for document %s (%d chunks, %d tokens)",
+                batch_number,
+                file_record.id,
+                len(batch),
+                sum(max(1, chunk.token_end - chunk.token_start) for chunk in batch),
+            )
+            vectors.extend(generate_embeddings([chunk.text for chunk in batch]))
         if len(vectors) != len(chunks):
             raise VectorIndexError("Embedding provider returned an unexpected number of vectors")
         self.ensure_collection(len(vectors[0]))

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -39,6 +39,7 @@ secret manager; do not store them in `.env` files committed to source control.
 | `VECTOR_INDEX_COLLECTION` | Qdrant collection for document chunks. | `docuelevate_documents` |
 | `VECTOR_CHUNK_TOKENS` | Target token count per chunk. | `600` |
 | `VECTOR_CHUNK_OVERLAP_TOKENS` | Token overlap between adjacent chunks. | `80` |
+| `VECTOR_EMBEDDING_BATCH_TOKENS` | Maximum aggregate tokens per embedding request; larger documents use multiple ordered requests. | `200000` |
 | `VECTOR_INDEX_TIMEOUT_SECONDS` | Qdrant request timeout. | `30` |
 | `DOCUMENT_INTAKE_SHARED_SECRET` | Optional dedicated secret for the controlled legacy sender. | unset |
 | `DOCUMENT_INTAKE_SHARED_OWNER_ID` | Owner/principal assigned to shared-secret intake. | `legacy-bridge` |
@@ -56,6 +57,7 @@ VECTOR_INDEX_URL=http://docuelevate-qdrant:6333
 VECTOR_INDEX_COLLECTION=docuelevate_documents
 VECTOR_CHUNK_TOKENS=600
 VECTOR_CHUNK_OVERLAP_TOKENS=80
+VECTOR_EMBEDDING_BATCH_TOKENS=200000
 ```
 
 The vector collection is derived state. PostgreSQL and the document work directory
@@ -71,6 +73,18 @@ Control how the `/processall` endpoint handles large batches of files to prevent
 |-----------------------------------|----------------------------------------------------------------------------------------------------|-------------|
 | `PROCESSALL_THROTTLE_THRESHOLD`   | Number of files above which throttling is applied. Files <= threshold are processed immediately.  | `20`        |
 | `PROCESSALL_THROTTLE_DELAY`       | Delay in seconds between each task submission when throttling is active.                          | `3`         |
+| `CORPUS_BACKFILL_BATCH_SIZE` | Maximum provider entries requested per Dropbox corpus page. | `10` |
+| `CORPUS_BACKFILL_QUEUE_HIGH_WATERMARK` | Pause corpus backfills at this total pending Celery queue depth. | `50` |
+| `CORPUS_BACKFILL_RESUME_DELAY_SECONDS` | Seconds before a queue-limited backfill checks capacity again. | `30` |
+| `CORPUS_BACKFILL_TASK_PRIORITY` | Celery Redis priority for corpus coordinator tasks; `9` runs behind normal priority `0` work. | `9` |
+| `METADATA_MAX_INPUT_TOKENS` | Maximum document-text tokens sent to metadata extraction; keeps the beginning plus a short ending. | `8000` |
+
+Dropbox Watch Folder integrations may override the first three defaults with
+`backfill_batch_size`, `backfill_queue_high_watermark`, and
+`backfill_resume_delay_seconds` in their database-backed integration config.
+The importer commits progress after every queued document and reuses the
+Dropbox cursor, so pausing or restarting a worker does not require rescanning
+the completed portion of the corpus.
 
 **Example Usage**: When processing 25 files with default settings:
 - Files are staggered: file 0 at 0s, file 1 at 3s, file 2 at 6s, etc.

--- a/tests/test_celery_app.py
+++ b/tests/test_celery_app.py
@@ -48,6 +48,15 @@ class TestCeleryAppConfig:
 
         assert celery.conf.broker_connection_retry_on_startup is True
 
+    def test_redis_transport_consumes_normal_work_before_corpus_backfills(self):
+        """Redis priority lists must be consumed from priority 0 through 9."""
+        from app.celery_app import celery
+
+        assert celery.conf.broker_transport_options == {
+            "queue_order_strategy": "priority",
+            "priority_steps": list(range(10)),
+        }
+
 
 @pytest.mark.unit
 class TestTaskFailureHandler:

--- a/tests/test_convert_pdf.py
+++ b/tests/test_convert_pdf.py
@@ -27,6 +27,16 @@ class TestDetectMimeTypeFromMagic:
         result = _detect_mime_type_from_magic("/test/file.pdf")
         assert result == "application/pdf"
 
+    @patch(
+        "app.tasks.convert_to_pdf.puremagic.from_file",
+        return_value="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    )
+    def test_accepts_string_return_from_puremagic(self, _mock_puremagic):
+        assert (
+            _detect_mime_type_from_magic("/test/document")
+            == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+
     @patch("app.tasks.convert_to_pdf.filetype.guess")
     @patch("app.tasks.convert_to_pdf.puremagic.from_file")
     def test_falls_back_to_filetype(self, mock_puremagic, mock_filetype):
@@ -121,6 +131,12 @@ class TestDetectExtension:
 
         result = _detect_extension("/test/file", None, None)
         assert result == ".png"
+
+    @patch("app.tasks.convert_to_pdf.filetype.guess")
+    @patch("app.tasks.convert_to_pdf.puremagic.from_file", return_value="docx")
+    @patch("app.tasks.convert_to_pdf.mimetypes.guess_extension", return_value=None)
+    def test_accepts_string_extension_from_puremagic(self, _mock_guess_ext, _mock_puremagic, _mock_filetype):
+        assert _detect_extension("/test/file", None, None) == ".docx"
 
     @patch("app.tasks.convert_to_pdf.filetype.guess")
     @patch("app.tasks.convert_to_pdf.puremagic.from_file")

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -1,8 +1,9 @@
 """Tests for resumable Dropbox corpus import and revision deduplication."""
 
 import json
+from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -30,14 +31,15 @@ def _integration(db_session) -> UserIntegration:
 
 def test_dropbox_import_start_queues_owned_source(client, db_session):
     integration = _integration(db_session)
-    with patch("app.tasks.dropbox_corpus_import.run_dropbox_corpus_import.delay") as delay:
-        delay.return_value.id = "import-task"
+    with patch("app.tasks.dropbox_corpus_import.run_dropbox_corpus_import.apply_async") as apply_async:
+        apply_async.return_value.id = "task-1"
         response = client.post("/api/dropbox-imports/", json={"integration_id": integration.id})
 
     assert response.status_code == 202
     assert response.json()["root_path"] == "/Documents"
     assert response.json()["state"] == "queued"
-    delay.assert_called_once()
+    assert response.json()["task_id"] == "task-1"
+    apply_async.assert_called_once_with(args=[response.json()["job_id"]], countdown=0, priority=9)
 
 
 def test_watch_true_up_reuses_completed_cursor(db_session):
@@ -61,7 +63,7 @@ def test_watch_true_up_reuses_completed_cursor(db_session):
     db_session.add(previous)
     db_session.commit()
 
-    with patch("app.tasks.dropbox_corpus_import.run_dropbox_corpus_import.delay") as delay:
+    with patch("app.tasks.dropbox_corpus_import.run_dropbox_corpus_import.apply_async") as apply_async:
         from app.tasks.dropbox_corpus_import import queue_dropbox_watch_sync
 
         result = queue_dropbox_watch_sync(integration.id, db_session)
@@ -69,7 +71,7 @@ def test_watch_true_up_reuses_completed_cursor(db_session):
     queued = db_session.query(DropboxImportJob).filter(DropboxImportJob.id == result["job_id"]).one()
     assert result["mode"] == "incremental"
     assert queued.cursor == "cursor-after-true-up"
-    delay.assert_called_once_with(queued.id)
+    apply_async.assert_called_once_with(args=[queued.id], countdown=0, priority=9)
 
 
 def test_watch_true_up_waits_for_folder_selection(db_session):
@@ -190,3 +192,132 @@ def test_dropbox_import_removes_download_when_queueing_fails(db_session, tmp_pat
             _import_file(db_session, job, integration, client, entry)
 
     assert not list(tmp_path.glob("dropbox_*"))
+
+
+@pytest.mark.unit
+def test_dropbox_import_pauses_at_queue_high_watermark(db_session):
+    integration = _integration(db_session)
+    integration.config = json.dumps({"backfill_queue_high_watermark": 25, "backfill_resume_delay_seconds": 12})
+    job = DropboxImportJob(
+        id="job-backpressure",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Documents",
+    )
+    db_session.add(job)
+    db_session.commit()
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=25),
+        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_import") as schedule,
+    ):
+        from app.tasks.dropbox_corpus_import import run_dropbox_corpus_import
+
+        result = run_dropbox_corpus_import.run(job.id)
+
+    db_session.refresh(job)
+    assert result == {
+        "status": "paused",
+        "job_id": job.id,
+        "queue_depth": 25,
+        "resume_in_seconds": 12,
+    }
+    assert job.state == "queued"
+    assert "depth 25" in job.error
+    schedule.assert_called_once_with(job.id, countdown=12)
+
+
+@pytest.mark.unit
+def test_dropbox_import_uses_configured_provider_batch_size(db_session):
+    integration = _integration(db_session)
+    integration.config = json.dumps({"backfill_batch_size": 7})
+    job = DropboxImportJob(
+        id="job-small-page",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Documents",
+    )
+    db_session.add(job)
+    db_session.commit()
+    page = SimpleNamespace(entries=[], cursor="cursor-1", has_more=False)
+    dropbox_client = MagicMock()
+    dropbox_client.files_list_folder.return_value = page
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.tasks.dropbox_corpus_import._dropbox_client", return_value=dropbox_client),
+    ):
+        from app.tasks.dropbox_corpus_import import run_dropbox_corpus_import
+
+        result = run_dropbox_corpus_import.run(job.id)
+
+    assert result["status"] == "completed"
+    dropbox_client.files_list_folder.assert_called_once_with(
+        "/Documents",
+        recursive=True,
+        include_deleted=False,
+        limit=7,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({}, 10),
+        ({"backfill_batch_size": "7"}, 7),
+        ({"backfill_batch_size": "not-a-number"}, 10),
+        ({"backfill_batch_size": 0}, 1),
+        ({"backfill_batch_size": 5000}, 2000),
+    ],
+)
+def test_bounded_config_int_uses_safe_fallbacks_and_limits(config, expected):
+    from app.tasks.dropbox_corpus_import import _bounded_config_int
+
+    assert (
+        _bounded_config_int(
+            config,
+            "backfill_batch_size",
+            10,
+            minimum=1,
+            maximum=2000,
+        )
+        == expected
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("override", ["not-a-number", [], {}])
+def test_dropbox_import_ignores_invalid_provider_batch_size(db_session, override):
+    integration = _integration(db_session)
+    integration.config = json.dumps({"backfill_batch_size": override})
+    job = DropboxImportJob(
+        id=f"job-invalid-page-{type(override).__name__}",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Documents",
+    )
+    db_session.add(job)
+    db_session.commit()
+    page = SimpleNamespace(entries=[], cursor="cursor-1", has_more=False)
+    dropbox_client = MagicMock()
+    dropbox_client.files_list_folder.return_value = page
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.tasks.dropbox_corpus_import._dropbox_client", return_value=dropbox_client),
+    ):
+        from app.tasks.dropbox_corpus_import import run_dropbox_corpus_import
+
+        result = run_dropbox_corpus_import.run(job.id)
+
+    assert result["status"] == "completed"
+    dropbox_client.files_list_folder.assert_called_once_with(
+        "/Documents",
+        recursive=True,
+        include_deleted=False,
+        limit=10,
+    )

--- a/tests/test_extract_metadata_gpt.py
+++ b/tests/test_extract_metadata_gpt.py
@@ -1,11 +1,56 @@
 """Comprehensive unit tests for app/tasks/extract_metadata_with_gpt.py module."""
 
 import json
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.tasks.extract_metadata_with_gpt import extract_json_from_text, extract_metadata_with_gpt
+from app.tasks.extract_metadata_with_gpt import (
+    _sample_text_for_metadata,
+    extract_json_from_text,
+    extract_metadata_with_gpt,
+)
+
+
+@pytest.mark.unit
+def test_metadata_input_sampling_keeps_front_and_short_ending():
+    text = "DOCUMENT_START " + " ".join(f"item-{index}" for index in range(10000)) + " DOCUMENT_END"
+
+    sampled, original_tokens, sampled_tokens = _sample_text_for_metadata(text, "gpt-4o-mini", 1000)
+
+    assert original_tokens > sampled_tokens
+    assert sampled_tokens <= 1000
+    assert sampled.startswith("DOCUMENT_START")
+    assert "[Document ending]" in sampled
+    assert sampled.endswith("DOCUMENT_END")
+
+
+@pytest.mark.unit
+def test_metadata_input_sampling_leaves_small_document_unchanged():
+    text = "A short invoice"
+
+    sampled, original_tokens, sampled_tokens = _sample_text_for_metadata(text, "gpt-4o-mini", 1000)
+
+    assert sampled == text
+    assert original_tokens == sampled_tokens
+
+
+@pytest.mark.unit
+def test_metadata_input_character_fallback_preserves_exact_document_tail():
+    text = "A" * 3500 + "EXACT_DOCUMENT_END"
+
+    with patch.dict(sys.modules, {"tiktoken": None}):
+        sampled, original_tokens, sampled_tokens = _sample_text_for_metadata(
+            text,
+            "unknown-model",
+            1000,
+        )
+
+    assert len(sampled) == 3000
+    assert sampled.endswith("EXACT_DOCUMENT_END")
+    assert "[Document ending]" in sampled
+    assert original_tokens > sampled_tokens
 
 
 @pytest.mark.unit

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -60,6 +60,51 @@ def test_index_replaces_document_after_embeddings_are_ready():
     assert all(point["payload"]["document_id"] == 7 for point in upsert["points"])
 
 
+def test_index_batches_large_embedding_requests_without_reordering_chunks():
+    from app.utils.vector_index import QdrantVectorIndex, TextChunk
+
+    record = _file()
+    chunks = [
+        TextChunk(0, "first", 0, 600),
+        TextChunk(1, "second", 520, 1120),
+        TextChunk(2, "third", 1040, 1640),
+    ]
+    with (
+        patch("app.utils.vector_index.chunk_text", return_value=chunks),
+        patch(
+            "app.utils.vector_index.generate_embeddings",
+            side_effect=[[[1.0, 0.0], [2.0, 0.0]], [[3.0, 0.0]]],
+        ) as embed,
+        patch("app.utils.vector_index.settings.vector_embedding_batch_tokens", 1200),
+        patch("app.utils.vector_index.QdrantVectorIndex.ensure_collection"),
+        patch("app.utils.vector_index.QdrantVectorIndex._request") as request,
+    ):
+        assert QdrantVectorIndex().index_document(record) == 3
+
+    assert embed.call_args_list == [call(["first", "second"]), call(["third"])]
+    points = request.call_args_list[1].args[2]["points"]
+    assert [point["vector"] for point in points] == [[1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]
+
+
+def test_index_keeps_old_points_when_a_later_embedding_batch_fails():
+    from app.utils.vector_index import QdrantVectorIndex, TextChunk
+
+    chunks = [TextChunk(0, "first", 0, 600), TextChunk(1, "second", 600, 1200)]
+    with (
+        patch("app.utils.vector_index.chunk_text", return_value=chunks),
+        patch(
+            "app.utils.vector_index.generate_embeddings",
+            side_effect=[[[1.0, 0.0]], RuntimeError("provider unavailable")],
+        ),
+        patch("app.utils.vector_index.settings.vector_embedding_batch_tokens", 600),
+        patch("app.utils.vector_index.QdrantVectorIndex._request") as request,
+    ):
+        with pytest.raises(RuntimeError, match="provider unavailable"):
+            QdrantVectorIndex().index_document(_file())
+
+    request.assert_not_called()
+
+
 def test_index_skips_empty_text_and_rejects_incomplete_embedding_batches():
     from app.utils.vector_index import QdrantVectorIndex, TextChunk, VectorIndexError
 


### PR DESCRIPTION
Closes #1046

## What changed
- request bounded Dropbox corpus pages (default 10)
- pause/reschedule backfills at a configurable Celery queue high-watermark
- run coordinator tasks at low priority
- commit each queued document before advancing the Dropbox cursor
- document global defaults and per-integration overrides

## Verification
- Ruff check and format
- 7 corpus import tests
- 309 Dropbox corpus, Watch Folder, and Dropbox API tests

## Deployment boundary
Preprod only. Production remains pinned to the legacy image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dropbox imports now support configurable batching, task priority, and automatic pausing when processing queues are busy.
  * Long documents are sampled before metadata extraction to improve processing reliability.
  * Added configuration options for import backfill controls and metadata input limits.

* **Bug Fixes**
  * Improved file type detection compatibility across supported formats and library responses.

* **Documentation**
  * Updated configuration guidance for backfill processing and metadata limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->