### PR TITLE
Fix Qdrant indexing for large documents

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1146,6 +1146,15 @@ class Settings(BaseSettings):
             "Large documents are split across multiple requests to stay below provider request limits."
         ),
     )
+    vector_upsert_batch_size: int = Field(
+        default=100,
+        ge=1,
+        le=1000,
+        description=(
+            "Maximum number of Qdrant points sent in one upsert request. "
+            "Large documents are split across requests to stay below Qdrant payload limits."
+        ),
+    )
     vector_index_timeout_seconds: float = Field(
         default=30.0,
         gt=0,

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -3429,6 +3429,14 @@ SETTING_METADATA = {
         "required": False,
         "restart_required": False,
     },
+    "vector_upsert_batch_size": {
+        "category": "Knowledge Bridge",
+        "description": "Maximum number of Qdrant points sent in one upsert request.",
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
     "vector_index_timeout_seconds": {
         "category": "Knowledge Bridge",
         "description": "Timeout in seconds for Qdrant operations.",

--- a/app/utils/vector_index.py
+++ b/app/utils/vector_index.py
@@ -209,9 +209,20 @@ class QdrantVectorIndex:
         self.ensure_collection(len(vectors[0]))
 
         digest = content_hash(text)
+        index_version = hashlib.sha256(
+            (
+                f"{digest}:{settings.embedding_model}:"
+                f"{settings.vector_chunk_tokens}:{settings.vector_chunk_overlap_tokens}"
+            ).encode("utf-8")
+        ).hexdigest()
         points = []
         for chunk, vector in zip(chunks, vectors, strict=True):
-            point_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"docuelevate:{file_record.id}:{digest}:{chunk.index}"))
+            point_id = str(
+                uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"docuelevate:{file_record.id}:{index_version}:{chunk.index}",
+                )
+            )
             created_at = getattr(file_record, "created_at", None)
             points.append(
                 {
@@ -222,6 +233,7 @@ class QdrantVectorIndex:
                         "owner_id": file_record.owner_id,
                         "file_hash": file_record.filehash,
                         "content_hash": digest,
+                        "index_version": index_version,
                         "filename": file_record.original_filename,
                         "title": file_record.document_title,
                         "mime_type": file_record.mime_type,
@@ -235,18 +247,27 @@ class QdrantVectorIndex:
                 }
             )
 
-        # Generate every embedding before deleting old points.  A provider
-        # outage therefore leaves the last known-good index intact.
+        # Keep the last complete index live until every new batch is stored.
+        # Stable point IDs make retries idempotent; cleanup happens only after
+        # the complete replacement version has been written successfully.
+        batch_size = settings.vector_upsert_batch_size
+        for start in range(0, len(points), batch_size):
+            batch = points[start : start + batch_size]
+            self._request(
+                "PUT",
+                f"/collections/{self.collection}/points?wait=true",
+                {"points": batch},
+                expected=(200, 201),
+            )
         self._request(
             "POST",
             f"/collections/{self.collection}/points/delete?wait=true",
-            {"filter": {"must": [{"key": "document_id", "match": {"value": file_record.id}}]}},
-        )
-        self._request(
-            "PUT",
-            f"/collections/{self.collection}/points?wait=true",
-            {"points": points},
-            expected=(200, 201),
+            {
+                "filter": {
+                    "must": [{"key": "document_id", "match": {"value": file_record.id}}],
+                    "must_not": [{"key": "index_version", "match": {"value": index_version}}],
+                }
+            },
         )
         return len(points)
 

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -37,6 +37,7 @@ secret manager; do not store them in `.env` files committed to source control.
 | `VECTOR_INDEX_URL` | Internal Qdrant base URL. | `http://qdrant:6333` |
 | `VECTOR_INDEX_API_KEY` | Qdrant API key sent only to the internal service. | unset |
 | `VECTOR_INDEX_COLLECTION` | Qdrant collection for document chunks. | `docuelevate_documents` |
+| `VECTOR_UPSERT_BATCH_SIZE` | Maximum Qdrant points per upsert request. | `100` |
 | `VECTOR_CHUNK_TOKENS` | Target token count per chunk. | `600` |
 | `VECTOR_CHUNK_OVERLAP_TOKENS` | Token overlap between adjacent chunks. | `80` |
 | `VECTOR_EMBEDDING_BATCH_TOKENS` | Maximum aggregate tokens per embedding request; larger documents use multiple ordered requests. | `200000` |

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -52,12 +52,15 @@ def test_index_replaces_document_after_embeddings_are_ready():
 
     ensure.assert_called_once_with(2)
     assert request.call_args_list[0].args[0:2] == (
-        "POST",
-        "/collections/docuelevate_documents/points/delete?wait=true",
+        "PUT",
+        "/collections/docuelevate_documents/points?wait=true",
     )
-    upsert = request.call_args_list[1].args[2]
+    upsert = request.call_args_list[0].args[2]
     assert [point["payload"]["text"] for point in upsert["points"]] == ["first", "second"]
     assert all(point["payload"]["document_id"] == 7 for point in upsert["points"])
+    index_version = upsert["points"][0]["payload"]["index_version"]
+    cleanup = request.call_args_list[1].args[2]["filter"]
+    assert cleanup["must_not"] == [{"key": "index_version", "match": {"value": index_version}}]
 
 
 def test_index_batches_large_embedding_requests_without_reordering_chunks():
@@ -82,8 +85,63 @@ def test_index_batches_large_embedding_requests_without_reordering_chunks():
         assert QdrantVectorIndex().index_document(record) == 3
 
     assert embed.call_args_list == [call(["first", "second"]), call(["third"])]
-    points = request.call_args_list[1].args[2]["points"]
+    points = request.call_args_list[0].args[2]["points"]
     assert [point["vector"] for point in points] == [[1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]
+
+
+def test_index_batches_qdrant_upserts_without_reordering_points():
+    from app.utils.vector_index import QdrantVectorIndex, TextChunk
+
+    chunks = [
+        TextChunk(0, "first", 0, 5),
+        TextChunk(1, "second", 5, 10),
+        TextChunk(2, "third", 10, 15),
+    ]
+    with (
+        patch("app.utils.vector_index.chunk_text", return_value=chunks),
+        patch(
+            "app.utils.vector_index.generate_embeddings",
+            return_value=[[1.0, 0.0], [2.0, 0.0], [3.0, 0.0]],
+        ),
+        patch("app.utils.vector_index.settings.vector_upsert_batch_size", 2),
+        patch("app.utils.vector_index.QdrantVectorIndex.ensure_collection"),
+        patch("app.utils.vector_index.QdrantVectorIndex._request") as request,
+    ):
+        assert QdrantVectorIndex().index_document(_file()) == 3
+
+    assert [call.args[0] for call in request.call_args_list] == ["PUT", "PUT", "POST"]
+    assert [
+        point["payload"]["text"]
+        for upsert_call in request.call_args_list[:2]
+        for point in upsert_call.args[2]["points"]
+    ] == ["first", "second", "third"]
+
+
+def test_index_keeps_old_points_when_a_later_qdrant_upsert_fails():
+    from app.utils.vector_index import QdrantVectorIndex, TextChunk
+
+    chunks = [
+        TextChunk(0, "first", 0, 5),
+        TextChunk(1, "second", 5, 10),
+        TextChunk(2, "third", 10, 15),
+    ]
+    with (
+        patch("app.utils.vector_index.chunk_text", return_value=chunks),
+        patch(
+            "app.utils.vector_index.generate_embeddings",
+            return_value=[[1.0, 0.0], [2.0, 0.0], [3.0, 0.0]],
+        ),
+        patch("app.utils.vector_index.settings.vector_upsert_batch_size", 2),
+        patch("app.utils.vector_index.QdrantVectorIndex.ensure_collection"),
+        patch(
+            "app.utils.vector_index.QdrantVectorIndex._request",
+            side_effect=[SimpleNamespace(), RuntimeError("qdrant unavailable")],
+        ) as request,
+    ):
+        with pytest.raises(RuntimeError, match="qdrant unavailable"):
+            QdrantVectorIndex().index_document(_file())
+
+    assert [call.args[0] for call in request.call_args_list] == ["PUT", "PUT"]
 
 
 def test_index_keeps_old_points_when_a_later_embedding_batch_fails():


### PR DESCRIPTION
## Summary
- batch Qdrant point upserts so large documents stay below the service payload limit
- keep the last complete document index until every replacement batch succeeds
- add stable index versions and idempotent retries
- expose a live-reloadable `VECTOR_UPSERT_BATCH_SIZE` setting (default 100)

## Validation
- 17 vector indexing/destination tests passed
- 86 settings/configuration tests passed (1 skipped)
- Ruff passed
- mypy passed

## Deployment boundary
This fix will be deployed to preprod only. The production legacy image pin must remain unchanged.