### PR TITLE
Fix corpus backpressure after Celery prefetch

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -911,7 +911,7 @@ class Settings(BaseSettings):
         default=50,
         ge=1,
         description=(
-            "Pause corpus backfills when the total pending Celery queue depth reaches this value. Default: 50."
+            "Pause corpus backfills when queued plus worker-reserved Celery work reaches this value. Default: 50."
         ),
     )
     corpus_backfill_resume_delay_seconds: int = Field(

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -21,17 +21,29 @@ from app.utils.filename_utils import sanitize_filename
 logger = logging.getLogger(__name__)
 
 _CELERY_QUEUES = ("document_processor", "default", "celery")
+_REDIS_PRIORITY_SEPARATOR = "\x06\x16"
+_REDIS_PRIORITY_STEPS = range(10)
 
 
 def _pending_queue_depth() -> int | None:
-    """Return pending interactive pipeline work, failing open if Redis is unavailable."""
+    """Return queued plus worker-reserved pipeline work, failing open on Redis errors."""
     try:
         client = redis.Redis.from_url(
             settings.redis_url,
             socket_connect_timeout=2,
             socket_timeout=2,
         )
-        return sum(int(client.llen(queue)) for queue in _CELERY_QUEUES)
+        queue_keys = (
+            queue if priority == 0 else f"{queue}{_REDIS_PRIORITY_SEPARATOR}{priority}"
+            for queue in _CELERY_QUEUES
+            for priority in _REDIS_PRIORITY_STEPS
+        )
+        queued = sum(int(client.llen(queue_key)) for queue_key in queue_keys)
+        # Kombu moves Redis messages into this hash as soon as a worker
+        # reserves them. Counting it closes the prefetch gap where the visible
+        # lists are empty while dozens of tasks are active or reserved.
+        in_flight = int(client.hlen("unacked"))
+        return queued + in_flight
     except Exception:  # noqa: BLE001
         logger.warning("Could not inspect queue depth before corpus backfill", exc_info=True)
         return None

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -2171,7 +2171,7 @@ SETTING_METADATA = {
     },
     "corpus_backfill_queue_high_watermark": {
         "category": "Processing",
-        "description": "Pause corpus backfills at this total pending Celery queue depth (default: 50)",
+        "description": "Pause corpus backfills at this queued plus worker-reserved Celery depth (default: 50)",
         "type": "integer",
         "sensitive": False,
         "required": False,
@@ -2187,7 +2187,7 @@ SETTING_METADATA = {
     },
     "corpus_backfill_task_priority": {
         "category": "Processing",
-        "description": "Celery priority for corpus backfill coordinator tasks (default: 0)",
+        "description": "Celery priority for corpus backfill coordinator tasks (default: 9)",
         "type": "integer",
         "sensitive": False,
         "required": False,

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -75,7 +75,7 @@ Control how the `/processall` endpoint handles large batches of files to prevent
 | `PROCESSALL_THROTTLE_THRESHOLD`   | Number of files above which throttling is applied. Files <= threshold are processed immediately.  | `20`        |
 | `PROCESSALL_THROTTLE_DELAY`       | Delay in seconds between each task submission when throttling is active.                          | `3`         |
 | `CORPUS_BACKFILL_BATCH_SIZE` | Maximum provider entries requested per Dropbox corpus page. | `10` |
-| `CORPUS_BACKFILL_QUEUE_HIGH_WATERMARK` | Pause corpus backfills at this total pending Celery queue depth. | `50` |
+| `CORPUS_BACKFILL_QUEUE_HIGH_WATERMARK` | Pause corpus backfills at this queued plus worker-reserved Celery depth. | `50` |
 | `CORPUS_BACKFILL_RESUME_DELAY_SECONDS` | Seconds before a queue-limited backfill checks capacity again. | `30` |
 | `CORPUS_BACKFILL_TASK_PRIORITY` | Celery Redis priority for corpus coordinator tasks; `9` runs behind normal priority `0` work. | `9` |
 | `METADATA_MAX_INPUT_TOKENS` | Maximum document-text tokens sent to metadata extraction; keeps the beginning plus a short ending. | `8000` |

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -229,6 +229,21 @@ def test_dropbox_import_pauses_at_queue_high_watermark(db_session):
 
 
 @pytest.mark.unit
+def test_queue_depth_counts_priority_queues_and_worker_reserved_tasks():
+    redis_client = MagicMock()
+    redis_client.llen.side_effect = lambda key: 4 if key == "document_processor\x06\x169" else 0
+    redis_client.hlen.return_value = 6
+
+    with patch("app.tasks.dropbox_corpus_import.redis.Redis.from_url", return_value=redis_client):
+        from app.tasks.dropbox_corpus_import import _pending_queue_depth
+
+        assert _pending_queue_depth() == 10
+
+    assert redis_client.llen.call_count == 30
+    redis_client.hlen.assert_called_once_with("unacked")
+
+
+@pytest.mark.unit
 def test_dropbox_import_uses_configured_provider_batch_size(db_session):
     integration = _integration(db_session)
     integration.config = json.dumps({"backfill_batch_size": 7})


### PR DESCRIPTION
## Summary
- count Celery Redis priority queues, including non-default priority lists
- include Kombu `unacked` work that workers already reserved or started
- prevent Dropbox corpus import from seeing a false queue depth of zero after prefetch
- align setting and documentation wording, including the actual default priority 9

## Live preprod finding
The corpus coordinator observed queue depth 0 while 31 tasks were already active/reserved. This caused the resumed old Dropbox cursor to enqueue more work despite the high-watermark guard. The coordinator was stopped; durable intake rows make the processed portion idempotent.

## Validation
- 66 corpus/settings/configuration tests passed
- Ruff passed
- mypy passed

## Deployment boundary
Preprod only. Production must remain on the legacy evergreen image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved corpus backfill queue monitoring by including priority queues and worker-reserved tasks.
  * Backfill pausing now triggers based on the combined queued and worker-reserved workload.

* **Documentation**
  * Clarified queue threshold behavior and the default task priority in configuration documentation.

* **Tests**
  * Added coverage for priority queue and worker-reserved task counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->