### PR TITLE
feat: guard corpus backfills with a daily LLM token budget

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -932,7 +932,7 @@ class Settings(BaseSettings):
         default=0,
         ge=0,
         description=(
-            "Conservative UTC-day token budget reserved by corpus imports before queuing documents. "
+            "Conservative, database-backed UTC-day token budget reserved by corpus imports before queuing documents. "
             "Set to 0 to disable the budget. Interactive uploads are not affected. Default: 0."
         ),
     )

--- a/app/config.py
+++ b/app/config.py
@@ -928,6 +928,22 @@ class Settings(BaseSettings):
             "so the default 9 keeps backfills behind interactive work."
         ),
     )
+    corpus_backfill_daily_llm_token_budget: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Conservative UTC-day token budget reserved by corpus imports before queuing documents. "
+            "Set to 0 to disable the budget. Interactive uploads are not affected. Default: 0."
+        ),
+    )
+    corpus_backfill_llm_token_reservation_per_document: int = Field(
+        default=10000,
+        ge=1,
+        description=(
+            "LLM tokens conservatively reserved for each corpus document. The effective reservation is never "
+            "lower than METADATA_MAX_INPUT_TOKENS plus prompt/output headroom. Default: 10000."
+        ),
+    )
 
     # Client-side upload throttling settings (applied when uploading files via the web UI)
     upload_concurrency: int = Field(

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,19 @@
 # app/models.py
 
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
 
 from app.database import Base
 
@@ -171,6 +184,16 @@ class DropboxImportObject(Base):
     task_id = Column(String, nullable=True)
     state = Column(String(20), nullable=False, default="queued", server_default="queued")
     imported_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class CorpusLlmDailyUsage(Base):
+    """Durable conservative LLM reservations for corpus imports by UTC day."""
+
+    __tablename__ = "corpus_llm_daily_usage"
+
+    usage_date = Column(Date, primary_key=True)
+    reserved_tokens = Column(BigInteger, nullable=False, default=0, server_default="0")
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
 
 class FileProcessingStep(Base):

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -26,6 +26,7 @@ _CELERY_QUEUES = ("document_processor", "default", "celery")
 _REDIS_PRIORITY_SEPARATOR = "\x06\x16"
 _REDIS_PRIORITY_STEPS = range(10)
 _METADATA_PROMPT_OUTPUT_HEADROOM = 1500
+_MAX_BUDGET_RECHECK_SECONDS = 15 * 60
 
 
 class CorpusDailyBudgetReached(RuntimeError):
@@ -464,14 +465,19 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
                 job.state = "queued"
                 job.error = str(exc)
                 db.commit()
-                schedule_dropbox_corpus_import(job.id, countdown=exc.retry_after_seconds)
+                # Redis' default Celery visibility timeout is shorter than a
+                # possible wait to the next UTC day. Short rechecks avoid a
+                # long-lived ETA task being restored and delivered twice.
+                recheck_in = min(exc.retry_after_seconds, _MAX_BUDGET_RECHECK_SECONDS)
+                schedule_dropbox_corpus_import(job.id, countdown=recheck_in)
                 return {
                     "status": "paused",
                     "reason": "daily_llm_token_budget",
                     "job_id": job.id,
                     "tokens_reserved": exc.used,
                     "token_budget": exc.budget,
-                    "resume_in_seconds": exc.retry_after_seconds,
+                    "resume_in_seconds": recheck_in,
+                    "budget_resets_in_seconds": exc.retry_after_seconds,
                 }
             except CorpusDailyBudgetUnavailable as exc:
                 job.discovered -= 1

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -4,15 +4,16 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import redis
 from celery.result import AsyncResult
+from sqlalchemy.exc import IntegrityError
 
 from app.celery_app import celery
 from app.config import settings
 from app.database import SessionLocal
-from app.models import DocumentIntake, DropboxImportJob, DropboxImportObject, UserIntegration
+from app.models import CorpusLlmDailyUsage, DocumentIntake, DropboxImportJob, DropboxImportObject, UserIntegration
 from app.tasks.retry_config import BaseTaskWithRetry
 from app.utils.allowed_types import ALLOWED_EXTENSIONS
 from app.utils.dropbox_credentials import resolve_dropbox_oauth_credentials
@@ -24,7 +25,6 @@ logger = logging.getLogger(__name__)
 _CELERY_QUEUES = ("document_processor", "default", "celery")
 _REDIS_PRIORITY_SEPARATOR = "\x06\x16"
 _REDIS_PRIORITY_STEPS = range(10)
-_CORPUS_TOKEN_BUDGET_KEY_PREFIX = "docuelevate:corpus:llm-tokens"
 _METADATA_PROMPT_OUTPUT_HEADROOM = 1500
 
 
@@ -47,13 +47,13 @@ def _next_utc_reset(now: datetime) -> datetime:
     return datetime.combine(tomorrow, datetime.min.time(), tzinfo=timezone.utc)
 
 
-def _reserve_corpus_llm_tokens() -> tuple[str | None, int]:
-    """Atomically reserve conservative LLM capacity for one corpus document.
+def _reserve_corpus_llm_tokens() -> tuple[date | None, int]:
+    """Atomically reserve durable LLM capacity for one corpus document.
 
     A zero budget disables the guard. When enabled, Redis is deliberately
-    fail-closed: losing the counter must pause background imports rather than
-    silently allowing billable overage. Interactive uploads do not use this
-    path.
+    not involved because it is an intentionally ephemeral task broker. The
+    database reservation survives Redis restarts and fails closed if durable
+    accounting is unavailable. Interactive uploads do not use this path.
     """
     budget = int(settings.corpus_backfill_daily_llm_token_budget)
     if budget <= 0:
@@ -65,42 +65,75 @@ def _reserve_corpus_llm_tokens() -> tuple[str | None, int]:
     )
     now = datetime.now(timezone.utc)
     reset_at = _next_utc_reset(now)
-    key = f"{_CORPUS_TOKEN_BUDGET_KEY_PREFIX}:{now.date().isoformat()}"
+    usage_date = now.date()
     try:
-        client = redis.Redis.from_url(
-            settings.redis_url,
-            socket_connect_timeout=2,
-            socket_timeout=2,
+        # The guarded UPDATE is atomic in PostgreSQL and SQLite. If two
+        # workers see a missing UTC-day row, one insert wins and the other
+        # retries the guarded UPDATE.
+        for _attempt in range(2):
+            with SessionLocal() as budget_db:
+                updated = (
+                    budget_db.query(CorpusLlmDailyUsage)
+                    .filter(
+                        CorpusLlmDailyUsage.usage_date == usage_date,
+                        CorpusLlmDailyUsage.reserved_tokens <= budget - reservation,
+                    )
+                    .update(
+                        {CorpusLlmDailyUsage.reserved_tokens: CorpusLlmDailyUsage.reserved_tokens + reservation},
+                        synchronize_session=False,
+                    )
+                )
+                if updated:
+                    budget_db.commit()
+                    return usage_date, reservation
+
+                existing = (
+                    budget_db.query(CorpusLlmDailyUsage).filter(CorpusLlmDailyUsage.usage_date == usage_date).first()
+                )
+                if existing is not None or reservation > budget:
+                    used = int(existing.reserved_tokens) if existing is not None else 0
+                    retry_after = max(1, int((reset_at - now).total_seconds()) + 5)
+                    raise CorpusDailyBudgetReached(
+                        used=used,
+                        budget=budget,
+                        retry_after_seconds=retry_after,
+                    )
+
+                budget_db.add(CorpusLlmDailyUsage(usage_date=usage_date, reserved_tokens=reservation))
+                try:
+                    budget_db.commit()
+                    return usage_date, reservation
+                except IntegrityError:
+                    budget_db.rollback()
+                    # A concurrent worker may have created the row. Retry the
+                    # guarded UPDATE once; other failures become fail-closed.
+                    continue
+        raise CorpusDailyBudgetUnavailable(
+            "Could not establish durable corpus LLM token accounting after a concurrent update"
         )
-        used = int(client.incrby(key, reservation))
-        client.expireat(key, reset_at)
-        if used > budget:
-            client.decrby(key, reservation)
-            retry_after = max(1, int((reset_at - now).total_seconds()) + 5)
-            raise CorpusDailyBudgetReached(
-                used=used - reservation,
-                budget=budget,
-                retry_after_seconds=retry_after,
-            )
-        return key, reservation
     except CorpusDailyBudgetReached:
+        raise
+    except CorpusDailyBudgetUnavailable:
         raise
     except Exception as exc:  # noqa: BLE001
         raise CorpusDailyBudgetUnavailable("Could not reserve the enabled corpus LLM token budget") from exc
 
 
-def _release_corpus_llm_tokens(reservation: tuple[str | None, int]) -> None:
+def _release_corpus_llm_tokens(reservation: tuple[date | None, int]) -> None:
     """Release a reservation when no pipeline task was queued."""
-    key, amount = reservation
-    if not key or amount <= 0:
+    usage_date, amount = reservation
+    if usage_date is None or amount <= 0:
         return
     try:
-        client = redis.Redis.from_url(
-            settings.redis_url,
-            socket_connect_timeout=2,
-            socket_timeout=2,
-        )
-        client.decrby(key, amount)
+        with SessionLocal() as budget_db:
+            budget_db.query(CorpusLlmDailyUsage).filter(
+                CorpusLlmDailyUsage.usage_date == usage_date,
+                CorpusLlmDailyUsage.reserved_tokens >= amount,
+            ).update(
+                {CorpusLlmDailyUsage.reserved_tokens: CorpusLlmDailyUsage.reserved_tokens - amount},
+                synchronize_session=False,
+            )
+            budget_db.commit()
     except Exception:  # noqa: BLE001
         # Keeping a conservative reservation only delays background work; it
         # is safer than losing track of usage and allowing an overage.

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import redis
 from celery.result import AsyncResult
@@ -23,6 +24,87 @@ logger = logging.getLogger(__name__)
 _CELERY_QUEUES = ("document_processor", "default", "celery")
 _REDIS_PRIORITY_SEPARATOR = "\x06\x16"
 _REDIS_PRIORITY_STEPS = range(10)
+_CORPUS_TOKEN_BUDGET_KEY_PREFIX = "docuelevate:corpus:llm-tokens"
+_METADATA_PROMPT_OUTPUT_HEADROOM = 1500
+
+
+class CorpusDailyBudgetReached(RuntimeError):
+    """Raised when a corpus import must wait for the next UTC token window."""
+
+    def __init__(self, *, used: int, budget: int, retry_after_seconds: int) -> None:
+        super().__init__(f"Daily corpus LLM token budget reached ({used}/{budget})")
+        self.used = used
+        self.budget = budget
+        self.retry_after_seconds = retry_after_seconds
+
+
+class CorpusDailyBudgetUnavailable(RuntimeError):
+    """Raised when an enabled cost guard cannot reserve tokens safely."""
+
+
+def _next_utc_reset(now: datetime) -> datetime:
+    tomorrow = now.date() + timedelta(days=1)
+    return datetime.combine(tomorrow, datetime.min.time(), tzinfo=timezone.utc)
+
+
+def _reserve_corpus_llm_tokens() -> tuple[str | None, int]:
+    """Atomically reserve conservative LLM capacity for one corpus document.
+
+    A zero budget disables the guard. When enabled, Redis is deliberately
+    fail-closed: losing the counter must pause background imports rather than
+    silently allowing billable overage. Interactive uploads do not use this
+    path.
+    """
+    budget = int(settings.corpus_backfill_daily_llm_token_budget)
+    if budget <= 0:
+        return None, 0
+
+    reservation = max(
+        int(settings.corpus_backfill_llm_token_reservation_per_document),
+        int(settings.metadata_max_input_tokens) + _METADATA_PROMPT_OUTPUT_HEADROOM,
+    )
+    now = datetime.now(timezone.utc)
+    reset_at = _next_utc_reset(now)
+    key = f"{_CORPUS_TOKEN_BUDGET_KEY_PREFIX}:{now.date().isoformat()}"
+    try:
+        client = redis.Redis.from_url(
+            settings.redis_url,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+        used = int(client.incrby(key, reservation))
+        client.expireat(key, reset_at)
+        if used > budget:
+            client.decrby(key, reservation)
+            retry_after = max(1, int((reset_at - now).total_seconds()) + 5)
+            raise CorpusDailyBudgetReached(
+                used=used - reservation,
+                budget=budget,
+                retry_after_seconds=retry_after,
+            )
+        return key, reservation
+    except CorpusDailyBudgetReached:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise CorpusDailyBudgetUnavailable("Could not reserve the enabled corpus LLM token budget") from exc
+
+
+def _release_corpus_llm_tokens(reservation: tuple[str | None, int]) -> None:
+    """Release a reservation when no pipeline task was queued."""
+    key, amount = reservation
+    if not key or amount <= 0:
+        return
+    try:
+        client = redis.Redis.from_url(
+            settings.redis_url,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+        client.decrby(key, amount)
+    except Exception:  # noqa: BLE001
+        # Keeping a conservative reservation only delays background work; it
+        # is safer than losing track of usage and allowing an overage.
+        logger.warning("Could not release unused corpus LLM token reservation", exc_info=True)
 
 
 def _pending_queue_depth() -> int | None:
@@ -213,6 +295,7 @@ def _import_file(db, job: DropboxImportJob, integration: UserIntegration, client
             db.add(imported)
         return "skipped"
 
+    reservation = _reserve_corpus_llm_tokens()
     target_path = os.path.join(settings.workdir, f"dropbox_{integration.id}_{uuid.uuid4().hex}{extension}")
     temporary_path = f"{target_path}.part"
     queued = False
@@ -270,6 +353,8 @@ def _import_file(db, job: DropboxImportJob, integration: UserIntegration, client
             os.remove(temporary_path)
         if not queued and os.path.exists(target_path):
             os.remove(target_path)
+        if not queued:
+            _release_corpus_llm_tokens(reservation)
 
 
 @celery.task(base=BaseTaskWithRetry, bind=True, name="run_dropbox_corpus_import")
@@ -341,6 +426,38 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
             job.discovered += 1
             try:
                 outcome = _import_file(db, job, integration, client, entry)
+            except CorpusDailyBudgetReached as exc:
+                job.discovered -= 1
+                job.state = "queued"
+                job.error = str(exc)
+                db.commit()
+                schedule_dropbox_corpus_import(job.id, countdown=exc.retry_after_seconds)
+                return {
+                    "status": "paused",
+                    "reason": "daily_llm_token_budget",
+                    "job_id": job.id,
+                    "tokens_reserved": exc.used,
+                    "token_budget": exc.budget,
+                    "resume_in_seconds": exc.retry_after_seconds,
+                }
+            except CorpusDailyBudgetUnavailable as exc:
+                job.discovered -= 1
+                job.state = "queued"
+                job.error = str(exc)
+                db.commit()
+                delay = _bounded_config_int(
+                    config,
+                    "backfill_resume_delay_seconds",
+                    settings.corpus_backfill_resume_delay_seconds,
+                    minimum=1,
+                )
+                schedule_dropbox_corpus_import(job.id, countdown=delay)
+                return {
+                    "status": "paused",
+                    "reason": "daily_llm_token_budget_unavailable",
+                    "job_id": job.id,
+                    "resume_in_seconds": delay,
+                }
             except Exception as exc:
                 logger.exception("Dropbox import failed for %s: %s", entry.path_display, exc)
                 outcome = "failed"

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -2196,7 +2196,8 @@ SETTING_METADATA = {
     "corpus_backfill_daily_llm_token_budget": {
         "category": "Processing",
         "description": (
-            "Conservative UTC-day LLM token budget for corpus imports only; 0 disables the budget (default: 0)"
+            "Conservative database-backed UTC-day LLM token budget for corpus imports only; "
+            "0 disables the budget (default: 0)"
         ),
         "type": "integer",
         "sensitive": False,

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -2193,6 +2193,26 @@ SETTING_METADATA = {
         "required": False,
         "restart_required": False,
     },
+    "corpus_backfill_daily_llm_token_budget": {
+        "category": "Processing",
+        "description": (
+            "Conservative UTC-day LLM token budget for corpus imports only; 0 disables the budget (default: 0)"
+        ),
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
+    "corpus_backfill_llm_token_reservation_per_document": {
+        "category": "Processing",
+        "description": (
+            "Tokens reserved per queued corpus document, with automatic metadata prompt headroom (default: 10000)"
+        ),
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
     "metadata_max_input_tokens": {
         "category": "Processing",
         "description": (

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -78,7 +78,7 @@ Control how the `/processall` endpoint handles large batches of files to prevent
 | `CORPUS_BACKFILL_QUEUE_HIGH_WATERMARK` | Pause corpus backfills at this queued plus worker-reserved Celery depth. | `50` |
 | `CORPUS_BACKFILL_RESUME_DELAY_SECONDS` | Seconds before a queue-limited backfill checks capacity again. | `30` |
 | `CORPUS_BACKFILL_TASK_PRIORITY` | Celery Redis priority for corpus coordinator tasks; `9` runs behind normal priority `0` work. | `9` |
-| `CORPUS_BACKFILL_DAILY_LLM_TOKEN_BUDGET` | Conservative UTC-day token budget for corpus imports only; `0` disables the budget. | `0` |
+| `CORPUS_BACKFILL_DAILY_LLM_TOKEN_BUDGET` | Conservative database-backed UTC-day token budget for corpus imports only; survives broker restarts; `0` disables it. | `0` |
 | `CORPUS_BACKFILL_LLM_TOKEN_RESERVATION_PER_DOCUMENT` | Tokens reserved per queued corpus document; metadata prompt/output headroom is enforced automatically. | `10000` |
 | `METADATA_MAX_INPUT_TOKENS` | Maximum document-text tokens sent to metadata extraction; keeps the beginning plus a short ending. | `8000` |
 

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -78,6 +78,8 @@ Control how the `/processall` endpoint handles large batches of files to prevent
 | `CORPUS_BACKFILL_QUEUE_HIGH_WATERMARK` | Pause corpus backfills at this queued plus worker-reserved Celery depth. | `50` |
 | `CORPUS_BACKFILL_RESUME_DELAY_SECONDS` | Seconds before a queue-limited backfill checks capacity again. | `30` |
 | `CORPUS_BACKFILL_TASK_PRIORITY` | Celery Redis priority for corpus coordinator tasks; `9` runs behind normal priority `0` work. | `9` |
+| `CORPUS_BACKFILL_DAILY_LLM_TOKEN_BUDGET` | Conservative UTC-day token budget for corpus imports only; `0` disables the budget. | `0` |
+| `CORPUS_BACKFILL_LLM_TOKEN_RESERVATION_PER_DOCUMENT` | Tokens reserved per queued corpus document; metadata prompt/output headroom is enforced automatically. | `10000` |
 | `METADATA_MAX_INPUT_TOKENS` | Maximum document-text tokens sent to metadata extraction; keeps the beginning plus a short ending. | `8000` |
 
 Dropbox Watch Folder integrations may override the first three defaults with

--- a/migrations/versions/054_corpus_llm_daily_usage.py
+++ b/migrations/versions/054_corpus_llm_daily_usage.py
@@ -1,0 +1,29 @@
+"""Add durable daily corpus LLM token reservations.
+
+Revision ID: 054_corpus_llm_daily_usage
+Revises: 053_onboarding_journey
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "054_corpus_llm_daily_usage"
+down_revision = "053_onboarding_journey"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if "corpus_llm_daily_usage" in sa.inspect(op.get_bind()).get_table_names():
+        return
+    op.create_table(
+        "corpus_llm_daily_usage",
+        sa.Column("usage_date", sa.Date(), primary_key=True),
+        sa.Column("reserved_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    if "corpus_llm_daily_usage" in sa.inspect(op.get_bind()).get_table_names():
+        op.drop_table("corpus_llm_daily_usage")

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.models import DropboxImportJob, IntegrationDirection, IntegrationType, UserIntegration
+from app.models import CorpusLlmDailyUsage, DropboxImportJob, IntegrationDirection, IntegrationType, UserIntegration
 from app.utils.encryption import encrypt_value
 
 
@@ -245,38 +245,34 @@ def test_queue_depth_counts_priority_queues_and_worker_reserved_tasks():
 
 
 @pytest.mark.unit
-def test_corpus_token_budget_reserves_with_prompt_headroom():
-    redis_client = MagicMock()
-    redis_client.incrby.return_value = 9500
-
+def test_corpus_token_budget_reserves_with_prompt_headroom(db_session):
     with (
         patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_daily_llm_token_budget", 9_000_000),
         patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_llm_token_reservation_per_document", 1),
         patch("app.tasks.dropbox_corpus_import.settings.metadata_max_input_tokens", 8000),
-        patch("app.tasks.dropbox_corpus_import.redis.Redis.from_url", return_value=redis_client),
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
     ):
         from app.tasks.dropbox_corpus_import import _reserve_corpus_llm_tokens
 
-        key, reservation = _reserve_corpus_llm_tokens()
+        usage_date, reservation = _reserve_corpus_llm_tokens()
 
-    assert key is not None and key.startswith("docuelevate:corpus:llm-tokens:")
+    assert usage_date is not None
     assert reservation == 9500
-    redis_client.incrby.assert_called_once_with(key, 9500)
-    redis_client.expireat.assert_called_once()
-    redis_client.decrby.assert_not_called()
+    usage = db_session.query(CorpusLlmDailyUsage).filter_by(usage_date=usage_date).one()
+    assert usage.reserved_tokens == 9500
 
 
 @pytest.mark.unit
-def test_corpus_token_budget_rejects_request_that_crosses_limit():
-    redis_client = MagicMock()
-    redis_client.incrby.return_value = 9_005_000
+def test_corpus_token_budget_rejects_request_that_crosses_limit(db_session):
     frozen_now = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)
+    db_session.add(CorpusLlmDailyUsage(usage_date=frozen_now.date(), reserved_tokens=8_995_000))
+    db_session.commit()
 
     with (
         patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_daily_llm_token_budget", 9_000_000),
         patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_llm_token_reservation_per_document", 10_000),
         patch("app.tasks.dropbox_corpus_import.settings.metadata_max_input_tokens", 8000),
-        patch("app.tasks.dropbox_corpus_import.redis.Redis.from_url", return_value=redis_client),
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
         patch("app.tasks.dropbox_corpus_import.datetime") as clock,
     ):
         clock.now.return_value = frozen_now
@@ -290,17 +286,15 @@ def test_corpus_token_budget_rejects_request_that_crosses_limit():
     assert error.value.used == 8_995_000
     assert error.value.budget == 9_000_000
     assert error.value.retry_after_seconds == 43_205
-    redis_client.decrby.assert_called_once()
+    usage = db_session.query(CorpusLlmDailyUsage).filter_by(usage_date=frozen_now.date()).one()
+    assert usage.reserved_tokens == 8_995_000
 
 
 @pytest.mark.unit
 def test_corpus_token_budget_fails_closed_when_counter_is_unavailable():
-    redis_client = MagicMock()
-    redis_client.incrby.side_effect = ConnectionError("redis unavailable")
-
     with (
         patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_daily_llm_token_budget", 9_000_000),
-        patch("app.tasks.dropbox_corpus_import.redis.Redis.from_url", return_value=redis_client),
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", side_effect=RuntimeError("database unavailable")),
     ):
         from app.tasks.dropbox_corpus_import import CorpusDailyBudgetUnavailable, _reserve_corpus_llm_tokens
 

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -2,6 +2,7 @@
 
 import json
 from contextlib import nullcontext
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -241,6 +242,99 @@ def test_queue_depth_counts_priority_queues_and_worker_reserved_tasks():
 
     assert redis_client.llen.call_count == 30
     redis_client.hlen.assert_called_once_with("unacked")
+
+
+@pytest.mark.unit
+def test_corpus_token_budget_reserves_with_prompt_headroom():
+    redis_client = MagicMock()
+    redis_client.incrby.return_value = 9500
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_daily_llm_token_budget", 9_000_000),
+        patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_llm_token_reservation_per_document", 1),
+        patch("app.tasks.dropbox_corpus_import.settings.metadata_max_input_tokens", 8000),
+        patch("app.tasks.dropbox_corpus_import.redis.Redis.from_url", return_value=redis_client),
+    ):
+        from app.tasks.dropbox_corpus_import import _reserve_corpus_llm_tokens
+
+        key, reservation = _reserve_corpus_llm_tokens()
+
+    assert key is not None and key.startswith("docuelevate:corpus:llm-tokens:")
+    assert reservation == 9500
+    redis_client.incrby.assert_called_once_with(key, 9500)
+    redis_client.expireat.assert_called_once()
+    redis_client.decrby.assert_not_called()
+
+
+@pytest.mark.unit
+def test_corpus_token_budget_rejects_request_that_crosses_limit():
+    redis_client = MagicMock()
+    redis_client.incrby.return_value = 9_005_000
+    frozen_now = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_daily_llm_token_budget", 9_000_000),
+        patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_llm_token_reservation_per_document", 10_000),
+        patch("app.tasks.dropbox_corpus_import.settings.metadata_max_input_tokens", 8000),
+        patch("app.tasks.dropbox_corpus_import.redis.Redis.from_url", return_value=redis_client),
+        patch("app.tasks.dropbox_corpus_import.datetime") as clock,
+    ):
+        clock.now.return_value = frozen_now
+        clock.combine.side_effect = datetime.combine
+        clock.min = datetime.min
+        from app.tasks.dropbox_corpus_import import CorpusDailyBudgetReached, _reserve_corpus_llm_tokens
+
+        with pytest.raises(CorpusDailyBudgetReached) as error:
+            _reserve_corpus_llm_tokens()
+
+    assert error.value.used == 8_995_000
+    assert error.value.budget == 9_000_000
+    assert error.value.retry_after_seconds == 43_205
+    redis_client.decrby.assert_called_once()
+
+
+@pytest.mark.unit
+def test_dropbox_import_pauses_until_utc_reset_at_daily_token_budget(db_session):
+    integration = _integration(db_session)
+    job = DropboxImportJob(
+        id="job-token-budget",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Documents",
+    )
+    db_session.add(job)
+    db_session.commit()
+    entry = SimpleNamespace(name="invoice.pdf")
+    page = SimpleNamespace(entries=[entry], cursor="cursor-1", has_more=True)
+    dropbox_client = MagicMock()
+    dropbox_client.files_list_folder.return_value = page
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.tasks.dropbox_corpus_import._dropbox_client", return_value=dropbox_client),
+        patch("dropbox.files.FileMetadata", SimpleNamespace),
+        patch("app.tasks.dropbox_corpus_import._import_file") as import_file,
+        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_import") as schedule,
+    ):
+        from app.tasks.dropbox_corpus_import import CorpusDailyBudgetReached, run_dropbox_corpus_import
+
+        import_file.side_effect = CorpusDailyBudgetReached(used=8_990_000, budget=9_000_000, retry_after_seconds=3600)
+        result = run_dropbox_corpus_import.run(job.id)
+
+    db_session.refresh(job)
+    assert result == {
+        "status": "paused",
+        "reason": "daily_llm_token_budget",
+        "job_id": job.id,
+        "tokens_reserved": 8_990_000,
+        "token_budget": 9_000_000,
+        "resume_in_seconds": 3600,
+    }
+    assert job.state == "queued"
+    assert job.cursor is None
+    assert job.discovered == 0
+    schedule.assert_called_once_with(job.id, countdown=3600)
 
 
 @pytest.mark.unit

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -338,12 +338,13 @@ def test_dropbox_import_pauses_until_utc_reset_at_daily_token_budget(db_session)
         "job_id": job.id,
         "tokens_reserved": 8_990_000,
         "token_budget": 9_000_000,
-        "resume_in_seconds": 3600,
+        "resume_in_seconds": 900,
+        "budget_resets_in_seconds": 3600,
     }
     assert job.state == "queued"
     assert job.cursor is None
     assert job.discovered == 0
-    schedule.assert_called_once_with(job.id, countdown=3600)
+    schedule.assert_called_once_with(job.id, countdown=900)
 
 
 @pytest.mark.unit

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -294,6 +294,21 @@ def test_corpus_token_budget_rejects_request_that_crosses_limit():
 
 
 @pytest.mark.unit
+def test_corpus_token_budget_fails_closed_when_counter_is_unavailable():
+    redis_client = MagicMock()
+    redis_client.incrby.side_effect = ConnectionError("redis unavailable")
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_daily_llm_token_budget", 9_000_000),
+        patch("app.tasks.dropbox_corpus_import.redis.Redis.from_url", return_value=redis_client),
+    ):
+        from app.tasks.dropbox_corpus_import import CorpusDailyBudgetUnavailable, _reserve_corpus_llm_tokens
+
+        with pytest.raises(CorpusDailyBudgetUnavailable, match="Could not reserve"):
+            _reserve_corpus_llm_tokens()
+
+
+@pytest.mark.unit
 def test_dropbox_import_pauses_until_utc_reset_at_daily_token_budget(db_session):
     integration = _integration(db_session)
     job = DropboxImportJob(


### PR DESCRIPTION
Closes #1055

## What changed

- adds a configurable conservative LLM token budget per UTC day for corpus imports
- persists daily reservations in the application database so ephemeral Redis restarts cannot reset the allowance
- atomically reserves metadata input plus prompt/output headroom before a new corpus document enters the pipeline
- pauses when the next document would cross the budget and rechecks at most every 15 minutes until the UTC reset
- avoids long-lived Celery ETA tasks that could exceed Redis' visibility timeout and be redelivered
- fails closed when durable budget accounting is unavailable
- keeps interactive uploads outside this guard
- exposes both settings through database-backed live configuration and aligns the configuration guide
- adds a reversible migration for the daily reservation ledger

## Why

The Dropbox corpus contains tens of thousands of documents. Queue backpressure protects the worker, but without a separate durable cost guard the importer could cross the OpenAI organization's complimentary daily shared-token allowance and create normal billable usage. Redis is intentionally ephemeral in this deployment and is therefore unsuitable as the authoritative cost ledger.

## Validation

- 80 relevant tests passed, 8 skipped
- focused corpus suite: 22 passed
- Ruff lint and format passed
- mypy passed for the changed application modules
- Alembic reports one migration head
- migration upgrade and downgrade verified on an isolated database

## Deployment intent

Generic installations remain unchanged because the default budget is `0` (disabled). Preprod will be configured through the database with a conservative daily budget after deployment; later setting changes are live and do not require an API or worker restart.