### PR TITLE
fix: sync release and image versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,14 @@ jobs:
               fi
               sleep 5
             done
+            if [[ -z "${NEW_VERSION}" ]]; then
+              REMOTE_VERSION="$(git show origin/main:VERSION | tr -d '\n')"
+              LOCAL_VERSION="$(tr -d '\n' < VERSION)"
+              if [[ "${REMOTE_VERSION}" != "${LOCAL_VERSION}" ]]; then
+                echo "Release metadata advanced to ${REMOTE_VERSION}, but no matching release tag was resolved"
+                exit 1
+              fi
+            fi
           fi
           ./scripts/generate_build_metadata.sh
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,9 +155,30 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          # The release workflow creates an annotated version tag on a direct
+          # child of this merge commit. Fetching tags lets the image build use
+          # that authoritative version instead of the previous VERSION file.
+          fetch-depth: 0
+          fetch-tags: true
       - name: Generate Build Metadata
         run: |
           chmod +x scripts/generate_build_metadata.sh
+          chmod +x scripts/resolve_release_version.sh
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            # Semantic Release runs in parallel and normally finishes well
+            # before tests unlock this build. Retry briefly to close the race.
+            for attempt in {1..12}; do
+              git fetch --force --tags origin
+              NEW_VERSION="$(scripts/resolve_release_version.sh "${GITHUB_SHA}")"
+              if [[ -n "${NEW_VERSION}" ]]; then
+                export NEW_VERSION
+                echo "Using release version ${NEW_VERSION} for image metadata"
+                break
+              fi
+              sleep 5
+            done
+          fi
           ./scripts/generate_build_metadata.sh
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/scripts/resolve_release_version.sh
+++ b/scripts/resolve_release_version.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Resolve the release version created for one exact merge commit.
+
+set -euo pipefail
+
+head_sha="${1:-$(git rev-parse HEAD)}"
+
+# Semantic Release creates an annotated tag on a release commit whose direct
+# parent is the merge commit that triggered the release workflow. Matching the
+# parent prevents a concurrent newer release from being assigned to this build.
+while IFS= read -r tag; do
+  tag_commit="$(git rev-parse "${tag}^{commit}")"
+  read -r -a commit_line <<<"$(git rev-list --parents -n 1 "${tag_commit}")"
+  for parent_sha in "${commit_line[@]:1}"; do
+    if [[ "${parent_sha}" == "${head_sha}" ]]; then
+      printf '%s\n' "${tag#v}"
+      exit 0
+    fi
+  done
+done < <(git tag --list 'v[0-9]*' --sort=-version:refname)
+
+# No tag means the commit did not create a release (for example, a docs-only
+# change). The caller deliberately falls back to the checked-in VERSION file.
+exit 0

--- a/scripts/resolve_release_version.sh
+++ b/scripts/resolve_release_version.sh
@@ -3,7 +3,8 @@
 
 set -euo pipefail
 
-head_sha="${1:-$(git rev-parse HEAD)}"
+head_ref="${1:-HEAD}"
+head_sha="$(git rev-parse "${head_ref}^{commit}")"
 
 # Semantic Release creates an annotated tag on a release commit whose direct
 # parent is the merge commit that triggered the release workflow. Matching the

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -1,0 +1,51 @@
+"""Integration coverage for release tag to image version resolution."""
+
+import subprocess
+from pathlib import Path
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()  # noqa: S603, S607
+
+
+def _commit(repo: Path, message: str, filename: str) -> str:
+    (repo / filename).write_text(message, encoding="utf-8")
+    _git(repo, "add", filename)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def test_release_version_matches_tag_created_for_merge_commit(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "ci@example.invalid")
+    _git(repo, "config", "user.name", "CI")
+    _commit(repo, "initial", "VERSION")
+    merge_sha = _commit(repo, "fix: searchable documents", "feature.txt")
+    _commit(repo, "chore(release): 1.2.3", "CHANGELOG.md")
+    _git(repo, "tag", "-a", "v1.2.3", "-m", "v1.2.3")
+    _commit(repo, "newer metadata commit", "BUILD_DATE")
+
+    script = Path(__file__).parents[1] / "scripts" / "resolve_release_version.sh"
+    version = subprocess.check_output(  # noqa: S603
+        ["/bin/bash", str(script), merge_sha], cwd=repo, text=True
+    ).strip()
+
+    assert version == "1.2.3"
+
+
+def test_release_version_is_empty_without_a_direct_release_child(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "ci@example.invalid")
+    _git(repo, "config", "user.name", "CI")
+    unrelated_sha = _commit(repo, "docs: no release", "README.md")
+
+    script = Path(__file__).parents[1] / "scripts" / "resolve_release_version.sh"
+    version = subprocess.check_output(  # noqa: S603
+        ["/bin/bash", str(script), unrelated_sha], cwd=repo, text=True
+    ).strip()
+
+    assert version == ""

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -3,6 +3,8 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 def _git(repo: Path, *args: str) -> str:
     return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()  # noqa: S603, S607
@@ -15,37 +17,39 @@ def _commit(repo: Path, message: str, filename: str) -> str:
     return _git(repo, "rev-parse", "HEAD")
 
 
-def test_release_version_matches_tag_created_for_merge_commit(tmp_path):
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(repo, "init")
     _git(repo, "config", "user.email", "ci@example.invalid")
     _git(repo, "config", "user.name", "CI")
-    _commit(repo, "initial", "VERSION")
-    merge_sha = _commit(repo, "fix: searchable documents", "feature.txt")
-    _commit(repo, "chore(release): 1.2.3", "CHANGELOG.md")
-    _git(repo, "tag", "-a", "v1.2.3", "-m", "v1.2.3")
-    _commit(repo, "newer metadata commit", "BUILD_DATE")
+    return repo
+
+
+@pytest.mark.integration
+def test_release_version_matches_tag_created_for_merge_commit(git_repo: Path):
+    _commit(git_repo, "initial", "VERSION")
+    merge_sha = _commit(git_repo, "fix: searchable documents", "feature.txt")
+    _commit(git_repo, "chore(release): 1.2.3", "CHANGELOG.md")
+    _git(git_repo, "tag", "-a", "v1.2.3", "-m", "v1.2.3")
+    _commit(git_repo, "newer metadata commit", "BUILD_DATE")
 
     script = Path(__file__).parents[1] / "scripts" / "resolve_release_version.sh"
     version = subprocess.check_output(  # noqa: S603
-        ["/bin/bash", str(script), merge_sha], cwd=repo, text=True
+        ["/bin/bash", str(script), merge_sha[:8]], cwd=git_repo, text=True
     ).strip()
 
     assert version == "1.2.3"
 
 
-def test_release_version_is_empty_without_a_direct_release_child(tmp_path):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git(repo, "init")
-    _git(repo, "config", "user.email", "ci@example.invalid")
-    _git(repo, "config", "user.name", "CI")
-    unrelated_sha = _commit(repo, "docs: no release", "README.md")
+@pytest.mark.integration
+def test_release_version_is_empty_without_a_direct_release_child(git_repo: Path):
+    unrelated_sha = _commit(git_repo, "docs: no release", "README.md")
 
     script = Path(__file__).parents[1] / "scripts" / "resolve_release_version.sh"
     version = subprocess.check_output(  # noqa: S603
-        ["/bin/bash", str(script), unrelated_sha], cwd=repo, text=True
+        ["/bin/bash", str(script), unrelated_sha], cwd=git_repo, text=True
     ).strip()
 
     assert version == ""


### PR DESCRIPTION
Closes #1052

## What changed

- fetches the complete tag history before building a main image
- resolves the annotated Semantic Release tag created specifically for the merge commit being built
- normalizes full and abbreviated commit SHAs before comparison
- feeds that authoritative release number into the existing build-metadata generator
- retries briefly to close the parallel CI/Semantic Release race
- fails instead of publishing stale metadata when `origin/main` has already advanced to a newer released version
- keeps non-release and develop builds on the checked-in `VERSION` fallback

## Why

The main CI image build and Semantic Release start from the same merge. Semantic Release creates the new version on a direct child commit, while the image build previously embedded the older checked-in `VERSION`. This made Preprod report one version behind its release.

## Validation

- two marked Git integration tests cover a matching release tag, abbreviated SHA input, and a non-release commit
- the resolver maps merge `adf25a68` to release `0.183.2` on the real repository history
- Ruff lint and format checks pass
- workflow YAML parses successfully
- shell syntax and diff checks pass
- all actionable review feedback was implemented and revalidated

## Deployment scope

Preprod only. Production remains pinned to the legacy image.