### PR TITLE
fix: label images with release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
         run: |
           chmod +x scripts/generate_build_metadata.sh
           chmod +x scripts/resolve_release_version.sh
+          RESOLVED_RELEASE_VERSION=""
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
             # Semantic Release runs in parallel and normally finishes well
             # before tests unlock this build. Retry briefly to close the race.
@@ -174,6 +175,7 @@ jobs:
               NEW_VERSION="$(scripts/resolve_release_version.sh "${GITHUB_SHA}")"
               if [[ -n "${NEW_VERSION}" ]]; then
                 export NEW_VERSION
+                RESOLVED_RELEASE_VERSION="${NEW_VERSION}"
                 echo "Using release version ${NEW_VERSION} for image metadata"
                 break
               fi
@@ -190,6 +192,7 @@ jobs:
           fi
           ./scripts/generate_build_metadata.sh
           echo "version=$(tr -d '\n' < VERSION)" >> "$GITHUB_OUTPUT"
+          echo "release_version=${RESOLVED_RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to Docker Hub
@@ -214,7 +217,7 @@ jobs:
             type=ref,event=branch
             type=sha,prefix={{branch}}-
             type=semver,pattern={{version}}
-            type=raw,value=${{ steps.build_metadata.outputs.version }},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ steps.build_metadata.outputs.release_version }},enable=${{ steps.build_metadata.outputs.release_version != '' }}
             type=raw,value=latest,enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.version=${{ steps.build_metadata.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: Generate Build Metadata
+        id: build_metadata
         run: |
           chmod +x scripts/generate_build_metadata.sh
           chmod +x scripts/resolve_release_version.sh
@@ -188,6 +189,7 @@ jobs:
             fi
           fi
           ./scripts/generate_build_metadata.sh
+          echo "version=$(tr -d '\n' < VERSION)" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to Docker Hub
@@ -212,7 +214,10 @@ jobs:
             type=ref,event=branch
             type=sha,prefix={{branch}}-
             type=semver,pattern={{version}}
+            type=raw,value=${{ steps.build_metadata.outputs.version }},enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.version=${{ steps.build_metadata.outputs.version }}
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
         with:

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -53,3 +53,11 @@ def test_release_version_is_empty_without_a_direct_release_child(git_repo: Path)
     ).strip()
 
     assert version == ""
+
+
+def test_image_tags_and_oci_label_use_resolved_release_version():
+    workflow = (Path(__file__).parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    resolved_version = "${{ steps.build_metadata.outputs.version }}"
+
+    assert f"type=raw,value={resolved_version}" in workflow
+    assert f"org.opencontainers.image.version={resolved_version}" in workflow

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -55,9 +55,12 @@ def test_release_version_is_empty_without_a_direct_release_child(git_repo: Path)
     assert version == ""
 
 
+@pytest.mark.unit
 def test_image_tags_and_oci_label_use_resolved_release_version():
     workflow = (Path(__file__).parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     resolved_version = "${{ steps.build_metadata.outputs.version }}"
+    release_version = "${{ steps.build_metadata.outputs.release_version }}"
 
-    assert f"type=raw,value={resolved_version}" in workflow
+    assert f"type=raw,value={release_version}" in workflow
+    assert "enable=${{ steps.build_metadata.outputs.release_version != '' }}" in workflow
     assert f"org.opencontainers.image.version={resolved_version}" in workflow


### PR DESCRIPTION
Closes #1052

## What changed

- exports the authoritative resolved release version as a workflow output
- publishes a matching immutable container version tag only when that exact build produced a release
- prevents docs/chore/test main builds from moving an existing release tag
- overrides `org.opencontainers.image.version` with the runtime version embedded in the image
- adds a source-level workflow contract test for release tag gating and OCI metadata

## Why

The real `v0.183.3` build proved that PR #1068 fixed the embedded runtime version (`VERSION=0.183.3`, `GIT_SHA=33e248e`) but Docker metadata still labeled the image as `version=main` and did not publish a `0.183.3` image tag. Review also identified that blindly tagging every main build would make release tags mutable; this version gates the immutable tag on an actually resolved release.

## Validation

- 3 explicitly marked release-version tests pass
- resolver maps real merge `33e248e` to `0.183.3`
- workflow contract verifies release-tag gating and OCI version label mapping
- Ruff lint and format pass
- workflow YAML parses successfully
- all actionable review feedback was implemented

## Deployment scope

Preprod only. Production remains pinned to the legacy image.