### PR TITLE
fix: include exact metadata in knowledge search

### DIFF
--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
+from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
 from app.auth import require_login
@@ -19,6 +20,8 @@ router = APIRouter(prefix="/knowledge", tags=["knowledge"])
 DbSession = Annotated[Session, Depends(get_db)]
 
 _SEARCH_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+_METADATA_CANDIDATE_LIMIT = 250
+_METADATA_EXCERPT_CHARS = 2_400
 
 
 class KnowledgeSearchRequest(BaseModel):
@@ -57,6 +60,65 @@ def _search_token_weight(token: str) -> float:
     return 1.0
 
 
+def _escaped_like_pattern(token: str) -> str:
+    """Return a literal SQL LIKE substring pattern for user-provided text."""
+    escaped = token.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
+def _metadata_candidates(db: Session, request: Request, query: str) -> list[FileRecord]:
+    """Find owner-scoped exact metadata candidates outside Qdrant's semantic window."""
+    normalized_query = _normalized_search_text(query)
+    query_tokens = sorted(
+        set(normalized_query.split()),
+        key=lambda token: (_search_token_weight(token), len(token), token),
+        reverse=True,
+    )[:12]
+    if not query_tokens:
+        return []
+
+    # Require every distinctive query term to occur in either authoritative
+    # title or filename. This stays selective for a large multi-user corpus,
+    # while the raw equality clauses preserve exact punctuation-heavy names.
+    token_clauses = []
+    for token in query_tokens:
+        pattern = _escaped_like_pattern(token)
+        token_clauses.append(
+            or_(
+                FileRecord.document_title.ilike(pattern, escape="\\"),
+                FileRecord.original_filename.ilike(pattern, escape="\\"),
+            )
+        )
+    raw_query = query.strip().casefold()
+    metadata_match = or_(
+        func.lower(FileRecord.document_title) == raw_query,
+        func.lower(FileRecord.original_filename) == raw_query,
+        and_(*token_clauses),
+    )
+    records = db.query(FileRecord).filter(
+        metadata_match,
+        FileRecord.ocr_text.isnot(None),
+        func.length(func.trim(FileRecord.ocr_text)) > 0,
+    )
+    return apply_owner_filter(records, request).limit(_METADATA_CANDIDATE_LIMIT).all()
+
+
+def _metadata_hit(record: FileRecord) -> dict[str, Any]:
+    """Build a bounded, source-backed fallback passage for a metadata match."""
+    text = (record.ocr_text or "").strip()[:_METADATA_EXCERPT_CHARS]
+    return {
+        "score": 0.0,
+        "payload": {
+            "document_id": record.id,
+            "text": text,
+            "chunk_index": None,
+            "chunk_count": None,
+            "token_start": None,
+            "token_end": None,
+        },
+    }
+
+
 def _hybrid_search_score(query: str, hit: dict[str, Any], record: FileRecord) -> tuple[float, float]:
     """Blend semantic similarity with exact evidence from authoritative metadata."""
     try:
@@ -73,8 +135,20 @@ def _hybrid_search_score(query: str, hit: dict[str, Any], record: FileRecord) ->
     token_coverage = matched_weight / query_weight if query_weight else 0.0
 
     normalized_title = _normalized_search_text(record.document_title)
-    exact_title_bonus = 1.0 if normalized_query and normalized_query in normalized_title else 0.0
-    hybrid_score = min(1.0, semantic_score + (0.30 * token_coverage) + (0.10 * exact_title_bonus))
+    normalized_filename = _normalized_search_text(record.original_filename)
+    exact_title_bonus = 0.60 if normalized_query and normalized_query == normalized_title else 0.0
+    exact_filename_bonus = 0.65 if normalized_query and normalized_query == normalized_filename else 0.0
+    phrase_bonus = (
+        0.15
+        if normalized_query
+        and not exact_title_bonus
+        and (normalized_query in normalized_title or normalized_query in normalized_filename)
+        else 0.0
+    )
+    hybrid_score = min(
+        1.0,
+        semantic_score + (0.30 * token_coverage) + exact_title_bonus + exact_filename_bonus + phrase_bonus,
+    )
     return hybrid_score, semantic_score
 
 
@@ -106,6 +180,9 @@ def search_knowledge(request: Request, body: KnowledgeSearchRequest, db: DbSessi
         if isinstance(value, int):
             document_ids.append(value)
     accessible = _accessible_records(db, request, list(set(document_ids)))
+    metadata_records = _metadata_candidates(db, request, body.query)
+    for record in metadata_records:
+        accessible[record.id] = record
 
     ranked_hits = []
     for original_rank, hit in enumerate(raw_hits):
@@ -115,12 +192,20 @@ def search_knowledge(request: Request, body: KnowledgeSearchRequest, db: DbSessi
         if record is None:
             continue
         hybrid_score, semantic_score = _hybrid_search_score(body.query, hit, record)
-        ranked_hits.append((hybrid_score, semantic_score, -original_rank, hit, record))
+        ranked_hits.append((hybrid_score, semantic_score, -original_rank, hit, record, "semantic"))
+
+    semantic_document_ids = set(document_ids)
+    for metadata_rank, record in enumerate(metadata_records):
+        if record.id in semantic_document_ids:
+            continue
+        hit = _metadata_hit(record)
+        hybrid_score, semantic_score = _hybrid_search_score(body.query, hit, record)
+        ranked_hits.append((hybrid_score, semantic_score, -metadata_rank, hit, record, "metadata"))
 
     ranked_hits.sort(key=lambda item: item[:3], reverse=True)
     results = []
     seen_documents: set[int] = set()
-    for hybrid_score, semantic_score, _original_rank, hit, record in ranked_hits:
+    for hybrid_score, semantic_score, _original_rank, hit, record, match_source in ranked_hits:
         if record.id in seen_documents:
             continue
         seen_documents.add(record.id)
@@ -130,6 +215,7 @@ def search_knowledge(request: Request, body: KnowledgeSearchRequest, db: DbSessi
                 "document_id": record.id,
                 "score": hybrid_score,
                 "semantic_score": semantic_score,
+                "match_source": match_source,
                 "text": payload.get("text", ""),
                 "chunk_index": payload.get("chunk_index"),
                 "chunk_count": payload.get("chunk_count"),

--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -89,9 +89,12 @@ def _metadata_candidates(db: Session, request: Request, query: str) -> list[File
         )
         weighted_clauses.append((clause, _search_token_weight(token)))
     raw_query = query.strip().lower()
-    metadata_match = or_(
+    exact_match = or_(
         func.lower(FileRecord.document_title) == raw_query,
         func.lower(FileRecord.original_filename) == raw_query,
+    )
+    metadata_match = or_(
+        exact_match,
         *(clause for clause, _weight in weighted_clauses),
     )
     match_weight = sum(
@@ -105,7 +108,7 @@ def _metadata_candidates(db: Session, request: Request, query: str) -> list[File
     )
     return (
         apply_owner_filter(records, request)
-        .order_by(match_weight.desc(), FileRecord.id.asc())
+        .order_by(case((exact_match, 1), else_=0).desc(), match_weight.desc(), FileRecord.id.asc())
         .limit(_METADATA_CANDIDATE_LIMIT)
         .all()
     )

--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -89,7 +89,7 @@ def _metadata_candidates(db: Session, request: Request, query: str) -> list[File
                 FileRecord.original_filename.ilike(pattern, escape="\\"),
             )
         )
-    raw_query = query.strip().casefold()
+    raw_query = query.strip().lower()
     metadata_match = or_(
         func.lower(FileRecord.document_title) == raw_query,
         func.lower(FileRecord.original_filename) == raw_query,
@@ -100,7 +100,7 @@ def _metadata_candidates(db: Session, request: Request, query: str) -> list[File
         FileRecord.ocr_text.isnot(None),
         func.length(func.trim(FileRecord.ocr_text)) > 0,
     )
-    return apply_owner_filter(records, request).limit(_METADATA_CANDIDATE_LIMIT).all()
+    return apply_owner_filter(records, request).order_by(FileRecord.id.asc()).limit(_METADATA_CANDIDATE_LIMIT).all()
 
 
 def _metadata_hit(record: FileRecord) -> dict[str, Any]:
@@ -141,7 +141,7 @@ def _hybrid_search_score(query: str, hit: dict[str, Any], record: FileRecord) ->
     phrase_bonus = (
         0.15
         if normalized_query
-        and not exact_title_bonus
+        and not (exact_title_bonus or exact_filename_bonus)
         and (normalized_query in normalized_title or normalized_query in normalized_filename)
         else 0.0
     )

--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
-from sqlalchemy import and_, func, or_
+from sqlalchemy import case, func, or_
 from sqlalchemy.orm import Session
 
 from app.auth import require_login
@@ -77,30 +77,38 @@ def _metadata_candidates(db: Session, request: Request, query: str) -> list[File
     if not query_tokens:
         return []
 
-    # Require every distinctive query term to occur in either authoritative
-    # title or filename. This stays selective for a large multi-user corpus,
-    # while the raw equality clauses preserve exact punctuation-heavy names.
-    token_clauses = []
+    # Rank metadata candidates by weighted query-term coverage. Using an OR
+    # here deliberately supports natural questions such as "summarize X.pdf";
+    # the bounded limit and weighted SQL ordering keep the scan selective.
+    weighted_clauses = []
     for token in query_tokens:
         pattern = _escaped_like_pattern(token)
-        token_clauses.append(
-            or_(
-                FileRecord.document_title.ilike(pattern, escape="\\"),
-                FileRecord.original_filename.ilike(pattern, escape="\\"),
-            )
+        clause = or_(
+            FileRecord.document_title.ilike(pattern, escape="\\"),
+            FileRecord.original_filename.ilike(pattern, escape="\\"),
         )
+        weighted_clauses.append((clause, _search_token_weight(token)))
     raw_query = query.strip().lower()
     metadata_match = or_(
         func.lower(FileRecord.document_title) == raw_query,
         func.lower(FileRecord.original_filename) == raw_query,
-        and_(*token_clauses),
+        *(clause for clause, _weight in weighted_clauses),
+    )
+    match_weight = sum(
+        (case((clause, weight), else_=0.0) for clause, weight in weighted_clauses),
+        start=0.0,
     )
     records = db.query(FileRecord).filter(
         metadata_match,
         FileRecord.ocr_text.isnot(None),
         func.length(func.trim(FileRecord.ocr_text)) > 0,
     )
-    return apply_owner_filter(records, request).order_by(FileRecord.id.asc()).limit(_METADATA_CANDIDATE_LIMIT).all()
+    return (
+        apply_owner_filter(records, request)
+        .order_by(match_weight.desc(), FileRecord.id.asc())
+        .limit(_METADATA_CANDIDATE_LIMIT)
+        .all()
+    )
 
 
 def _metadata_hit(record: FileRecord) -> dict[str, Any]:
@@ -136,8 +144,10 @@ def _hybrid_search_score(query: str, hit: dict[str, Any], record: FileRecord) ->
 
     normalized_title = _normalized_search_text(record.document_title)
     normalized_filename = _normalized_search_text(record.original_filename)
-    exact_title_bonus = 0.60 if normalized_query and normalized_query == normalized_title else 0.0
-    exact_filename_bonus = 0.65 if normalized_query and normalized_query == normalized_filename else 0.0
+    exact_title_bonus = 0.60 if normalized_query and normalized_title and normalized_title in normalized_query else 0.0
+    exact_filename_bonus = (
+        0.65 if normalized_query and normalized_filename and normalized_filename in normalized_query else 0.0
+    )
     phrase_bonus = (
         0.15
         if normalized_query

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -598,3 +598,38 @@ def test_metadata_candidates_handle_unicode_exact_names_in_stable_order(db_sessi
     candidates = _metadata_candidates(db_session, request, "Straße.pdf")
 
     assert [record.id for record in candidates] == [26, 27]
+
+
+def test_metadata_candidates_put_exact_name_before_lower_id_partial_match(db_session):
+    partial = FileRecord(
+        id=28,
+        owner_id=None,
+        filehash="partial-name",
+        original_filename="report-final.pdf",
+        document_title="Final report",
+        local_filename="/tmp/partial.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="Partial source text",
+    )
+    exact = FileRecord(
+        id=29,
+        owner_id=None,
+        filehash="exact-name",
+        original_filename="report.pdf",
+        document_title="Report",
+        local_filename="/tmp/exact.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="Exact source text",
+    )
+    db_session.add_all([partial, exact])
+    db_session.commit()
+    request = Request({"type": "http", "headers": []})
+    request.scope["session"] = {}
+
+    from app.api.knowledge import _metadata_candidates
+
+    candidates = _metadata_candidates(db_session, request, "report.pdf")
+
+    assert [record.id for record in candidates] == [29, 28]

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -412,3 +412,145 @@ def test_search_reranks_exact_metadata_and_deduplicates_documents(client, db_ses
         limit=50,
         score_threshold=0.25,
     )
+
+
+def test_search_unions_exact_filename_outside_semantic_candidates(client, db_session):
+    exact = FileRecord(
+        id=20,
+        owner_id=None,
+        filehash="filename-exact",
+        original_filename="Posteingang_0007.pdf",
+        document_title="Deutsche Bank Kontoauszug Dezember 2010",
+        local_filename="/tmp/Posteingang_0007.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="Source-backed account statement text " * 200,
+    )
+    semantic_only = FileRecord(
+        id=21,
+        owner_id=None,
+        filehash="semantic-only",
+        original_filename="mobile-invoice.pdf",
+        document_title="Mobile phone invoice",
+        local_filename="/tmp/mobile-invoice.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="Unrelated semantic passage",
+    )
+    db_session.add_all([exact, semantic_only])
+    db_session.commit()
+    hits = [
+        {
+            "score": 0.52,
+            "payload": {
+                "document_id": 21,
+                "text": "Unrelated semantic passage",
+                "chunk_index": 0,
+            },
+        }
+    ]
+
+    with (
+        patch("app.api.knowledge.settings.vector_index_enabled", True),
+        patch("app.utils.vector_index.QdrantVectorIndex.search", return_value=hits),
+    ):
+        response = client.post(
+            "/api/knowledge/search",
+            json={"query": "Posteingang_0007.pdf", "limit": 2},
+        )
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert [result["document_id"] for result in results] == [20, 21]
+    assert results[0]["semantic_score"] == 0.0
+    assert results[0]["match_source"] == "metadata"
+    assert results[0]["source_url"] == "/files/20"
+    assert 0 < len(results[0]["text"]) <= 2400
+
+
+def test_search_unions_and_prioritizes_exact_title_without_vector_hit(client, db_session):
+    exact = FileRecord(
+        id=22,
+        owner_id=None,
+        filehash="title-exact",
+        original_filename="scan.pdf",
+        document_title="Deutsche Bank Kontoauszug Dezember 2010",
+        local_filename="/tmp/scan.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="Exact title source text",
+    )
+    semantic_only = FileRecord(
+        id=23,
+        owner_id=None,
+        filehash="title-semantic",
+        original_filename="similar.pdf",
+        document_title="Kontoauszug Deutsche Bank Christian Louis",
+        local_filename="/tmp/similar.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="Similar source text",
+    )
+    db_session.add_all([exact, semantic_only])
+    db_session.commit()
+    hits = [
+        {
+            "score": 0.74,
+            "payload": {
+                "document_id": 23,
+                "text": "Similar source text",
+                "chunk_index": 0,
+            },
+        }
+    ]
+
+    with (
+        patch("app.api.knowledge.settings.vector_index_enabled", True),
+        patch("app.utils.vector_index.QdrantVectorIndex.search", return_value=hits),
+    ):
+        response = client.post(
+            "/api/knowledge/search",
+            json={"query": "Deutsche Bank Kontoauszug Dezember 2010", "limit": 2},
+        )
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert [result["document_id"] for result in results] == [22, 23]
+    assert results[0]["score"] > results[1]["score"]
+    assert results[0]["match_source"] == "metadata"
+
+
+def test_metadata_candidates_preserve_owner_isolation(db_session):
+    own = FileRecord(
+        id=24,
+        owner_id="alice@example.com",
+        filehash="alice-exact",
+        original_filename="Posteingang_0007.pdf",
+        document_title="Alice statement",
+        local_filename="/tmp/alice.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="Alice source text",
+    )
+    other = FileRecord(
+        id=25,
+        owner_id="bob@example.com",
+        filehash="bob-exact",
+        original_filename="Posteingang_0007.pdf",
+        document_title="Bob statement",
+        local_filename="/tmp/bob.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="Bob source text",
+    )
+    db_session.add_all([own, other])
+    db_session.commit()
+    request = Request({"type": "http", "headers": []})
+    request.scope["session"] = {"user": {"email": "alice@example.com"}}
+
+    with patch("app.utils.user_scope.settings.multi_user_enabled", True):
+        from app.api.knowledge import _metadata_candidates
+
+        candidates = _metadata_candidates(db_session, request, "Posteingang_0007.pdf")
+
+    assert [record.id for record in candidates] == [24]

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -463,6 +463,7 @@ def test_search_unions_exact_filename_outside_semantic_candidates(client, db_ses
     results = response.json()["results"]
     assert [result["document_id"] for result in results] == [20, 21]
     assert results[0]["semantic_score"] == 0.0
+    assert results[0]["score"] == pytest.approx(0.95)
     assert results[0]["match_source"] == "metadata"
     assert results[0]["source_url"] == "/files/20"
     assert 0 < len(results[0]["text"]) <= 2400
@@ -554,3 +555,38 @@ def test_metadata_candidates_preserve_owner_isolation(db_session):
         candidates = _metadata_candidates(db_session, request, "Posteingang_0007.pdf")
 
     assert [record.id for record in candidates] == [24]
+
+
+def test_metadata_candidates_handle_unicode_exact_names_in_stable_order(db_session):
+    later = FileRecord(
+        id=27,
+        owner_id=None,
+        filehash="unicode-later",
+        original_filename="Straße.pdf",
+        document_title="Archive copy",
+        local_filename="/tmp/later.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="Later source text",
+    )
+    earlier = FileRecord(
+        id=26,
+        owner_id=None,
+        filehash="unicode-earlier",
+        original_filename="Straße.pdf",
+        document_title="Original copy",
+        local_filename="/tmp/earlier.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="Earlier source text",
+    )
+    db_session.add_all([later, earlier])
+    db_session.commit()
+    request = Request({"type": "http", "headers": []})
+    request.scope["session"] = {}
+
+    from app.api.knowledge import _metadata_candidates
+
+    candidates = _metadata_candidates(db_session, request, "Straße.pdf")
+
+    assert [record.id for record in candidates] == [26, 27]

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -454,19 +454,27 @@ def test_search_unions_exact_filename_outside_semantic_candidates(client, db_ses
         patch("app.api.knowledge.settings.vector_index_enabled", True),
         patch("app.utils.vector_index.QdrantVectorIndex.search", return_value=hits),
     ):
-        response = client.post(
+        exact_response = client.post(
             "/api/knowledge/search",
             json={"query": "Posteingang_0007.pdf", "limit": 2},
         )
+        embedded_response = client.post(
+            "/api/knowledge/search",
+            json={"query": "summarize Posteingang_0007.pdf", "limit": 2},
+        )
 
-    assert response.status_code == 200
-    results = response.json()["results"]
+    assert exact_response.status_code == 200
+    results = exact_response.json()["results"]
     assert [result["document_id"] for result in results] == [20, 21]
     assert results[0]["semantic_score"] == 0.0
     assert results[0]["score"] == pytest.approx(0.95)
     assert results[0]["match_source"] == "metadata"
     assert results[0]["source_url"] == "/files/20"
     assert 0 < len(results[0]["text"]) <= 2400
+    assert embedded_response.status_code == 200
+    embedded_results = embedded_response.json()["results"]
+    assert embedded_results[0]["document_id"] == 20
+    assert embedded_results[0]["score"] >= 0.8
 
 
 def test_search_unions_and_prioritizes_exact_title_without_vector_hit(client, db_session):


### PR DESCRIPTION
## Summary

- union owner-scoped exact title and filename candidates with Qdrant semantic candidates
- rank exact metadata deterministically while preserving semantic scores
- return bounded, source-backed OCR excerpts for metadata-only matches
- retain one result per document and expose whether a match came from semantic or metadata retrieval

## Live problem reproduced

On Preprod v0.183.4, `Posteingang_0007.pdf` did not return document 988 because it was outside Qdrant's semantic candidate window.

## Validation

- `17 passed` in `tests/test_vector_knowledge.py`
- full Ruff lint passed for `app/` and `tests/`
- full Ruff format check passed for `app/` and `tests/`
- `git diff --check` passed

Closes #1070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Knowledge search now supplements semantic results with OCR and document metadata, improving discovery through exact title and filename matches.
  - Search results use combined relevance signals to prioritize strong exact or phrase matches.
  - Results indicate whether a match came from semantic search or metadata.

- **Bug Fixes**
  - Improved search coverage when relevant documents are not returned by semantic matching.
  - Maintained access restrictions so users only see authorized documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->