### PR TITLE
Resume Dropbox corpus pages without recounting

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -158,6 +158,7 @@ class DropboxImportJob(Base):
     owner_id = Column(String, nullable=False, index=True)
     root_path = Column(String, nullable=False)
     cursor = Column(Text, nullable=True)
+    page_offset = Column(Integer, nullable=False, default=0, server_default="0")
     state = Column(String(20), nullable=False, default="queued", server_default="queued", index=True)
     discovered = Column(Integer, nullable=False, default=0, server_default="0")
     downloaded = Column(Integer, nullable=False, default=0, server_default="0")

--- a/app/models.py
+++ b/app/models.py
@@ -158,7 +158,7 @@ class DropboxImportJob(Base):
     owner_id = Column(String, nullable=False, index=True)
     root_path = Column(String, nullable=False)
     cursor = Column(Text, nullable=True)
-    page_offset = Column(Integer, nullable=False, default=0, server_default="0")
+    page_entry_keys = Column(Text, nullable=False, default="[]", server_default="[]")
     state = Column(String(20), nullable=False, default="queued", server_default="queued", index=True)
     discovered = Column(Integer, nullable=False, default=0, server_default="0")
     downloaded = Column(Integer, nullable=False, default=0, server_default="0")

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -286,6 +286,33 @@ def _dropbox_client(integration: UserIntegration):
     )
 
 
+def _load_page_entry_keys(job: DropboxImportJob) -> set[str]:
+    """Load stable identities already committed within the current Dropbox page."""
+    try:
+        values = json.loads(job.page_entry_keys or "[]")
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise RuntimeError("Saved Dropbox page progress is not valid JSON") from exc
+    if not isinstance(values, list) or not all(isinstance(value, str) and value for value in values):
+        raise RuntimeError("Saved Dropbox page progress must be a list of entry identities")
+    return set(values)
+
+
+def _dropbox_file_key(entry) -> str:
+    """Return an immutable identity for one Dropbox file revision."""
+    file_id = str(getattr(entry, "id", "") or "").strip()
+    revision = str(getattr(entry, "rev", "") or "").strip()
+    if not file_id or not revision:
+        raise RuntimeError("Dropbox file metadata is missing its stable id or revision")
+    return f"{file_id}:{revision}"
+
+
+def _fail_import_job(db, job: DropboxImportJob, message: str) -> None:
+    """Persist a terminal coordinator error before surfacing it to Celery."""
+    job.state = "failed"
+    job.error = message
+    db.commit()
+
+
 def _import_file(db, job: DropboxImportJob, integration: UserIntegration, client, entry) -> str:
     """Import one Dropbox FileMetadata and return queued/skipped/failed."""
     filename = sanitize_filename(entry.name) or "document"
@@ -454,16 +481,21 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
             )
             page = client.files_list_folder(root, recursive=True, include_deleted=False, limit=batch_size)
 
-        page_offset = int(job.page_offset or 0)
-        if page_offset < 0 or page_offset > len(page.entries):
-            raise RuntimeError(f"Saved Dropbox page offset {page_offset} is invalid for {len(page.entries)} entries")
+        try:
+            committed_entry_keys = _load_page_entry_keys(job)
+        except RuntimeError as exc:
+            _fail_import_job(db, job, str(exc))
+            raise
 
-        for entry_index, entry in enumerate(page.entries):
-            if entry_index < page_offset:
-                continue
+        for entry in page.entries:
             if not isinstance(entry, dropbox.files.FileMetadata):
-                job.page_offset = entry_index + 1
-                db.commit()
+                continue
+            try:
+                entry_key = _dropbox_file_key(entry)
+            except RuntimeError as exc:
+                _fail_import_job(db, job, str(exc))
+                raise
+            if entry_key in committed_entry_keys:
                 continue
             job.discovered += 1
             try:
@@ -515,16 +547,16 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
                 job.skipped += 1
             else:
                 job.failed += 1
-            job.page_offset = entry_index + 1
+            committed_entry_keys.add(entry_key)
+            job.page_entry_keys = json.dumps(sorted(committed_entry_keys))
             # Persist each enqueued document before moving on. If the worker is
-            # interrupted, Dropbox returns the same page and idempotency skips
-            # the already committed entries instead of creating orphan tasks.
-            # The offset also prevents budget rechecks from recounting that
-            # committed prefix before the page cursor can advance.
+            # interrupted, stable file-revision identities prevent recounting
+            # committed entries. Unlike a numeric offset, this remains safe if
+            # the Dropbox page changes between budget rechecks.
             db.commit()
 
         job.cursor = page.cursor
-        job.page_offset = 0
+        job.page_entry_keys = "[]"
         job.state = "running" if page.has_more else "completed"
         db.commit()
         result = {

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -454,8 +454,16 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
             )
             page = client.files_list_folder(root, recursive=True, include_deleted=False, limit=batch_size)
 
-        for entry in page.entries:
+        page_offset = int(job.page_offset or 0)
+        if page_offset < 0 or page_offset > len(page.entries):
+            raise RuntimeError(f"Saved Dropbox page offset {page_offset} is invalid for {len(page.entries)} entries")
+
+        for entry_index, entry in enumerate(page.entries):
+            if entry_index < page_offset:
+                continue
             if not isinstance(entry, dropbox.files.FileMetadata):
+                job.page_offset = entry_index + 1
+                db.commit()
                 continue
             job.discovered += 1
             try:
@@ -507,12 +515,16 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
                 job.skipped += 1
             else:
                 job.failed += 1
+            job.page_offset = entry_index + 1
             # Persist each enqueued document before moving on. If the worker is
             # interrupted, Dropbox returns the same page and idempotency skips
             # the already committed entries instead of creating orphan tasks.
+            # The offset also prevents budget rechecks from recounting that
+            # committed prefix before the page cursor can advance.
             db.commit()
 
         job.cursor = page.cursor
+        job.page_offset = 0
         job.state = "running" if page.has_more else "completed"
         db.commit()
         result = {

--- a/migrations/versions/055_dropbox_import_page_entries.py
+++ b/migrations/versions/055_dropbox_import_page_entries.py
@@ -1,13 +1,13 @@
-"""Persist the current Dropbox result-page offset.
+"""Persist committed Dropbox result-page entries.
 
-Revision ID: 055_dropbox_import_page_offset
+Revision ID: 055_dropbox_import_page_entries
 Revises: 054_corpus_llm_daily_usage
 """
 
 import sqlalchemy as sa
 from alembic import op
 
-revision = "055_dropbox_import_page_offset"
+revision = "055_dropbox_import_page_entries"
 down_revision = "054_corpus_llm_daily_usage"
 branch_labels = None
 depends_on = None
@@ -18,10 +18,10 @@ def upgrade() -> None:
     if "dropbox_import_jobs" not in inspector.get_table_names():
         return
     columns = {column["name"] for column in inspector.get_columns("dropbox_import_jobs")}
-    if "page_offset" not in columns:
+    if "page_entry_keys" not in columns:
         op.add_column(
             "dropbox_import_jobs",
-            sa.Column("page_offset", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("page_entry_keys", sa.Text(), nullable=False, server_default="[]"),
         )
 
 
@@ -30,5 +30,5 @@ def downgrade() -> None:
     if "dropbox_import_jobs" not in inspector.get_table_names():
         return
     columns = {column["name"] for column in inspector.get_columns("dropbox_import_jobs")}
-    if "page_offset" in columns:
-        op.drop_column("dropbox_import_jobs", "page_offset")
+    if "page_entry_keys" in columns:
+        op.drop_column("dropbox_import_jobs", "page_entry_keys")

--- a/migrations/versions/055_dropbox_import_page_offset.py
+++ b/migrations/versions/055_dropbox_import_page_offset.py
@@ -1,0 +1,34 @@
+"""Persist the current Dropbox result-page offset.
+
+Revision ID: 055_dropbox_import_page_offset
+Revises: 054_corpus_llm_daily_usage
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "055_dropbox_import_page_offset"
+down_revision = "054_corpus_llm_daily_usage"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "dropbox_import_jobs" not in inspector.get_table_names():
+        return
+    columns = {column["name"] for column in inspector.get_columns("dropbox_import_jobs")}
+    if "page_offset" not in columns:
+        op.add_column(
+            "dropbox_import_jobs",
+            sa.Column("page_offset", sa.Integer(), nullable=False, server_default="0"),
+        )
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "dropbox_import_jobs" not in inspector.get_table_names():
+        return
+    columns = {column["name"] for column in inspector.get_columns("dropbox_import_jobs")}
+    if "page_offset" in columns:
+        op.drop_column("dropbox_import_jobs", "page_offset")

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -313,7 +313,7 @@ def test_dropbox_import_pauses_until_utc_reset_at_daily_token_budget(db_session)
     )
     db_session.add(job)
     db_session.commit()
-    entry = SimpleNamespace(name="invoice.pdf")
+    entry = SimpleNamespace(id="id:invoice", rev="rev-1", name="invoice.pdf")
     page = SimpleNamespace(entries=[entry], cursor="cursor-1", has_more=True)
     dropbox_client = MagicMock()
     dropbox_client.files_list_folder.return_value = page
@@ -343,27 +343,29 @@ def test_dropbox_import_pauses_until_utc_reset_at_daily_token_budget(db_session)
     }
     assert job.state == "queued"
     assert job.cursor is None
-    assert job.page_offset == 0
+    assert json.loads(job.page_entry_keys) == []
     assert job.discovered == 0
     schedule.assert_called_once_with(job.id, countdown=900)
 
 
 @pytest.mark.unit
-def test_budget_rechecks_resume_at_unprocessed_page_entry_without_recounting(db_session):
+def test_budget_rechecks_use_stable_entry_keys_when_page_changes(db_session):
     integration = _integration(db_session)
     job = DropboxImportJob(
-        id="job-page-offset",
+        id="job-page-progress",
         integration_id=integration.id,
         owner_id=integration.owner_id,
         root_path="/Documents",
     )
     db_session.add(job)
     db_session.commit()
-    first = SimpleNamespace(name="first.pdf")
-    second = SimpleNamespace(name="second.pdf")
-    page = SimpleNamespace(entries=[first, second], cursor="cursor-1", has_more=False)
+    first = SimpleNamespace(id="id:first", rev="rev-1", name="first.pdf")
+    second = SimpleNamespace(id="id:second", rev="rev-1", name="second.pdf")
+    inserted = SimpleNamespace(id="id:inserted", rev="rev-1", name="inserted.pdf")
+    first_page = SimpleNamespace(entries=[first, second], cursor="cursor-1", has_more=False)
+    changed_page = SimpleNamespace(entries=[inserted, first, second], cursor="cursor-2", has_more=False)
     dropbox_client = MagicMock()
-    dropbox_client.files_list_folder.return_value = page
+    dropbox_client.files_list_folder.side_effect = [first_page, changed_page, changed_page]
 
     with (
         patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
@@ -385,19 +387,19 @@ def test_budget_rechecks_resume_at_unprocessed_page_entry_without_recounting(db_
 
         db_session.refresh(job)
         assert first_pause["reason"] == "daily_llm_token_budget"
-        assert job.page_offset == 1
+        assert set(json.loads(job.page_entry_keys)) == {"id:first:rev-1"}
         assert job.discovered == 1
         assert job.queued == 1
         assert job.skipped == 0
 
-        import_file.side_effect = [budget_reached]
+        import_file.side_effect = ["queued", budget_reached]
         second_pause = run_dropbox_corpus_import.run(job.id)
 
         db_session.refresh(job)
         assert second_pause["reason"] == "daily_llm_token_budget"
-        assert job.page_offset == 1
-        assert job.discovered == 1
-        assert job.queued == 1
+        assert set(json.loads(job.page_entry_keys)) == {"id:first:rev-1", "id:inserted:rev-1"}
+        assert job.discovered == 2
+        assert job.queued == 2
         assert job.skipped == 0
 
         import_file.side_effect = ["queued"]
@@ -405,20 +407,20 @@ def test_budget_rechecks_resume_at_unprocessed_page_entry_without_recounting(db_
 
     db_session.refresh(job)
     assert completed["status"] == "completed"
-    assert job.cursor == "cursor-1"
-    assert job.page_offset == 0
-    assert job.discovered == 2
-    assert job.queued == 2
+    assert job.cursor == "cursor-2"
+    assert json.loads(job.page_entry_keys) == []
+    assert job.discovered == 3
+    assert job.queued == 3
     assert job.skipped == 0
     assert import_file.call_args.args[-1] is second
     assert schedule.call_count == 2
 
 
 @pytest.mark.unit
-def test_page_offset_persists_non_file_prefix_before_budget_pause(db_session):
+def test_invalid_page_progress_fails_closed_and_persists_error(db_session):
     integration = _integration(db_session)
     job = DropboxImportJob(
-        id="job-directory-offset",
+        id="job-invalid-page-progress",
         integration_id=integration.id,
         owner_id=integration.owner_id,
         root_path="/Documents",
@@ -426,10 +428,9 @@ def test_page_offset_persists_non_file_prefix_before_budget_pause(db_session):
     db_session.add(job)
     db_session.commit()
 
-    class FileEntry:
-        name = "invoice.pdf"
-
-    page = SimpleNamespace(entries=[SimpleNamespace(name="Folder"), FileEntry()], cursor="cursor-1", has_more=True)
+    job.page_entry_keys = "not-json"
+    db_session.commit()
+    page = SimpleNamespace(entries=[], cursor="cursor-1", has_more=True)
     dropbox_client = MagicMock()
     dropbox_client.files_list_folder.return_value = page
 
@@ -437,22 +438,15 @@ def test_page_offset_persists_non_file_prefix_before_budget_pause(db_session):
         patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
         patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
         patch("app.tasks.dropbox_corpus_import._dropbox_client", return_value=dropbox_client),
-        patch("dropbox.files.FileMetadata", FileEntry),
-        patch("app.tasks.dropbox_corpus_import._import_file") as import_file,
-        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_import"),
     ):
-        from app.tasks.dropbox_corpus_import import CorpusDailyBudgetReached, run_dropbox_corpus_import
+        from app.tasks.dropbox_corpus_import import run_dropbox_corpus_import
 
-        import_file.side_effect = CorpusDailyBudgetReached(
-            used=9_000_000,
-            budget=9_000_000,
-            retry_after_seconds=3600,
-        )
-        run_dropbox_corpus_import.run(job.id)
+        with pytest.raises(RuntimeError, match="not valid JSON"):
+            run_dropbox_corpus_import.run(job.id)
 
     db_session.refresh(job)
-    assert job.page_offset == 1
-    assert job.discovered == 0
+    assert job.state == "failed"
+    assert job.error == "Saved Dropbox page progress is not valid JSON"
 
 
 @pytest.mark.unit

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -343,8 +343,116 @@ def test_dropbox_import_pauses_until_utc_reset_at_daily_token_budget(db_session)
     }
     assert job.state == "queued"
     assert job.cursor is None
+    assert job.page_offset == 0
     assert job.discovered == 0
     schedule.assert_called_once_with(job.id, countdown=900)
+
+
+@pytest.mark.unit
+def test_budget_rechecks_resume_at_unprocessed_page_entry_without_recounting(db_session):
+    integration = _integration(db_session)
+    job = DropboxImportJob(
+        id="job-page-offset",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Documents",
+    )
+    db_session.add(job)
+    db_session.commit()
+    first = SimpleNamespace(name="first.pdf")
+    second = SimpleNamespace(name="second.pdf")
+    page = SimpleNamespace(entries=[first, second], cursor="cursor-1", has_more=False)
+    dropbox_client = MagicMock()
+    dropbox_client.files_list_folder.return_value = page
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.tasks.dropbox_corpus_import._dropbox_client", return_value=dropbox_client),
+        patch("dropbox.files.FileMetadata", SimpleNamespace),
+        patch("app.tasks.dropbox_corpus_import._import_file") as import_file,
+        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_import") as schedule,
+    ):
+        from app.tasks.dropbox_corpus_import import CorpusDailyBudgetReached, run_dropbox_corpus_import
+
+        budget_reached = CorpusDailyBudgetReached(
+            used=9_000_000,
+            budget=9_000_000,
+            retry_after_seconds=3600,
+        )
+        import_file.side_effect = ["queued", budget_reached]
+        first_pause = run_dropbox_corpus_import.run(job.id)
+
+        db_session.refresh(job)
+        assert first_pause["reason"] == "daily_llm_token_budget"
+        assert job.page_offset == 1
+        assert job.discovered == 1
+        assert job.queued == 1
+        assert job.skipped == 0
+
+        import_file.side_effect = [budget_reached]
+        second_pause = run_dropbox_corpus_import.run(job.id)
+
+        db_session.refresh(job)
+        assert second_pause["reason"] == "daily_llm_token_budget"
+        assert job.page_offset == 1
+        assert job.discovered == 1
+        assert job.queued == 1
+        assert job.skipped == 0
+
+        import_file.side_effect = ["queued"]
+        completed = run_dropbox_corpus_import.run(job.id)
+
+    db_session.refresh(job)
+    assert completed["status"] == "completed"
+    assert job.cursor == "cursor-1"
+    assert job.page_offset == 0
+    assert job.discovered == 2
+    assert job.queued == 2
+    assert job.skipped == 0
+    assert import_file.call_args.args[-1] is second
+    assert schedule.call_count == 2
+
+
+@pytest.mark.unit
+def test_page_offset_persists_non_file_prefix_before_budget_pause(db_session):
+    integration = _integration(db_session)
+    job = DropboxImportJob(
+        id="job-directory-offset",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Documents",
+    )
+    db_session.add(job)
+    db_session.commit()
+
+    class FileEntry:
+        name = "invoice.pdf"
+
+    page = SimpleNamespace(entries=[SimpleNamespace(name="Folder"), FileEntry()], cursor="cursor-1", has_more=True)
+    dropbox_client = MagicMock()
+    dropbox_client.files_list_folder.return_value = page
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.tasks.dropbox_corpus_import._dropbox_client", return_value=dropbox_client),
+        patch("dropbox.files.FileMetadata", FileEntry),
+        patch("app.tasks.dropbox_corpus_import._import_file") as import_file,
+        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_import"),
+    ):
+        from app.tasks.dropbox_corpus_import import CorpusDailyBudgetReached, run_dropbox_corpus_import
+
+        import_file.side_effect = CorpusDailyBudgetReached(
+            used=9_000_000,
+            budget=9_000_000,
+            retry_after_seconds=3600,
+        )
+        run_dropbox_corpus_import.run(job.id)
+
+    db_session.refresh(job)
+    assert job.page_offset == 1
+    assert job.discovered == 0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- persist stable Dropbox file-id + revision identities committed within the current result page
- resume budget-paused jobs without replaying or recounting completed entries
- safely handle Dropbox page insertions/reordering while paused; newly visible files are still processed
- fail closed with durable job error state when saved page progress is invalid
- reset page progress only when the complete page cursor is committed

## Validation

- `24 passed` in `tests/test_dropbox_corpus_import.py`
- regression test changes the Dropbox page between budget rechecks and proves no file is lost or recounted
- invalid saved progress test proves failed/error state is persisted
- Ruff lint and format checks passed
- Alembic reports a single `055_dropbox_import_page_entries` head
- migration from revision 054 succeeds with `page_entry_keys TEXT NOT NULL DEFAULT '[]'`
- `git diff --check` passed

Closes #1073