### PR TITLE
Scope corpus token budget to initial backfills

### DIFF
--- a/app/api/dropbox_imports.py
+++ b/app/api/dropbox_imports.py
@@ -28,6 +28,7 @@ def _job_response(job: DropboxImportJob) -> dict[str, Any]:
         "job_id": job.id,
         "integration_id": job.integration_id,
         "root_path": job.root_path,
+        "mode": "backfill" if job.is_backfill else "incremental",
         "state": job.state,
         "discovered": job.discovered,
         "downloaded": job.downloaded,
@@ -86,6 +87,7 @@ def start_dropbox_import(request: Request, body: DropboxImportCreate, db: DbSess
         integration_id=integration.id,
         owner_id=integration.owner_id,
         root_path=root_path or "",
+        is_backfill=True,
     )
     db.add(job)
     db.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    true,
 )
 
 from app.database import Base
@@ -159,6 +160,7 @@ class DropboxImportJob(Base):
     root_path = Column(String, nullable=False)
     cursor = Column(Text, nullable=True)
     page_entry_keys = Column(Text, nullable=False, default="[]", server_default="[]")
+    is_backfill = Column(Boolean, nullable=False, default=True, server_default=true())
     state = Column(String(20), nullable=False, default="queued", server_default="queued", index=True)
     discovered = Column(Integer, nullable=False, default=0, server_default="0")
     downloaded = Column(Integer, nullable=False, default=0, server_default="0")

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -247,6 +247,7 @@ def queue_dropbox_watch_sync(integration_id: int, db_session=None) -> dict:
             # A completed recursive listing cursor becomes an incremental
             # Dropbox change cursor for the next watch cycle.
             cursor=previous.cursor if previous else None,
+            is_backfill=previous is None,
         )
         db.add(job)
         db.commit()
@@ -313,6 +314,13 @@ def _fail_import_job(db, job: DropboxImportJob, message: str) -> None:
     db.commit()
 
 
+def _reserve_job_llm_tokens(job: DropboxImportJob) -> tuple[date | None, int]:
+    """Apply the daily cost guard only to an initial corpus backfill."""
+    if not job.is_backfill:
+        return None, 0
+    return _reserve_corpus_llm_tokens()
+
+
 def _import_file(db, job: DropboxImportJob, integration: UserIntegration, client, entry) -> str:
     """Import one Dropbox FileMetadata and return queued/skipped/failed."""
     filename = sanitize_filename(entry.name) or "document"
@@ -356,7 +364,7 @@ def _import_file(db, job: DropboxImportJob, integration: UserIntegration, client
             db.add(imported)
         return "skipped"
 
-    reservation = _reserve_corpus_llm_tokens()
+    reservation = _reserve_job_llm_tokens(job)
     target_path = os.path.join(settings.workdir, f"dropbox_{integration.id}_{uuid.uuid4().hex}{extension}")
     temporary_path = f"{target_path}.part"
     queued = False

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -48,7 +48,7 @@ def _next_utc_reset(now: datetime) -> datetime:
     return datetime.combine(tomorrow, datetime.min.time(), tzinfo=timezone.utc)
 
 
-def _reserve_corpus_llm_tokens() -> tuple[date | None, int]:
+def _reserve_corpus_llm_tokens(*, budget: int | None = None) -> tuple[date | None, int]:
     """Atomically reserve durable LLM capacity for one corpus document.
 
     A zero budget disables the guard. When enabled, Redis is deliberately
@@ -56,7 +56,7 @@ def _reserve_corpus_llm_tokens() -> tuple[date | None, int]:
     database reservation survives Redis restarts and fails closed if durable
     accounting is unavailable. Interactive uploads do not use this path.
     """
-    budget = int(settings.corpus_backfill_daily_llm_token_budget)
+    budget = int(settings.corpus_backfill_daily_llm_token_budget if budget is None else budget)
     if budget <= 0:
         return None, 0
 
@@ -314,11 +314,33 @@ def _fail_import_job(db, job: DropboxImportJob, message: str) -> None:
     db.commit()
 
 
-def _reserve_job_llm_tokens(job: DropboxImportJob) -> tuple[date | None, int]:
+def _configured_backfill_token_budget(integration: UserIntegration) -> int:
+    """Resolve the live per-integration backfill budget with a global fallback."""
+    try:
+        config = json.loads(integration.config or "{}")
+    except (json.JSONDecodeError, TypeError):
+        config = {}
+    if not isinstance(config, dict):
+        config = {}
+    enabled = config.get("backfill_token_budget_enabled", True)
+    if enabled is False or str(enabled).strip().lower() in {"0", "false", "no", "off"}:
+        return 0
+    return _bounded_config_int(
+        config,
+        "backfill_daily_llm_token_budget",
+        settings.corpus_backfill_daily_llm_token_budget,
+        minimum=0,
+    )
+
+
+def _reserve_job_llm_tokens(job: DropboxImportJob, integration: UserIntegration) -> tuple[date | None, int]:
     """Apply the daily cost guard only to an initial corpus backfill."""
     if not job.is_backfill:
         return None, 0
-    return _reserve_corpus_llm_tokens()
+    budget = _configured_backfill_token_budget(integration)
+    if budget <= 0:
+        return None, 0
+    return _reserve_corpus_llm_tokens(budget=budget)
 
 
 def _import_file(db, job: DropboxImportJob, integration: UserIntegration, client, entry) -> str:
@@ -364,7 +386,7 @@ def _import_file(db, job: DropboxImportJob, integration: UserIntegration, client
             db.add(imported)
         return "skipped"
 
-    reservation = _reserve_job_llm_tokens(job)
+    reservation = _reserve_job_llm_tokens(job, integration)
     target_path = os.path.join(settings.workdir, f"dropbox_{integration.id}_{uuid.uuid4().hex}{extension}")
     temporary_path = f"{target_path}.part"
     queued = False

--- a/app/views/integrations.py
+++ b/app/views/integrations.py
@@ -5,6 +5,7 @@ import logging
 from fastapi import HTTPException, Request, status
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.models import IntegrationDirection, IntegrationType, UserIntegration
 from app.utils.subscription import get_tier, get_user_tier_id
 from app.utils.user_scope import get_current_owner_id
@@ -105,6 +106,7 @@ async def integrations_dashboard(request: Request, db: Session = Depends(get_db)
                 "tier_id": tier_id,
                 "tier_name": tier_name,
                 "is_preprod": bool(request.url.hostname and "preprod" in request.url.hostname.lower()),
+                "default_backfill_token_budget": settings.corpus_backfill_daily_llm_token_budget,
             },
         )
     except HTTPException:

--- a/frontend/templates/integrations_dashboard.html
+++ b/frontend/templates/integrations_dashboard.html
@@ -715,6 +715,22 @@
                     <span class="text-xs text-gray-500 dark:text-gray-400">Import every existing document recursively, including subfolders, then continue from Dropbox's change cursor.</span>
                   </span>
                 </label>
+                <template x-if="form.config.true_up_existing">
+                  <div class="rounded-md border border-gray-200 dark:border-gray-700 p-3 space-y-3">
+                    <label class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-200 cursor-pointer">
+                      <input type="checkbox" x-model="form.config.backfill_token_budget_enabled" class="mt-0.5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+                      <span>
+                        <strong>Daily LLM token budget</strong><br />
+                        <span class="text-xs text-gray-500 dark:text-gray-400">Pause only this initial corpus backfill at the configured daily limit. Normal uploads and later watch updates are unaffected.</span>
+                      </span>
+                    </label>
+                    <div>
+                      <label for="wf-dbx-token-budget" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Tokens per UTC day</label>
+                      <input id="wf-dbx-token-budget" type="number" min="0" step="1000" x-model.number="form.config.backfill_daily_llm_token_budget" :disabled="!form.config.backfill_token_budget_enabled" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 dark:bg-gray-700 dark:text-white text-sm" />
+                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Turn the switch off or enter 0 to disable the budget. Changes are read from the database without restarting the app or worker.</p>
+                    </div>
+                  </div>
+                </template>
                 <div class="bg-blue-50 dark:bg-blue-900/30 rounded-md p-3 text-sm text-blue-700 dark:text-blue-300">
                   <i class="fas fa-key mr-1" aria-hidden="true"></i>
                   Saving opens Dropbox so you can authorize this source with your own account. Only your renewable grant is stored; App Key and App Secret remain operator-managed.
@@ -1066,6 +1082,7 @@ print(response.json())</code></pre>
 <script>
 function integrationsDashboard() {
   const PREPROD_PATH = {{ ('/DocuElevate Preprod' if is_preprod else '/DocuElevate') | tojson }};
+  const DEFAULT_BACKFILL_TOKEN_BUDGET = {{ default_backfill_token_budget | tojson }};
   const SOURCE_TYPES = ['IMAP', 'WATCH_FOLDER', 'WEBHOOK'];
   const DEST_TYPES = ['VECTOR_DATABASE', 'S3', 'DROPBOX', 'GOOGLE_DRIVE', 'ONEDRIVE', 'WEBDAV', 'NEXTCLOUD', 'FTP', 'SFTP', 'EMAIL', 'PAPERLESS', 'RCLONE'];
   const TYPES_WITH_FORM_FIELDS = new Set(['IMAP', 'VECTOR_DATABASE', 'S3', 'WEBDAV', 'NEXTCLOUD', 'FTP', 'SFTP', 'DROPBOX', 'GOOGLE_DRIVE', 'ONEDRIVE', 'EMAIL', 'WATCH_FOLDER', 'PAPERLESS']);
@@ -1299,7 +1316,16 @@ function integrationsDashboard() {
         this.form.config = { source_type: st, bucket: '', region: 'us-east-1', prefix: '', endpoint_url: '', preserve_source_files: preserve, delete_after_process: dap };
         this.form.credentials = { access_key_id: '', secret_access_key: '' };
       } else if (st === 'dropbox') {
-        this.form.config = { source_type: st, folder_path: '', preserve_source_files: preserve, delete_after_process: dap, true_up_existing: false, recursive: true };
+        this.form.config = {
+          source_type: st,
+          folder_path: '',
+          preserve_source_files: preserve,
+          delete_after_process: dap,
+          true_up_existing: false,
+          recursive: true,
+          backfill_token_budget_enabled: true,
+          backfill_daily_llm_token_budget: DEFAULT_BACKFILL_TOKEN_BUDGET,
+        };
         this.form.credentials = {};
       } else if (st === 'google_drive') {
         this.form.config = { source_type: st, folder_id: '', preserve_source_files: preserve, delete_after_process: dap };
@@ -1337,6 +1363,10 @@ function integrationsDashboard() {
       const config = intg.config ? JSON.parse(JSON.stringify(intg.config)) : {};
       if (intg.integration_type === 'WATCH_FOLDER' && config.preserve_source_files === undefined) {
         config.preserve_source_files = true;
+      }
+      if (intg.integration_type === 'WATCH_FOLDER' && config.source_type === 'dropbox') {
+        if (config.backfill_token_budget_enabled === undefined) config.backfill_token_budget_enabled = true;
+        if (config.backfill_daily_llm_token_budget === undefined) config.backfill_daily_llm_token_budget = DEFAULT_BACKFILL_TOKEN_BUDGET;
       }
       this.form = {
         direction: intg.direction,

--- a/migrations/versions/056_dropbox_import_job_mode.py
+++ b/migrations/versions/056_dropbox_import_job_mode.py
@@ -1,0 +1,36 @@
+"""Distinguish initial Dropbox backfills from incremental watch jobs.
+
+Revision ID: 056_dropbox_import_job_mode
+Revises: 055_dropbox_import_page_entries
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "056_dropbox_import_job_mode"
+down_revision = "055_dropbox_import_page_entries"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "dropbox_import_jobs" not in inspector.get_table_names():
+        return
+    columns = {column["name"] for column in inspector.get_columns("dropbox_import_jobs")}
+    if "is_backfill" not in columns:
+        # Existing jobs are true-ups created before mode was persisted, so the
+        # safe migration default keeps their cost guard enabled.
+        op.add_column(
+            "dropbox_import_jobs",
+            sa.Column("is_backfill", sa.Boolean(), nullable=False, server_default=sa.true()),
+        )
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "dropbox_import_jobs" not in inspector.get_table_names():
+        return
+    columns = {column["name"] for column in inspector.get_columns("dropbox_import_jobs")}
+    if "is_backfill" in columns:
+        op.drop_column("dropbox_import_jobs", "is_backfill")

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -330,23 +330,45 @@ def test_corpus_token_budget_fails_closed_when_counter_is_unavailable():
 @pytest.mark.unit
 def test_incremental_watch_job_bypasses_backfill_token_budget():
     job = SimpleNamespace(is_backfill=False)
+    integration = SimpleNamespace(config="{}")
     with patch("app.tasks.dropbox_corpus_import._reserve_corpus_llm_tokens") as reserve:
         from app.tasks.dropbox_corpus_import import _reserve_job_llm_tokens
 
-        assert _reserve_job_llm_tokens(job) == (None, 0)
+        assert _reserve_job_llm_tokens(job, integration) == (None, 0)
     reserve.assert_not_called()
 
 
 @pytest.mark.unit
 def test_initial_backfill_job_uses_token_budget():
     job = SimpleNamespace(is_backfill=True)
+    integration = SimpleNamespace(
+        config=json.dumps({"backfill_token_budget_enabled": True, "backfill_daily_llm_token_budget": 8_500_000})
+    )
     with patch(
         "app.tasks.dropbox_corpus_import._reserve_corpus_llm_tokens", return_value=(date(2026, 7, 15), 9500)
     ) as reserve:
         from app.tasks.dropbox_corpus_import import _reserve_job_llm_tokens
 
-        assert _reserve_job_llm_tokens(job) == (date(2026, 7, 15), 9500)
-    reserve.assert_called_once_with()
+        assert _reserve_job_llm_tokens(job, integration) == (date(2026, 7, 15), 9500)
+    reserve.assert_called_once_with(budget=8_500_000)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"backfill_token_budget_enabled": False, "backfill_daily_llm_token_budget": 9_000_000},
+        {"backfill_token_budget_enabled": True, "backfill_daily_llm_token_budget": 0},
+    ],
+)
+def test_initial_backfill_budget_can_be_disabled_live(config):
+    job = SimpleNamespace(is_backfill=True)
+    integration = SimpleNamespace(config=json.dumps(config))
+    with patch("app.tasks.dropbox_corpus_import._reserve_corpus_llm_tokens") as reserve:
+        from app.tasks.dropbox_corpus_import import _reserve_job_llm_tokens
+
+        assert _reserve_job_llm_tokens(job, integration) == (None, 0)
+    reserve.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -2,7 +2,7 @@
 
 import json
 from contextlib import nullcontext
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -38,6 +38,7 @@ def test_dropbox_import_start_queues_owned_source(client, db_session):
 
     assert response.status_code == 202
     assert response.json()["root_path"] == "/Documents"
+    assert response.json()["mode"] == "backfill"
     assert response.json()["state"] == "queued"
     assert response.json()["task_id"] == "task-1"
     apply_async.assert_called_once_with(args=[response.json()["job_id"]], countdown=0, priority=9)
@@ -72,7 +73,31 @@ def test_watch_true_up_reuses_completed_cursor(db_session):
     queued = db_session.query(DropboxImportJob).filter(DropboxImportJob.id == result["job_id"]).one()
     assert result["mode"] == "incremental"
     assert queued.cursor == "cursor-after-true-up"
+    assert queued.is_backfill is False
     apply_async.assert_called_once_with(args=[queued.id], countdown=0, priority=9)
+
+
+def test_watch_true_up_marks_initial_job_as_backfill(db_session):
+    integration = _integration(db_session)
+    integration.config = json.dumps(
+        {
+            "source_type": "dropbox",
+            "folder_path": "/Posteingang",
+            "true_up_existing": True,
+            "recursive": True,
+        }
+    )
+    db_session.commit()
+
+    with patch("app.tasks.dropbox_corpus_import.run_dropbox_corpus_import.apply_async"):
+        from app.tasks.dropbox_corpus_import import queue_dropbox_watch_sync
+
+        result = queue_dropbox_watch_sync(integration.id, db_session)
+
+    queued = db_session.query(DropboxImportJob).filter(DropboxImportJob.id == result["job_id"]).one()
+    assert result["mode"] == "true-up"
+    assert queued.cursor is None
+    assert queued.is_backfill is True
 
 
 def test_watch_true_up_waits_for_folder_selection(db_session):
@@ -300,6 +325,28 @@ def test_corpus_token_budget_fails_closed_when_counter_is_unavailable():
 
         with pytest.raises(CorpusDailyBudgetUnavailable, match="Could not reserve"):
             _reserve_corpus_llm_tokens()
+
+
+@pytest.mark.unit
+def test_incremental_watch_job_bypasses_backfill_token_budget():
+    job = SimpleNamespace(is_backfill=False)
+    with patch("app.tasks.dropbox_corpus_import._reserve_corpus_llm_tokens") as reserve:
+        from app.tasks.dropbox_corpus_import import _reserve_job_llm_tokens
+
+        assert _reserve_job_llm_tokens(job) == (None, 0)
+    reserve.assert_not_called()
+
+
+@pytest.mark.unit
+def test_initial_backfill_job_uses_token_budget():
+    job = SimpleNamespace(is_backfill=True)
+    with patch(
+        "app.tasks.dropbox_corpus_import._reserve_corpus_llm_tokens", return_value=(date(2026, 7, 15), 9500)
+    ) as reserve:
+        from app.tasks.dropbox_corpus_import import _reserve_job_llm_tokens
+
+        assert _reserve_job_llm_tokens(job) == (date(2026, 7, 15), 9500)
+    reserve.assert_called_once_with()
 
 
 @pytest.mark.unit

--- a/tests/test_views_dropbox.py
+++ b/tests/test_views_dropbox.py
@@ -46,6 +46,9 @@ class TestDropboxViews:
         assert " required" not in tag.group(0)
         assert 'aria-required="true"' not in tag.group(0)
         assert "Optional before sign-in" in response.text
+        assert 'id="wf-dbx-token-budget"' in response.text
+        assert "Normal uploads and later watch updates are unaffected" in response.text
+        assert "DEFAULT_BACKFILL_TOKEN_BUDGET" in response.text
 
     def test_dropbox_setup_page_with_integration_id(self, client):
         """Test the Dropbox setup page accepts integration_id query param."""


### PR DESCRIPTION
## Summary

- persist whether each Dropbox import job is an initial backfill or an incremental watch delta
- keep the daily LLM token guard enabled across every page of initial true-up jobs
- bypass the backfill cost guard for later cursor-based watch imports
- configure the budget per Dropbox source in the UI with a numeric UTC-day limit and explicit enable/disable switch
- read saved integration configuration on subsequent coordinator runs without restarting app or worker
- expose the persisted job mode in the import API
- migrate existing jobs as guarded backfills so the active preprod true-up stays protected

## Validation

- `43 passed` across Dropbox corpus and Dropbox view tests
- explicit tests for incremental bypass, numeric override, disabled switch, and zero budget
- Ruff, template lint, and formatting passed
- Alembic has a single `056_dropbox_import_job_mode` head
- focused migration from 055 preserves an existing job as `is_backfill=true`
- `git diff --check` passed

Closes #1075