### PR TITLE
Speed up index-first Dropbox corpus backfills

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -907,6 +907,15 @@ class Settings(BaseSettings):
         le=2000,
         description="Maximum provider entries requested per corpus backfill page. Default: 10.",
     )
+    corpus_backfill_download_concurrency: int = Field(
+        default=1,
+        ge=1,
+        le=8,
+        description=(
+            "Parallel Dropbox downloads per index-first corpus page. "
+            "Only opt-in initial backfills use values above 1. Default: 1."
+        ),
+    )
     corpus_backfill_queue_high_watermark: int = Field(
         default=50,
         ge=1,

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import date, datetime, timedelta, timezone
 
 import redis
@@ -272,10 +273,10 @@ def _decode(stored: str | None) -> dict:
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _dropbox_client(integration: UserIntegration):
+def _dropbox_client_from_stored_credentials(stored_credentials: str | None):
     import dropbox
 
-    credentials = _decode(integration.credentials)
+    credentials = _decode(stored_credentials)
     try:
         app_key, app_secret, refresh_token = resolve_dropbox_oauth_credentials(credentials)
     except ValueError as exc:
@@ -285,6 +286,10 @@ def _dropbox_client(integration: UserIntegration):
         app_key=app_key,
         app_secret=app_secret,
     )
+
+
+def _dropbox_client(integration: UserIntegration):
+    return _dropbox_client_from_stored_credentials(integration.credentials)
 
 
 def _load_page_entry_keys(job: DropboxImportJob) -> set[str]:
@@ -347,6 +352,52 @@ def _index_first_enabled(integration: UserIntegration) -> bool:
     return value is True or str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _index_first_download_concurrency(config: dict, *, index_only: bool) -> int:
+    """Return bounded Dropbox prefetch concurrency for an opt-in initial backfill."""
+    if not index_only:
+        return 1
+    return _bounded_config_int(
+        config,
+        "backfill_download_concurrency",
+        settings.corpus_backfill_download_concurrency,
+        minimum=1,
+        maximum=8,
+    )
+
+
+def _entry_can_be_prefetched(entry) -> bool:
+    """Reject entries that the durable importer would skip before downloading."""
+    filename = sanitize_filename(entry.name) or "document"
+    extension = os.path.splitext(filename)[1].lower()
+    return extension in ALLOWED_EXTENSIONS and getattr(entry, "size", 0) <= settings.max_upload_size
+
+
+def _prefetch_dropbox_entry(integration_id: int, stored_credentials: str | None, entry) -> str:
+    """Download one Dropbox object into an isolated temporary file.
+
+    Each thread creates its own Dropbox client because requests sessions are
+    not guaranteed to be thread-safe. The caller owns cleanup of the returned
+    path, including when the durable import later discovers a duplicate.
+    """
+    filename = sanitize_filename(entry.name) or "document"
+    extension = os.path.splitext(filename)[1].lower()
+    target_path = os.path.join(settings.workdir, f"dropbox_prefetch_{integration_id}_{uuid.uuid4().hex}{extension}")
+    temporary_path = f"{target_path}.part"
+    try:
+        client = _dropbox_client_from_stored_credentials(stored_credentials)
+        _metadata, response = client.files_download(entry.path_lower)
+        content = response.content
+        if len(content) > settings.max_upload_size:
+            raise ValueError("Dropbox object exceeds the configured upload limit")
+        with open(temporary_path, "wb") as output:
+            output.write(content)
+        os.replace(temporary_path, target_path)
+        return target_path
+    finally:
+        if os.path.exists(temporary_path):
+            os.remove(temporary_path)
+
+
 def _reserve_job_llm_tokens(job: DropboxImportJob, integration: UserIntegration) -> tuple[date | None, int]:
     """Apply the daily cost guard only to an initial corpus backfill."""
     if not job.is_backfill:
@@ -357,7 +408,15 @@ def _reserve_job_llm_tokens(job: DropboxImportJob, integration: UserIntegration)
     return _reserve_corpus_llm_tokens(budget=budget)
 
 
-def _import_file(db, job: DropboxImportJob, integration: UserIntegration, client, entry) -> str:
+def _import_file(
+    db,
+    job: DropboxImportJob,
+    integration: UserIntegration,
+    client,
+    entry,
+    *,
+    prefetched_path: str | None = None,
+) -> str:
     """Import one Dropbox FileMetadata and return queued/skipped/failed."""
     filename = sanitize_filename(entry.name) or "document"
     extension = os.path.splitext(filename)[1].lower()
@@ -406,13 +465,18 @@ def _import_file(db, job: DropboxImportJob, integration: UserIntegration, client
     temporary_path = f"{target_path}.part"
     queued = False
     try:
-        _metadata, response = client.files_download(entry.path_lower)
-        content = response.content
-        if len(content) > settings.max_upload_size:
-            return "failed"
-        with open(temporary_path, "wb") as output:
-            output.write(content)
-        os.replace(temporary_path, target_path)
+        if prefetched_path:
+            if os.path.getsize(prefetched_path) > settings.max_upload_size:
+                return "failed"
+            os.replace(prefetched_path, target_path)
+        else:
+            _metadata, response = client.files_download(entry.path_lower)
+            content = response.content
+            if len(content) > settings.max_upload_size:
+                return "failed"
+            with open(temporary_path, "wb") as output:
+                output.write(content)
+            os.replace(temporary_path, target_path)
 
         if intake is None:
             intake = DocumentIntake(
@@ -559,73 +623,124 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
             _fail_import_job(db, job, str(exc))
             raise
 
-        for entry in page.entries:
-            if not isinstance(entry, dropbox.files.FileMetadata):
-                continue
-            try:
-                entry_key = _dropbox_file_key(entry)
-            except RuntimeError as exc:
-                _fail_import_job(db, job, str(exc))
-                raise
-            if entry_key in committed_entry_keys:
-                continue
-            job.discovered += 1
-            try:
-                outcome = _import_file(db, job, integration, client, entry)
-            except CorpusDailyBudgetReached as exc:
-                job.discovered -= 1
-                job.state = "queued"
-                job.error = str(exc)
-                db.commit()
-                # Redis' default Celery visibility timeout is shorter than a
-                # possible wait to the next UTC day. Short rechecks avoid a
-                # long-lived ETA task being restored and delivered twice.
-                recheck_in = min(exc.retry_after_seconds, _MAX_BUDGET_RECHECK_SECONDS)
-                schedule_dropbox_corpus_import(job.id, countdown=recheck_in)
-                return {
-                    "status": "paused",
-                    "reason": "daily_llm_token_budget",
-                    "job_id": job.id,
-                    "tokens_reserved": exc.used,
-                    "token_budget": exc.budget,
-                    "resume_in_seconds": recheck_in,
-                    "budget_resets_in_seconds": exc.retry_after_seconds,
-                }
-            except CorpusDailyBudgetUnavailable as exc:
-                job.discovered -= 1
-                job.state = "queued"
-                job.error = str(exc)
-                db.commit()
-                delay = _bounded_config_int(
-                    config,
-                    "backfill_resume_delay_seconds",
-                    settings.corpus_backfill_resume_delay_seconds,
-                    minimum=1,
+        index_only = job.is_backfill and _index_first_enabled(integration)
+        download_concurrency = _index_first_download_concurrency(config, index_only=index_only)
+        integration_id = integration.id
+        stored_credentials = integration.credentials
+        prefetch_executor: ThreadPoolExecutor | None = None
+        prefetch_futures: dict[str, Future[str]] = {}
+        try:
+            if download_concurrency > 1:
+                prefetch_executor = ThreadPoolExecutor(
+                    max_workers=download_concurrency,
+                    thread_name_prefix="dropbox-corpus",
                 )
-                schedule_dropbox_corpus_import(job.id, countdown=delay)
-                return {
-                    "status": "paused",
-                    "reason": "daily_llm_token_budget_unavailable",
-                    "job_id": job.id,
-                    "resume_in_seconds": delay,
-                }
-            except Exception as exc:
-                logger.exception("Dropbox import failed for %s: %s", entry.path_display, exc)
-                outcome = "failed"
-            if outcome == "queued":
-                job.downloaded += 1
-                job.queued += 1
-            elif outcome == "skipped":
-                job.skipped += 1
-            else:
-                job.failed += 1
-            committed_entry_keys.add(entry_key)
-            job.page_entry_keys = json.dumps(sorted(committed_entry_keys))
-            # Persist each enqueued document before moving on. If the worker is
-            # interrupted, stable file-revision identities prevent recounting
-            # committed entries. Unlike a numeric offset, this remains safe if
-            # the Dropbox page changes between budget rechecks.
-            db.commit()
+                for entry in page.entries:
+                    if not isinstance(entry, dropbox.files.FileMetadata) or not _entry_can_be_prefetched(entry):
+                        continue
+                    try:
+                        entry_key = _dropbox_file_key(entry)
+                    except RuntimeError:
+                        continue
+                    if entry_key not in committed_entry_keys:
+                        prefetch_futures[entry_key] = prefetch_executor.submit(
+                            _prefetch_dropbox_entry,
+                            integration_id,
+                            stored_credentials,
+                            entry,
+                        )
+
+            for entry in page.entries:
+                if not isinstance(entry, dropbox.files.FileMetadata):
+                    continue
+                try:
+                    entry_key = _dropbox_file_key(entry)
+                except RuntimeError as exc:
+                    _fail_import_job(db, job, str(exc))
+                    raise
+                if entry_key in committed_entry_keys:
+                    continue
+                job.discovered += 1
+                prefetched_path = None
+                try:
+                    future = prefetch_futures.get(entry_key)
+                    prefetched_path = future.result() if future else None
+                    outcome = _import_file(
+                        db,
+                        job,
+                        integration,
+                        client,
+                        entry,
+                        prefetched_path=prefetched_path,
+                    )
+                    if prefetched_path and not os.path.exists(prefetched_path):
+                        prefetched_path = None  # ownership moved into the durable pipeline
+                except CorpusDailyBudgetReached as exc:
+                    job.discovered -= 1
+                    job.state = "queued"
+                    job.error = str(exc)
+                    db.commit()
+                    # Redis' default Celery visibility timeout is shorter than a
+                    # possible wait to the next UTC day. Short rechecks avoid a
+                    # long-lived ETA task being restored and delivered twice.
+                    recheck_in = min(exc.retry_after_seconds, _MAX_BUDGET_RECHECK_SECONDS)
+                    schedule_dropbox_corpus_import(job.id, countdown=recheck_in)
+                    return {
+                        "status": "paused",
+                        "reason": "daily_llm_token_budget",
+                        "job_id": job.id,
+                        "tokens_reserved": exc.used,
+                        "token_budget": exc.budget,
+                        "resume_in_seconds": recheck_in,
+                        "budget_resets_in_seconds": exc.retry_after_seconds,
+                    }
+                except CorpusDailyBudgetUnavailable as exc:
+                    job.discovered -= 1
+                    job.state = "queued"
+                    job.error = str(exc)
+                    db.commit()
+                    delay = _bounded_config_int(
+                        config,
+                        "backfill_resume_delay_seconds",
+                        settings.corpus_backfill_resume_delay_seconds,
+                        minimum=1,
+                    )
+                    schedule_dropbox_corpus_import(job.id, countdown=delay)
+                    return {
+                        "status": "paused",
+                        "reason": "daily_llm_token_budget_unavailable",
+                        "job_id": job.id,
+                        "resume_in_seconds": delay,
+                    }
+                except Exception as exc:
+                    logger.exception("Dropbox import failed for %s: %s", entry.path_display, exc)
+                    outcome = "failed"
+                finally:
+                    if prefetched_path and os.path.exists(prefetched_path):
+                        os.remove(prefetched_path)
+                if outcome == "queued":
+                    job.downloaded += 1
+                    job.queued += 1
+                elif outcome == "skipped":
+                    job.skipped += 1
+                else:
+                    job.failed += 1
+                committed_entry_keys.add(entry_key)
+                job.page_entry_keys = json.dumps(sorted(committed_entry_keys))
+                # Persist each enqueued document before moving on. If the worker is
+                # interrupted, stable file-revision identities prevent recounting
+                # committed entries. Unlike a numeric offset, this remains safe if
+                # the Dropbox page changes between budget rechecks.
+                db.commit()
+        finally:
+            if prefetch_executor is not None:
+                prefetch_executor.shutdown(wait=True, cancel_futures=True)
+            for future in prefetch_futures.values():
+                if not future.done() or future.cancelled() or future.exception() is not None:
+                    continue
+                prefetched_path = future.result()
+                if os.path.exists(prefetched_path):
+                    os.remove(prefetched_path)
 
         job.cursor = page.cursor
         job.page_entry_keys = "[]"

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -6,6 +6,7 @@ import os
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import date, datetime, timedelta, timezone
+from threading import local
 
 import redis
 from celery.result import AsyncResult
@@ -28,6 +29,7 @@ _REDIS_PRIORITY_SEPARATOR = "\x06\x16"
 _REDIS_PRIORITY_STEPS = range(10)
 _METADATA_PROMPT_OUTPUT_HEADROOM = 1500
 _MAX_BUDGET_RECHECK_SECONDS = 15 * 60
+_PREFETCH_THREAD_STATE = local()
 
 
 class CorpusDailyBudgetReached(RuntimeError):
@@ -384,7 +386,13 @@ def _prefetch_dropbox_entry(integration_id: int, stored_credentials: str | None,
     target_path = os.path.join(settings.workdir, f"dropbox_prefetch_{integration_id}_{uuid.uuid4().hex}{extension}")
     temporary_path = f"{target_path}.part"
     try:
-        client = _dropbox_client_from_stored_credentials(stored_credentials)
+        if (
+            not hasattr(_PREFETCH_THREAD_STATE, "client")
+            or getattr(_PREFETCH_THREAD_STATE, "stored_credentials", None) != stored_credentials
+        ):
+            _PREFETCH_THREAD_STATE.client = _dropbox_client_from_stored_credentials(stored_credentials)
+            _PREFETCH_THREAD_STATE.stored_credentials = stored_credentials
+        client = _PREFETCH_THREAD_STATE.client
         _metadata, response = client.files_download(entry.path_lower)
         content = response.content
         if len(content) > settings.max_upload_size:

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -629,6 +629,24 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
         stored_credentials = integration.credentials
         prefetch_executor: ThreadPoolExecutor | None = None
         prefetch_futures: dict[str, Future[str]] = {}
+        prefetch_entries: list[tuple[str, object]] = []
+        prefetch_position = 0
+
+        def fill_prefetch_window() -> None:
+            """Keep at most one bounded window of downloads on disk or in flight."""
+            nonlocal prefetch_position
+            if prefetch_executor is None:
+                return
+            while len(prefetch_futures) < download_concurrency and prefetch_position < len(prefetch_entries):
+                entry_key, entry = prefetch_entries[prefetch_position]
+                prefetch_position += 1
+                prefetch_futures[entry_key] = prefetch_executor.submit(
+                    _prefetch_dropbox_entry,
+                    integration_id,
+                    stored_credentials,
+                    entry,
+                )
+
         try:
             if download_concurrency > 1:
                 prefetch_executor = ThreadPoolExecutor(
@@ -643,12 +661,8 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
                     except RuntimeError:
                         continue
                     if entry_key not in committed_entry_keys:
-                        prefetch_futures[entry_key] = prefetch_executor.submit(
-                            _prefetch_dropbox_entry,
-                            integration_id,
-                            stored_credentials,
-                            entry,
-                        )
+                        prefetch_entries.append((entry_key, entry))
+                fill_prefetch_window()
 
             for entry in page.entries:
                 if not isinstance(entry, dropbox.files.FileMetadata):
@@ -663,8 +677,12 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
                 job.discovered += 1
                 prefetched_path = None
                 try:
-                    future = prefetch_futures.get(entry_key)
-                    prefetched_path = future.result() if future else None
+                    future = prefetch_futures.pop(entry_key, None)
+                    if future:
+                        try:
+                            prefetched_path = future.result()
+                        finally:
+                            fill_prefetch_window()
                     outcome = _import_file(
                         db,
                         job,

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -2169,6 +2169,16 @@ SETTING_METADATA = {
         "required": False,
         "restart_required": False,
     },
+    "corpus_backfill_download_concurrency": {
+        "category": "Processing",
+        "description": (
+            "Parallel Dropbox downloads for opt-in index-first initial backfills; bounded to 8 (default: 1)"
+        ),
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
     "corpus_backfill_queue_high_watermark": {
         "category": "Processing",
         "description": "Pause corpus backfills at this queued plus worker-reserved Celery depth (default: 50)",

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -75,6 +75,7 @@ Control how the `/processall` endpoint handles large batches of files to prevent
 | `PROCESSALL_THROTTLE_THRESHOLD`   | Number of files above which throttling is applied. Files <= threshold are processed immediately.  | `20`        |
 | `PROCESSALL_THROTTLE_DELAY`       | Delay in seconds between each task submission when throttling is active.                          | `3`         |
 | `CORPUS_BACKFILL_BATCH_SIZE` | Maximum provider entries requested per Dropbox corpus page. | `10` |
+| `CORPUS_BACKFILL_DOWNLOAD_CONCURRENCY` | Parallel Dropbox downloads for opt-in index-first initial backfills; bounded to 8. | `1` |
 | `CORPUS_BACKFILL_QUEUE_HIGH_WATERMARK` | Pause corpus backfills at this queued plus worker-reserved Celery depth. | `50` |
 | `CORPUS_BACKFILL_RESUME_DELAY_SECONDS` | Seconds before a queue-limited backfill checks capacity again. | `30` |
 | `CORPUS_BACKFILL_TASK_PRIORITY` | Celery Redis priority for corpus coordinator tasks; `9` runs behind normal priority `0` work. | `9` |
@@ -82,8 +83,8 @@ Control how the `/processall` endpoint handles large batches of files to prevent
 | `CORPUS_BACKFILL_LLM_TOKEN_RESERVATION_PER_DOCUMENT` | Tokens reserved per queued corpus document; metadata prompt/output headroom is enforced automatically. | `10000` |
 | `METADATA_MAX_INPUT_TOKENS` | Maximum document-text tokens sent to metadata extraction; keeps the beginning plus a short ending. | `8000` |
 
-Dropbox Watch Folder integrations may override the first three defaults with
-`backfill_batch_size`, `backfill_queue_high_watermark`, and
+Dropbox Watch Folder integrations may override the first four defaults with
+`backfill_batch_size`, `backfill_download_concurrency`, `backfill_queue_high_watermark`, and
 `backfill_resume_delay_seconds` in their database-backed integration config.
 The importer commits progress after every queued document and reuses the
 Dropbox cursor, so pausing or restarting a worker does not require rescanning

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -495,6 +495,36 @@ def test_index_first_import_consumes_prefetched_file_without_redownloading(db_se
 
 
 @pytest.mark.unit
+def test_prefetch_reuses_one_dropbox_client_per_worker_thread(tmp_path):
+    entries = [
+        SimpleNamespace(
+            name=f"notes-{index}.pdf",
+            path_lower=f"/documents/notes-{index}.pdf",
+        )
+        for index in range(2)
+    ]
+    client = MagicMock()
+    client.files_download.return_value = (None, SimpleNamespace(content=b"document"))
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.settings.workdir", str(tmp_path)),
+        patch("app.tasks.dropbox_corpus_import._PREFETCH_THREAD_STATE", SimpleNamespace()),
+        patch(
+            "app.tasks.dropbox_corpus_import._dropbox_client_from_stored_credentials",
+            return_value=client,
+        ) as client_factory,
+    ):
+        from app.tasks.dropbox_corpus_import import _prefetch_dropbox_entry
+
+        paths = [_prefetch_dropbox_entry(4, "encrypted", entry) for entry in entries]
+
+    assert client_factory.call_count == 1
+    assert client.files_download.call_count == 2
+    for path in paths:
+        os.remove(path)
+
+
+@pytest.mark.unit
 def test_index_first_page_prefetches_downloads_in_parallel(db_session, tmp_path):
     integration = _integration(db_session)
     integration.config = json.dumps(

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -558,6 +558,95 @@ def test_index_first_page_prefetches_downloads_in_parallel(db_session, tmp_path)
 
 
 @pytest.mark.unit
+def test_index_first_prefetch_keeps_a_bounded_lookahead_window(db_session, tmp_path):
+    from concurrent.futures import ThreadPoolExecutor as RealThreadPoolExecutor
+
+    integration = _integration(db_session)
+    integration.config = json.dumps(
+        {
+            "backfill_index_first_enabled": True,
+            "backfill_download_concurrency": 2,
+        }
+    )
+    job = DropboxImportJob(
+        id="job-index-first-bounded-prefetch",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Documents",
+        is_backfill=True,
+    )
+    db_session.add(job)
+    db_session.commit()
+    entries = [
+        SimpleNamespace(
+            id=f"id:bounded-{index}",
+            rev="rev-1",
+            name=f"notes-{index}.pdf",
+            size=8,
+            path_lower=f"/documents/notes-{index}.pdf",
+            path_display=f"/Documents/notes-{index}.pdf",
+        )
+        for index in range(10)
+    ]
+    page = SimpleNamespace(entries=entries, cursor="cursor-1", has_more=False)
+    dropbox_client = MagicMock()
+    dropbox_client.files_list_folder.return_value = page
+    executors = []
+
+    class TrackingExecutor:
+        def __init__(self, *, max_workers, thread_name_prefix):
+            self.submit_count = 0
+            self.executor = RealThreadPoolExecutor(
+                max_workers=max_workers,
+                thread_name_prefix=thread_name_prefix,
+            )
+            executors.append(self)
+
+        def submit(self, *args, **kwargs):
+            self.submit_count += 1
+            return self.executor.submit(*args, **kwargs)
+
+        def shutdown(self, *, wait, cancel_futures):
+            return self.executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+    def fake_prefetch(_integration_id, _stored_credentials, entry):
+        path = tmp_path / f"{entry.id.replace(':', '-')}.pdf"
+        path.write_bytes(b"document")
+        return str(path)
+
+    first_import = True
+
+    def fake_import(_db, _job, _integration, _client, _entry, *, prefetched_path=None):
+        nonlocal first_import
+        if first_import:
+            # Two initial submissions plus one replacement after consuming the
+            # first future prove that the other seven entries were not queued.
+            assert executors[0].submit_count == 3
+            first_import = False
+        assert prefetched_path is not None
+        os.remove(prefetched_path)
+        return "queued"
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.tasks.dropbox_corpus_import._dropbox_client", return_value=dropbox_client),
+        patch("app.tasks.dropbox_corpus_import.settings.vector_index_enabled", True),
+        patch("dropbox.files.FileMetadata", SimpleNamespace),
+        patch("app.tasks.dropbox_corpus_import.ThreadPoolExecutor", TrackingExecutor),
+        patch("app.tasks.dropbox_corpus_import._prefetch_dropbox_entry", side_effect=fake_prefetch) as prefetch,
+        patch("app.tasks.dropbox_corpus_import._import_file", side_effect=fake_import),
+    ):
+        from app.tasks.dropbox_corpus_import import run_dropbox_corpus_import
+
+        result = run_dropbox_corpus_import.run(job.id)
+
+    assert result["status"] == "completed"
+    assert result["queued"] == 10
+    assert prefetch.call_count == 10
+
+
+@pytest.mark.unit
 def test_index_first_falls_back_to_full_pipeline_when_vector_index_is_disabled():
     integration = SimpleNamespace(config=json.dumps({"backfill_index_first_enabled": True}))
 

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -1,6 +1,7 @@
 """Tests for resumable Dropbox corpus import and revision deduplication."""
 
 import json
+import os
 from contextlib import nullcontext
 from datetime import date, datetime, timezone
 from types import SimpleNamespace
@@ -383,6 +384,23 @@ def test_initial_backfill_index_first_can_be_enabled_live(value):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("config", "index_only", "expected"),
+    [
+        ({"backfill_download_concurrency": 4}, True, 4),
+        ({"backfill_download_concurrency": 99}, True, 8),
+        ({"backfill_download_concurrency": "invalid"}, True, 1),
+        ({"backfill_download_concurrency": 4}, False, 1),
+    ],
+)
+def test_index_first_download_concurrency_is_live_bounded_and_scoped(config, index_only, expected):
+    from app.tasks.dropbox_corpus_import import _index_first_download_concurrency
+
+    with patch("app.tasks.dropbox_corpus_import.settings.corpus_backfill_download_concurrency", 1):
+        assert _index_first_download_concurrency(config, index_only=index_only) == expected
+
+
+@pytest.mark.unit
 def test_index_first_backfill_bypasses_llm_budget_and_queues_direct_processing(db_session, tmp_path):
     integration = _integration(db_session)
     integration.config = json.dumps({"backfill_index_first_enabled": True})
@@ -426,6 +444,117 @@ def test_index_first_backfill_bypasses_llm_budget_and_queues_direct_processing(d
     queue_document.assert_called_once()
     assert queue_document.call_args.kwargs["index_only"] is True
     assert queue_document.call_args.kwargs["task_id"]
+
+
+@pytest.mark.unit
+def test_index_first_import_consumes_prefetched_file_without_redownloading(db_session, tmp_path):
+    integration = _integration(db_session)
+    integration.config = json.dumps({"backfill_index_first_enabled": True})
+    job = DropboxImportJob(
+        id="job-index-first-prefetched",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Documents",
+        is_backfill=True,
+    )
+    db_session.add(job)
+    db_session.commit()
+    entry = SimpleNamespace(
+        id="id:prefetched",
+        rev="rev-1",
+        name="notes.pdf",
+        size=8,
+        path_lower="/documents/notes.pdf",
+        path_display="/Documents/notes.pdf",
+    )
+    prefetched_path = tmp_path / "prefetched.pdf"
+    prefetched_path.write_bytes(b"document")
+    client = MagicMock()
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.settings.workdir", str(tmp_path)),
+        patch("app.tasks.dropbox_corpus_import.settings.vector_index_enabled", True),
+        patch("app.api.intake._queue_document", return_value=SimpleNamespace(id="task-id")),
+    ):
+        from app.tasks.dropbox_corpus_import import _import_file
+
+        assert (
+            _import_file(
+                db_session,
+                job,
+                integration,
+                client,
+                entry,
+                prefetched_path=str(prefetched_path),
+            )
+            == "queued"
+        )
+
+    client.files_download.assert_not_called()
+    assert not prefetched_path.exists()
+
+
+@pytest.mark.unit
+def test_index_first_page_prefetches_downloads_in_parallel(db_session, tmp_path):
+    integration = _integration(db_session)
+    integration.config = json.dumps(
+        {
+            "backfill_index_first_enabled": True,
+            "backfill_download_concurrency": 2,
+        }
+    )
+    job = DropboxImportJob(
+        id="job-index-first-parallel",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Documents",
+        is_backfill=True,
+    )
+    db_session.add(job)
+    db_session.commit()
+    entries = [
+        SimpleNamespace(
+            id=f"id:parallel-{index}",
+            rev="rev-1",
+            name=f"notes-{index}.pdf",
+            size=8,
+            path_lower=f"/documents/notes-{index}.pdf",
+            path_display=f"/Documents/notes-{index}.pdf",
+        )
+        for index in range(2)
+    ]
+    page = SimpleNamespace(entries=entries, cursor="cursor-1", has_more=False)
+    dropbox_client = MagicMock()
+    dropbox_client.files_list_folder.return_value = page
+
+    def fake_prefetch(_integration_id, _stored_credentials, entry):
+        path = tmp_path / f"{entry.id.replace(':', '-')}.pdf"
+        path.write_bytes(b"document")
+        return str(path)
+
+    def fake_import(_db, _job, _integration, _client, _entry, *, prefetched_path=None):
+        assert prefetched_path is not None
+        assert os.path.exists(prefetched_path)
+        os.remove(prefetched_path)
+        return "queued"
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.tasks.dropbox_corpus_import._dropbox_client", return_value=dropbox_client),
+        patch("app.tasks.dropbox_corpus_import.settings.vector_index_enabled", True),
+        patch("dropbox.files.FileMetadata", SimpleNamespace),
+        patch("app.tasks.dropbox_corpus_import._prefetch_dropbox_entry", side_effect=fake_prefetch) as prefetch,
+        patch("app.tasks.dropbox_corpus_import._import_file", side_effect=fake_import) as import_file,
+    ):
+        from app.tasks.dropbox_corpus_import import run_dropbox_corpus_import
+
+        result = run_dropbox_corpus_import.run(job.id)
+
+    assert result["status"] == "completed"
+    assert result["queued"] == 2
+    assert prefetch.call_count == 2
+    assert import_file.call_count == 2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- prefetch index-first Dropbox page downloads with bounded worker threads
- keep concurrency live-configurable per integration and disabled by default
- isolate Dropbox clients per thread and clean temporary files across skip/failure/retry paths
- document the operator and database-backed settings

## Safety boundaries
- initial backfills only
- index-first opt-in only
- normal uploads, incremental watch runs, full processing pipelines, and source preservation are unchanged
- concurrency is bounded to 8 and defaults to 1

## Validation
- 42 focused Dropbox corpus tests pass
- Ruff check and format pass
- mypy passes for the changed application modules
- the full local macOS suite exposes pre-existing environment/fixture failures around WORKDIR and UI assets; GitHub CI remains the authoritative Linux full-suite gate

Closes #1085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dropbox corpus backfills can download eligible files in parallel, improving processing speed for opted-in initial backfills.
  * Added a configurable download concurrency setting, supporting values from 1 to 8.
  * Prefetched files are reused during import to avoid redundant downloads.

* **Bug Fixes**
  * Improved cleanup of temporary downloaded files after processing.

* **Documentation**
  * Updated configuration guidance with backfill concurrency and related processing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->