### PR TITLE
Keep vector retries non-terminal

### DIFF
--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -1060,6 +1060,7 @@ def run_dropbox_corpus_ocr_backlog(self, job_id: str) -> dict:
                             "ocr_retrying",
                             "ocr_complete",
                             "indexing",
+                            "index_retrying",
                         )
                     ),
                 )

--- a/app/tasks/vector_index.py
+++ b/app/tasks/vector_index.py
@@ -52,7 +52,14 @@ def index_document_vectors(self, file_id: int, source_task_id: str | None = None
         try:
             count = QdrantVectorIndex().index_document(file_record)
         except Exception as exc:
-            _set_source_state(db, source_task_id, "failed", type(exc).__name__)
+            # ``BaseTaskWithRetry`` will reschedule intermediate failures after
+            # this task body raises.  Keep the durable source ledger explicitly
+            # non-terminal until Celery has exhausted that retry budget so the
+            # UI and corpus reconciliation do not report false failures.
+            retries = int(getattr(self.request, "retries", 0))
+            max_retries = int(getattr(self, "max_retries", 0))
+            state = "failed" if retries >= max_retries else "index_retrying"
+            _set_source_state(db, source_task_id, state, type(exc).__name__)
             db.commit()
             raise
         _set_source_state(db, source_task_id, "indexed")

--- a/tests/test_deferred_corpus_ocr.py
+++ b/tests/test_deferred_corpus_ocr.py
@@ -552,3 +552,52 @@ def test_deferred_ocr_backlog_respects_queue_high_watermark(db_session):
         "resume_in_seconds": 11,
     }
     schedule.assert_called_once_with(job.id, countdown=11)
+
+
+@pytest.mark.unit
+def test_deferred_ocr_backlog_waits_for_vector_index_retries(db_session):
+    integration = _integration(
+        db_session,
+        config={
+            "backfill_index_first_enabled": True,
+            "backfill_deferred_ocr_enabled": True,
+            "backfill_ocr_recheck_seconds": 13,
+        },
+    )
+    job = DropboxImportJob(
+        id="vector-retry-job",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Posteingang",
+        state="completed",
+        is_backfill=True,
+    )
+    imported = DropboxImportObject(
+        integration_id=integration.id,
+        dropbox_file_id="id:vector-retry",
+        revision="rev-1",
+        remote_path="/Posteingang/vector-retry.pdf",
+        task_id="vector-retry-task",
+        state="index_retrying",
+    )
+    db_session.add_all([job, imported])
+    db_session.commit()
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.settings.vector_index_enabled", True),
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_ocr_backlog") as schedule,
+    ):
+        from app.tasks.dropbox_corpus_import import run_dropbox_corpus_ocr_backlog
+
+        result = run_dropbox_corpus_ocr_backlog.run(job.id)
+
+    assert result == {
+        "status": "running",
+        "job_id": job.id,
+        "queued": 0,
+        "failed": 0,
+        "resume_in_seconds": 13,
+    }
+    schedule.assert_called_once_with(job.id, countdown=13)

--- a/tests/test_vector_destination.py
+++ b/tests/test_vector_destination.py
@@ -4,6 +4,8 @@ from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.models import DocumentIntake, FileRecord, IntegrationType
 
 
@@ -100,3 +102,83 @@ def test_index_first_vector_task_completes_source_ledger(db_session):
     assert result == {"status": "success", "file_id": record.id, "chunks_indexed": 2}
     assert intake.state == "indexed"
     assert intake.error is None
+
+
+def test_index_first_vector_task_keeps_intermediate_failure_retryable(db_session):
+    record = FileRecord(
+        filehash="vector-retry",
+        original_filename="retry.pdf",
+        local_filename="/workdir/original/retry.pdf",
+        file_size=10,
+        mime_type="application/pdf",
+        ocr_text="Retry this document after a transient Qdrant timeout.",
+    )
+    intake = DocumentIntake(
+        principal_id="owner",
+        idempotency_key="dropbox:retry",
+        source="dropbox",
+        original_filename="retry.pdf",
+        task_id="retry-task",
+        state="indexing",
+    )
+    db_session.add_all([record, intake])
+    db_session.commit()
+
+    with (
+        patch("app.tasks.vector_index.settings.vector_index_enabled", True),
+        patch("app.tasks.vector_index.SessionLocal", return_value=nullcontext(db_session)),
+        patch(
+            "app.utils.vector_index.QdrantVectorIndex.index_document",
+            side_effect=TimeoutError("Qdrant timed out"),
+        ),
+    ):
+        from app.tasks.vector_index import index_document_vectors
+
+        with pytest.raises(TimeoutError, match="Qdrant timed out"):
+            index_document_vectors.run(record.id, source_task_id="retry-task")
+
+    db_session.refresh(intake)
+    assert intake.state == "index_retrying"
+    assert intake.error == "TimeoutError"
+
+
+def test_index_first_vector_task_marks_exhausted_failure_terminal(db_session):
+    record = FileRecord(
+        filehash="vector-exhausted",
+        original_filename="exhausted.pdf",
+        local_filename="/workdir/original/exhausted.pdf",
+        file_size=10,
+        mime_type="application/pdf",
+        ocr_text="This document exhausted its Qdrant retry budget.",
+    )
+    intake = DocumentIntake(
+        principal_id="owner",
+        idempotency_key="dropbox:exhausted",
+        source="dropbox",
+        original_filename="exhausted.pdf",
+        task_id="exhausted-task",
+        state="indexing",
+    )
+    db_session.add_all([record, intake])
+    db_session.commit()
+
+    with (
+        patch("app.tasks.vector_index.settings.vector_index_enabled", True),
+        patch("app.tasks.vector_index.SessionLocal", return_value=nullcontext(db_session)),
+        patch(
+            "app.utils.vector_index.QdrantVectorIndex.index_document",
+            side_effect=TimeoutError("Qdrant timed out"),
+        ),
+    ):
+        from app.tasks.vector_index import index_document_vectors
+
+        index_document_vectors.push_request(retries=index_document_vectors.max_retries)
+        try:
+            with pytest.raises(TimeoutError, match="Qdrant timed out"):
+                index_document_vectors.run(record.id, source_task_id="exhausted-task")
+        finally:
+            index_document_vectors.pop_request()
+
+    db_session.refresh(intake)
+    assert intake.state == "failed"
+    assert intake.error == "TimeoutError"


### PR DESCRIPTION
Closes #1092

## What changed
- keep transient Qdrant indexing failures in an explicit `index_retrying` source-ledger state while Celery still has retries available
- mark the source as `failed` only after the retry budget is exhausted
- retain the successful transition to `indexed`, including clearing the intake error

## Why
The retry mechanism already rescheduled transient failures, but the durable intake/import ledger was marked terminal too early. That made the UI and corpus reconciliation report false failures while indexing was still in flight.

## Validation
- 78 focused vector, corpus import, and deferred OCR tests passed
- Ruff passed for changed files
- mypy passed for the vector task
- `git diff --check` passed

Preprod only; production remains untouched.