### PR TITLE
Reconcile stale corpus queue entries

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -934,6 +934,20 @@ class Settings(BaseSettings):
         ge=1,
         description="Delay between deferred corpus OCR backlog capacity checks. Default: 30 seconds.",
     )
+    corpus_backfill_reconcile_batch_size: int = Field(
+        default=10,
+        ge=1,
+        le=100,
+        description="Maximum stale corpus ledger items reconciled per coordinator pass. Default: 10.",
+    )
+    corpus_backfill_stale_queue_seconds: int = Field(
+        default=900,
+        ge=60,
+        description=(
+            "Minimum age before a queued corpus item can be recovered after a worker or broker interruption. "
+            "Default: 900 seconds."
+        ),
+    )
     corpus_backfill_queue_high_watermark: int = Field(
         default=50,
         ge=1,

--- a/app/tasks/dropbox_corpus_import.py
+++ b/app/tasks/dropbox_corpus_import.py
@@ -671,7 +671,6 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
             raise
 
         index_only = job.is_backfill and _index_first_enabled(integration)
-        deferred_ocr = _deferred_ocr_enabled(config, index_only=index_only)
         download_concurrency = _index_first_download_concurrency(config, index_only=index_only)
         integration_id = integration.id
         stored_credentials = integration.credentials
@@ -823,7 +822,7 @@ def run_dropbox_corpus_import(self, job_id: str) -> dict:
 
     if page.has_more:
         schedule_dropbox_corpus_import(job_id)
-    elif deferred_ocr:
+    elif index_only:
         schedule_dropbox_corpus_ocr_backlog(job_id)
     return result
 
@@ -881,7 +880,11 @@ def _claim_deferred_state(db, imported: DropboxImportObject, expected: str, clai
 
 def _recover_stale_deferred_claims(db, integration_id: int, *, stale_before: datetime) -> int:
     """Return abandoned coordinator claims to a recoverable durable state."""
-    mappings = {"ocr_claimed": "needs_ocr", "indexing": "ocr_complete"}
+    mappings = {
+        "ocr_claimed": "needs_ocr",
+        "indexing": "ocr_complete",
+        "requeue_claimed": "queued",
+    }
     recovered = 0
     for claimed, ready in mappings.items():
         rows = (
@@ -902,6 +905,97 @@ def _recover_stale_deferred_claims(db, integration_id: int, *, stale_before: dat
     return recovered
 
 
+def _reconcile_stale_queued(
+    db,
+    integration: UserIntegration,
+    *,
+    stale_before: datetime,
+    limit: int,
+) -> tuple[int, int]:
+    """Recover bounded index-first work abandoned before its ledger advanced.
+
+    Existing FileRecords are never sent through document ingestion again:
+    text-backed records go straight to the idempotent vector task, while
+    textless records enter the deferred OCR pass. Only rows without any
+    FileRecord are requeued from their still-durable staging file.
+    """
+    if limit <= 0:
+        return 0, 0
+
+    candidates = (
+        db.query(DropboxImportObject, DocumentIntake)
+        .join(DocumentIntake, DocumentIntake.id == DropboxImportObject.intake_id)
+        .filter(
+            DropboxImportObject.integration_id == integration.id,
+            DropboxImportObject.state == "queued",
+            DocumentIntake.state == "queued",
+            DocumentIntake.updated_at < stale_before,
+        )
+        .order_by(DocumentIntake.updated_at, DropboxImportObject.id)
+        .limit(limit)
+        .all()
+    )
+    queued = 0
+    gaps = 0
+
+    from app.api.intake import _queue_document
+    from app.tasks.vector_index import index_document_vectors
+
+    for imported, intake in candidates:
+        if not imported.task_id:
+            _set_deferred_ocr_state(db, imported, "requeue_missing", "Corpus task correlation is unavailable")
+            db.commit()
+            gaps += 1
+            continue
+
+        file_id = _deferred_ocr_file_id(db, imported)
+        record = db.query(FileRecord).filter(FileRecord.id == file_id).first() if file_id else None
+        if record is not None:
+            if not record.ocr_text or not record.ocr_text.strip():
+                _set_deferred_ocr_state(db, imported, "needs_ocr", "Recovered stale queued document without text")
+                db.commit()
+                continue
+            if not _claim_deferred_state(db, imported, "queued", "indexing"):
+                continue
+            try:
+                index_document_vectors.apply_async(
+                    args=[record.id],
+                    kwargs={"source_task_id": imported.task_id},
+                    priority=settings.corpus_backfill_task_priority,
+                )
+            except Exception as exc:
+                _set_deferred_ocr_state(db, imported, "queued", type(exc).__name__)
+                db.commit()
+                continue
+            queued += 1
+            continue
+
+        staged_path = intake.local_path
+        if not staged_path or not os.path.exists(staged_path):
+            _set_deferred_ocr_state(db, imported, "requeue_missing", "Staged corpus file is unavailable")
+            db.commit()
+            gaps += 1
+            continue
+        if not _claim_deferred_state(db, imported, "queued", "requeue_claimed"):
+            continue
+        try:
+            _queue_document(
+                staged_path,
+                intake.original_filename or os.path.basename(staged_path),
+                None,
+                integration.owner_id if settings.multi_user_enabled else None,
+                index_only=True,
+                task_id=imported.task_id,
+            )
+        except Exception as exc:
+            _set_deferred_ocr_state(db, imported, "queued", type(exc).__name__)
+            db.commit()
+            continue
+        queued += 1
+
+    return queued, gaps
+
+
 @celery.task(base=BaseTaskWithRetry, bind=True, name="run_dropbox_corpus_ocr_backlog")
 def run_dropbox_corpus_ocr_backlog(self, job_id: str) -> dict:
     """Queue bounded OCR-only work for scanned index-first corpus documents."""
@@ -909,6 +1003,7 @@ def run_dropbox_corpus_ocr_backlog(self, job_id: str) -> dict:
     recheck_delay = settings.corpus_backfill_ocr_recheck_seconds
     queued = 0
     failed = 0
+    gaps = 0
 
     with SessionLocal() as db:
         job = db.query(DropboxImportJob).filter(DropboxImportJob.id == job_id).first()
@@ -925,8 +1020,10 @@ def run_dropbox_corpus_ocr_backlog(self, job_id: str) -> dict:
             config = {}
         if job.state != "completed":
             return {"status": "waiting", "job_id": job.id, "detail": "Initial corpus import is not complete"}
-        if not _deferred_ocr_enabled(config, index_only=job.is_backfill and _index_first_enabled(integration)):
+        index_only = job.is_backfill and _index_first_enabled(integration)
+        if not index_only:
             return {"status": "disabled", "job_id": job.id}
+        deferred_ocr = _deferred_ocr_enabled(config, index_only=index_only)
 
         recheck_delay = _bounded_config_int(
             config,
@@ -934,8 +1031,16 @@ def run_dropbox_corpus_ocr_backlog(self, job_id: str) -> dict:
             settings.corpus_backfill_ocr_recheck_seconds,
             minimum=1,
         )
-        stale_before = datetime.now(timezone.utc) - timedelta(seconds=max(300, recheck_delay * 10))
-        _recover_stale_deferred_claims(db, integration.id, stale_before=stale_before)
+        now = datetime.now(timezone.utc)
+        stale_claim_before = now - timedelta(seconds=max(300, recheck_delay * 10))
+        _recover_stale_deferred_claims(db, integration.id, stale_before=stale_claim_before)
+        stale_queue_seconds = _bounded_config_int(
+            config,
+            "backfill_stale_queue_seconds",
+            settings.corpus_backfill_stale_queue_seconds,
+            minimum=60,
+        )
+        stale_queue_before = now - timedelta(seconds=stale_queue_seconds)
         high_watermark = _bounded_config_int(
             config,
             "backfill_queue_high_watermark",
@@ -945,13 +1050,30 @@ def run_dropbox_corpus_ocr_backlog(self, job_id: str) -> dict:
         queue_depth = _pending_queue_depth()
         if queue_depth is not None and queue_depth >= high_watermark:
             should_recheck = True
-            result = {
+            result: dict[str, object] = {
                 "status": "paused",
                 "job_id": job.id,
                 "queue_depth": queue_depth,
                 "resume_in_seconds": recheck_delay,
             }
         else:
+            available_slots = high_watermark if queue_depth is None else max(0, high_watermark - queue_depth)
+            reconcile_batch_size = _bounded_config_int(
+                config,
+                "backfill_reconcile_batch_size",
+                settings.corpus_backfill_reconcile_batch_size,
+                minimum=1,
+                maximum=100,
+            )
+            reconciled_queued, reconciled_gaps = _reconcile_stale_queued(
+                db,
+                integration,
+                stale_before=stale_queue_before,
+                limit=min(reconcile_batch_size, available_slots),
+            )
+            queued += reconciled_queued
+            gaps += reconciled_gaps
+            available_slots = max(0, available_slots - reconciled_queued)
             batch_size = _bounded_config_int(
                 config,
                 "backfill_ocr_batch_size",
@@ -959,8 +1081,7 @@ def run_dropbox_corpus_ocr_backlog(self, job_id: str) -> dict:
                 minimum=1,
                 maximum=100,
             )
-            if queue_depth is not None:
-                batch_size = min(batch_size, max(0, high_watermark - queue_depth))
+            batch_size = min(batch_size, available_slots)
             remaining_slots = batch_size
 
             from app.tasks.vector_index import index_document_vectors
@@ -998,16 +1119,18 @@ def run_dropbox_corpus_ocr_backlog(self, job_id: str) -> dict:
                 queued += 1
                 remaining_slots -= 1
 
-            candidates = (
-                db.query(DropboxImportObject)
-                .filter(
-                    DropboxImportObject.integration_id == integration.id,
-                    DropboxImportObject.state == "needs_ocr",
+            candidates: list[DropboxImportObject] = []
+            if deferred_ocr:
+                candidates = (
+                    db.query(DropboxImportObject)
+                    .filter(
+                        DropboxImportObject.integration_id == integration.id,
+                        DropboxImportObject.state == "needs_ocr",
+                    )
+                    .order_by(DropboxImportObject.imported_at, DropboxImportObject.id)
+                    .limit(remaining_slots)
+                    .all()
                 )
-                .order_by(DropboxImportObject.imported_at, DropboxImportObject.id)
-                .limit(remaining_slots)
-                .all()
-            )
 
             from app.tasks.process_with_ocr import process_with_ocr
 
@@ -1048,33 +1171,49 @@ def run_dropbox_corpus_ocr_backlog(self, job_id: str) -> dict:
                     _set_deferred_ocr_state(db, imported, "needs_ocr", type(exc).__name__)
                     db.commit()
 
+            pending_states = [
+                "ocr_claimed",
+                "ocr_queued",
+                "ocr_retrying",
+                "ocr_complete",
+                "indexing",
+                "index_retrying",
+                "queued",
+                "requeue_claimed",
+            ]
+            if deferred_ocr:
+                pending_states.append("needs_ocr")
             pending = (
                 db.query(DropboxImportObject.id)
                 .filter(
                     DropboxImportObject.integration_id == integration.id,
-                    DropboxImportObject.state.in_(
-                        (
-                            "needs_ocr",
-                            "ocr_claimed",
-                            "ocr_queued",
-                            "ocr_retrying",
-                            "ocr_complete",
-                            "indexing",
-                            "index_retrying",
-                        )
-                    ),
+                    DropboxImportObject.state.in_(pending_states),
                 )
                 .first()
                 is not None
             )
             should_recheck = pending
+            gap_states = ["failed", "needs_conversion", "requeue_missing"]
+            if not deferred_ocr:
+                gap_states.append("needs_ocr")
+            gap_count = (
+                db.query(DropboxImportObject.id)
+                .filter(
+                    DropboxImportObject.integration_id == integration.id,
+                    DropboxImportObject.state.in_(gap_states),
+                )
+                .count()
+            )
+            gaps = max(gaps, gap_count)
             result = {
-                "status": "running" if pending else "completed",
+                "status": "running" if pending else ("completed_with_gaps" if gaps else "completed"),
                 "job_id": job.id,
                 "queued": queued,
                 "failed": failed,
                 "resume_in_seconds": recheck_delay if pending else None,
             }
+            if gaps:
+                result["gaps"] = gaps
 
     if should_recheck:
         schedule_dropbox_corpus_ocr_backlog(job_id, countdown=recheck_delay)

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -2203,6 +2203,22 @@ SETTING_METADATA = {
         "required": False,
         "restart_required": False,
     },
+    "corpus_backfill_reconcile_batch_size": {
+        "category": "Processing",
+        "description": "Maximum stale corpus ledger items reconciled per coordinator pass (default: 10)",
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
+    "corpus_backfill_stale_queue_seconds": {
+        "category": "Processing",
+        "description": "Minimum queued age before interrupted corpus work is recovered (default: 900 seconds)",
+        "type": "integer",
+        "sensitive": False,
+        "required": False,
+        "restart_required": False,
+    },
     "corpus_backfill_queue_high_watermark": {
         "category": "Processing",
         "description": "Pause corpus backfills at this queued plus worker-reserved Celery depth (default: 50)",

--- a/tests/test_deferred_corpus_ocr.py
+++ b/tests/test_deferred_corpus_ocr.py
@@ -2,6 +2,7 @@
 
 import json
 from contextlib import nullcontext
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -360,6 +361,45 @@ def test_completed_index_first_import_schedules_deferred_ocr(db_session):
 
 
 @pytest.mark.unit
+def test_completed_index_first_import_schedules_reconciliation_without_ocr(db_session):
+    integration = _integration(
+        db_session,
+        config={
+            "source_type": "dropbox",
+            "folder_path": "/Posteingang",
+            "backfill_index_first_enabled": True,
+            "backfill_deferred_ocr_enabled": False,
+        },
+    )
+    job = DropboxImportJob(
+        id="reconciliation-only-job",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Posteingang",
+        is_backfill=True,
+    )
+    db_session.add(job)
+    db_session.commit()
+    page = SimpleNamespace(entries=[], cursor="finished-cursor", has_more=False)
+    dropbox_client = Mock()
+    dropbox_client.files_list_folder.return_value = page
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.tasks.dropbox_corpus_import._dropbox_client", return_value=dropbox_client),
+        patch("app.tasks.dropbox_corpus_import.settings.vector_index_enabled", True),
+        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_ocr_backlog") as schedule,
+    ):
+        from app.tasks.dropbox_corpus_import import run_dropbox_corpus_import
+
+        result = run_dropbox_corpus_import.run(job.id)
+
+    assert result["status"] == "completed"
+    schedule.assert_called_once_with(job.id)
+
+
+@pytest.mark.unit
 def test_deferred_ocr_backlog_stages_bounded_low_priority_work(db_session, tmp_path):
     integration = _integration(
         db_session,
@@ -506,11 +546,384 @@ def test_deferred_ocr_backlog_leaves_office_files_for_conversion(db_session, tmp
 
     db_session.refresh(imported)
     db_session.refresh(intake)
-    assert result["status"] == "completed"
+    assert result["status"] == "completed_with_gaps"
+    assert result["gaps"] == 1
     assert imported.state == "needs_conversion"
     assert intake.state == "needs_conversion"
     assert intake.error == "PDF conversion is required"
     apply_async.assert_not_called()
+
+
+@pytest.mark.unit
+def test_stale_queued_text_record_is_reindexed_without_reingestion(db_session, tmp_path):
+    integration = _integration(db_session)
+    original = tmp_path / "searchable.pdf"
+    original.write_bytes(b"searchable")
+    record = _file_record(db_session, original, filename="searchable.pdf")
+    record.ocr_text = "Useful embedded document text"
+    intake = DocumentIntake(
+        principal_id=integration.owner_id,
+        idempotency_key="dropbox:stale-searchable",
+        source="dropbox-corpus",
+        original_filename="searchable.pdf",
+        local_path=str(original),
+        task_id="stale-searchable-task",
+        state="queued",
+        updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    db_session.add(intake)
+    db_session.flush()
+    imported = DropboxImportObject(
+        integration_id=integration.id,
+        dropbox_file_id="id:stale-searchable",
+        revision="rev-1",
+        remote_path="/Posteingang/searchable.pdf",
+        intake_id=intake.id,
+        task_id="stale-searchable-task",
+        state="queued",
+    )
+    db_session.add_all(
+        [
+            imported,
+            ProcessingLog(
+                file_id=record.id,
+                task_id="stale-searchable-task",
+                step_name="process_document",
+                status="success",
+            ),
+        ]
+    )
+    db_session.commit()
+
+    with patch("app.tasks.vector_index.index_document_vectors.apply_async") as index:
+        from app.tasks.dropbox_corpus_import import _reconcile_stale_queued
+
+        queued, gaps = _reconcile_stale_queued(
+            db_session,
+            integration,
+            stale_before=datetime.now(timezone.utc) - timedelta(minutes=15),
+            limit=10,
+        )
+
+    db_session.refresh(imported)
+    db_session.refresh(intake)
+    assert (queued, gaps) == (1, 0)
+    assert imported.state == "indexing"
+    assert intake.state == "indexing"
+    index.assert_called_once_with(
+        args=[record.id],
+        kwargs={"source_task_id": "stale-searchable-task"},
+        priority=9,
+    )
+
+
+@pytest.mark.unit
+def test_stale_queued_textless_record_moves_to_deferred_ocr(db_session, tmp_path):
+    integration = _integration(db_session)
+    original = tmp_path / "scan.pdf"
+    original.write_bytes(b"scan")
+    record = _file_record(db_session, original)
+    intake = DocumentIntake(
+        principal_id=integration.owner_id,
+        idempotency_key="dropbox:stale-scan",
+        source="dropbox-corpus",
+        original_filename="scan.pdf",
+        local_path=str(original),
+        task_id="stale-scan-task",
+        state="queued",
+        updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    db_session.add(intake)
+    db_session.flush()
+    imported = DropboxImportObject(
+        integration_id=integration.id,
+        dropbox_file_id="id:stale-scan",
+        revision="rev-1",
+        remote_path="/Posteingang/scan.pdf",
+        intake_id=intake.id,
+        task_id="stale-scan-task",
+        state="queued",
+    )
+    db_session.add_all(
+        [
+            imported,
+            ProcessingLog(
+                file_id=record.id,
+                task_id="stale-scan-task",
+                step_name="process_document",
+                status="skipped",
+            ),
+        ]
+    )
+    db_session.commit()
+
+    with patch("app.tasks.vector_index.index_document_vectors.apply_async") as index:
+        from app.tasks.dropbox_corpus_import import _reconcile_stale_queued
+
+        queued, gaps = _reconcile_stale_queued(
+            db_session,
+            integration,
+            stale_before=datetime.now(timezone.utc) - timedelta(minutes=15),
+            limit=10,
+        )
+
+    db_session.refresh(imported)
+    db_session.refresh(intake)
+    assert (queued, gaps) == (0, 0)
+    assert imported.state == "needs_ocr"
+    assert intake.state == "needs_ocr"
+    index.assert_not_called()
+
+
+@pytest.mark.unit
+def test_stale_queue_reconciliation_runs_when_deferred_ocr_is_disabled(db_session, tmp_path):
+    integration = _integration(
+        db_session,
+        config={
+            "backfill_index_first_enabled": True,
+            "backfill_deferred_ocr_enabled": False,
+            "backfill_stale_queue_seconds": 60,
+            "backfill_ocr_recheck_seconds": 17,
+        },
+    )
+    job = DropboxImportJob(
+        id="reconcile-without-ocr-job",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Posteingang",
+        state="completed",
+        is_backfill=True,
+    )
+    original = tmp_path / "searchable-without-ocr.pdf"
+    original.write_bytes(b"searchable")
+    record = _file_record(db_session, original, filename="searchable-without-ocr.pdf")
+    record.ocr_text = "Existing embedded text"
+    intake = DocumentIntake(
+        principal_id=integration.owner_id,
+        idempotency_key="dropbox:reconcile-without-ocr",
+        source="dropbox-corpus",
+        original_filename="searchable-without-ocr.pdf",
+        local_path=str(original),
+        task_id="reconcile-without-ocr-task",
+        state="queued",
+        updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    db_session.add_all([job, intake])
+    db_session.flush()
+    imported = DropboxImportObject(
+        integration_id=integration.id,
+        dropbox_file_id="id:reconcile-without-ocr",
+        revision="rev-1",
+        remote_path="/Posteingang/searchable-without-ocr.pdf",
+        intake_id=intake.id,
+        task_id="reconcile-without-ocr-task",
+        state="queued",
+    )
+    db_session.add_all(
+        [
+            imported,
+            ProcessingLog(
+                file_id=record.id,
+                task_id="reconcile-without-ocr-task",
+                step_name="process_document",
+                status="success",
+            ),
+        ]
+    )
+    db_session.commit()
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.settings.vector_index_enabled", True),
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.tasks.vector_index.index_document_vectors.apply_async") as index,
+        patch("app.tasks.process_with_ocr.process_with_ocr.apply_async") as ocr,
+        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_ocr_backlog") as schedule,
+    ):
+        from app.tasks.dropbox_corpus_import import run_dropbox_corpus_ocr_backlog
+
+        result = run_dropbox_corpus_ocr_backlog.run(job.id)
+
+    db_session.refresh(imported)
+    assert result == {
+        "status": "running",
+        "job_id": job.id,
+        "queued": 1,
+        "failed": 0,
+        "resume_in_seconds": 17,
+    }
+    assert imported.state == "indexing"
+    index.assert_called_once()
+    ocr.assert_not_called()
+    schedule.assert_called_once_with(job.id, countdown=17)
+
+
+@pytest.mark.unit
+def test_stale_queued_unprocessed_file_is_requeued_once(db_session, tmp_path):
+    integration = _integration(db_session)
+    staged = tmp_path / "staged.pdf"
+    staged.write_bytes(b"staged")
+    intake = DocumentIntake(
+        principal_id=integration.owner_id,
+        idempotency_key="dropbox:stale-unprocessed",
+        source="dropbox-corpus",
+        original_filename="staged.pdf",
+        local_path=str(staged),
+        task_id="stale-unprocessed-task",
+        state="queued",
+        updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    db_session.add(intake)
+    db_session.flush()
+    imported = DropboxImportObject(
+        integration_id=integration.id,
+        dropbox_file_id="id:stale-unprocessed",
+        revision="rev-1",
+        remote_path="/Posteingang/staged.pdf",
+        intake_id=intake.id,
+        task_id="stale-unprocessed-task",
+        state="queued",
+    )
+    db_session.add(imported)
+    db_session.commit()
+
+    with patch("app.api.intake._queue_document") as queue_document:
+        from app.tasks.dropbox_corpus_import import _reconcile_stale_queued
+
+        first = _reconcile_stale_queued(
+            db_session,
+            integration,
+            stale_before=datetime.now(timezone.utc) - timedelta(minutes=15),
+            limit=10,
+        )
+        second = _reconcile_stale_queued(
+            db_session,
+            integration,
+            stale_before=datetime.now(timezone.utc) - timedelta(minutes=15),
+            limit=10,
+        )
+
+    db_session.refresh(imported)
+    db_session.refresh(intake)
+    assert first == (1, 0)
+    assert second == (0, 0)
+    assert imported.state == "requeue_claimed"
+    assert intake.state == "requeue_claimed"
+    queue_document.assert_called_once_with(
+        str(staged),
+        "staged.pdf",
+        None,
+        None,
+        index_only=True,
+        task_id="stale-unprocessed-task",
+    )
+
+
+@pytest.mark.unit
+def test_stale_queued_missing_staging_file_is_reported_as_gap(db_session, tmp_path):
+    integration = _integration(db_session)
+    intake = DocumentIntake(
+        principal_id=integration.owner_id,
+        idempotency_key="dropbox:stale-missing",
+        source="dropbox-corpus",
+        original_filename="missing.pdf",
+        local_path=str(tmp_path / "missing.pdf"),
+        task_id="stale-missing-task",
+        state="queued",
+        updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    db_session.add(intake)
+    db_session.flush()
+    imported = DropboxImportObject(
+        integration_id=integration.id,
+        dropbox_file_id="id:stale-missing",
+        revision="rev-1",
+        remote_path="/Posteingang/missing.pdf",
+        intake_id=intake.id,
+        task_id="stale-missing-task",
+        state="queued",
+    )
+    db_session.add(imported)
+    db_session.commit()
+
+    from app.tasks.dropbox_corpus_import import _reconcile_stale_queued
+
+    queued, gaps = _reconcile_stale_queued(
+        db_session,
+        integration,
+        stale_before=datetime.now(timezone.utc) - timedelta(minutes=15),
+        limit=10,
+    )
+
+    db_session.refresh(imported)
+    db_session.refresh(intake)
+    assert (queued, gaps) == (0, 1)
+    assert imported.state == "requeue_missing"
+    assert intake.state == "requeue_missing"
+    assert intake.error == "Staged corpus file is unavailable"
+
+
+@pytest.mark.unit
+def test_fresh_queued_record_keeps_coordinator_running_without_requeue(db_session):
+    integration = _integration(
+        db_session,
+        config={
+            "backfill_index_first_enabled": True,
+            "backfill_deferred_ocr_enabled": True,
+            "backfill_ocr_recheck_seconds": 13,
+            "backfill_stale_queue_seconds": 900,
+        },
+    )
+    job = DropboxImportJob(
+        id="fresh-queued-job",
+        integration_id=integration.id,
+        owner_id=integration.owner_id,
+        root_path="/Posteingang",
+        state="completed",
+        is_backfill=True,
+    )
+    intake = DocumentIntake(
+        principal_id=integration.owner_id,
+        idempotency_key="dropbox:fresh-queued",
+        source="dropbox-corpus",
+        original_filename="fresh.pdf",
+        task_id="fresh-queued-task",
+        state="queued",
+    )
+    db_session.add_all([job, intake])
+    db_session.flush()
+    imported = DropboxImportObject(
+        integration_id=integration.id,
+        dropbox_file_id="id:fresh-queued",
+        revision="rev-1",
+        remote_path="/Posteingang/fresh.pdf",
+        intake_id=intake.id,
+        task_id="fresh-queued-task",
+        state="queued",
+    )
+    db_session.add(imported)
+    db_session.commit()
+
+    with (
+        patch("app.tasks.dropbox_corpus_import.settings.vector_index_enabled", True),
+        patch("app.tasks.dropbox_corpus_import.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.dropbox_corpus_import._pending_queue_depth", return_value=0),
+        patch("app.api.intake._queue_document") as queue_document,
+        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_ocr_backlog") as schedule,
+    ):
+        from app.tasks.dropbox_corpus_import import run_dropbox_corpus_ocr_backlog
+
+        result = run_dropbox_corpus_ocr_backlog.run(job.id)
+
+    assert result == {
+        "status": "running",
+        "job_id": job.id,
+        "queued": 0,
+        "failed": 0,
+        "resume_in_seconds": 13,
+    }
+    queue_document.assert_not_called()
+    schedule.assert_called_once_with(job.id, countdown=13)
 
 
 @pytest.mark.unit

--- a/tests/test_dropbox_corpus_import.py
+++ b/tests/test_dropbox_corpus_import.py
@@ -576,6 +576,7 @@ def test_index_first_page_prefetches_downloads_in_parallel(db_session, tmp_path)
         patch("dropbox.files.FileMetadata", SimpleNamespace),
         patch("app.tasks.dropbox_corpus_import._prefetch_dropbox_entry", side_effect=fake_prefetch) as prefetch,
         patch("app.tasks.dropbox_corpus_import._import_file", side_effect=fake_import) as import_file,
+        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_ocr_backlog"),
     ):
         from app.tasks.dropbox_corpus_import import run_dropbox_corpus_import
 
@@ -666,6 +667,7 @@ def test_index_first_prefetch_keeps_a_bounded_lookahead_window(db_session, tmp_p
         patch("app.tasks.dropbox_corpus_import.ThreadPoolExecutor", TrackingExecutor),
         patch("app.tasks.dropbox_corpus_import._prefetch_dropbox_entry", side_effect=fake_prefetch) as prefetch,
         patch("app.tasks.dropbox_corpus_import._import_file", side_effect=fake_import),
+        patch("app.tasks.dropbox_corpus_import.schedule_dropbox_corpus_ocr_backlog"),
     ):
         from app.tasks.dropbox_corpus_import import run_dropbox_corpus_import
 


### PR DESCRIPTION
## What changed

- recover stale queued corpus ledgers in bounded batches
- reindex existing text-backed records idempotently
- route textless records into deferred OCR
- requeue only unprocessed records whose durable staged file still exists
- expose missing staging files and conversion requirements as corpus gaps
- make the reconciliation batch and stale age live-configurable

## Why

Worker, broker, or rollout interruptions could leave durable Dropbox corpus rows in queued state even after the corresponding Celery task disappeared. The coordinator previously ignored those rows, so a corpus could appear to stop progressing without an explicit failure.

## Validation

- 71 related import, intake, vector destination, and deferred OCR tests pass
- Ruff lint and format pass
- mypy passes for the changed source modules

Closes #1094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable controls for recovering interrupted corpus processing and limiting reconciliation batches.
  * Improved OCR backlog recovery for stalled queued items, including reindexing, reprocessing, and missing-file handling.
  * Added clearer completion reporting when processing finishes with unresolved gaps.

* **Bug Fixes**
  * Prevented fresh queued items from being reprocessed prematurely.
  * Preserved relevant error details when deferred processing cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->