### PR TITLE
Fix index-first deferred text step status

### DIFF
--- a/app/tasks/process_document.py
+++ b/app/tasks/process_document.py
@@ -108,6 +108,7 @@ def _mark_index_first_pending(
     *,
     original_input_path: str | None = None,
     working_path: str | None = None,
+    embedded_text_checked: bool = False,
 ) -> dict[str, object]:
     """Retain a corpus item for a later OCR/conversion pass without LLM work."""
     with SessionLocal() as db:
@@ -117,6 +118,21 @@ def _mark_index_first_pending(
             record.local_filename = immutable_path
         _set_index_first_source_state(db, task_id, "needs_ocr", reason)
         db.commit()
+    if embedded_text_checked:
+        log_task_progress(
+            task_id,
+            "check_text",
+            "success",
+            "No embedded text found; deferred to the corpus OCR pass",
+            file_id=file_id,
+        )
+        log_task_progress(
+            task_id,
+            "extract_text",
+            "skipped",
+            "No embedded text available; deferred to the corpus OCR pass",
+            file_id=file_id,
+        )
     log_task_progress(
         task_id,
         "process_document",
@@ -873,6 +889,7 @@ def process_document(
             "No usable embedded text",
             original_input_path=original_local_file,
             working_path=new_local_path,
+            embedded_text_checked=True,
         )
     logger.info(f"[{task_id}] No embedded text found. Queueing OCR processing")
     log_task_progress(

--- a/tests/test_process_document.py
+++ b/tests/test_process_document.py
@@ -183,7 +183,7 @@ def test_index_first_pending_never_deletes_only_remaining_source(db_session, tmp
 
     with (
         patch("app.tasks.process_document.SessionLocal", return_value=nullcontext(db_session)),
-        patch("app.tasks.process_document.log_task_progress"),
+        patch("app.tasks.process_document.log_task_progress") as progress,
     ):
         from app.tasks.process_document import _mark_index_first_pending
 
@@ -193,12 +193,21 @@ def test_index_first_pending_never_deletes_only_remaining_source(db_session, tmp
             "No usable embedded text",
             original_input_path=str(only_copy),
             working_path=str(only_copy),
+            embedded_text_checked=True,
         )
 
     db_session.refresh(record)
     assert result["status"] == "Index-first pending OCR"
     assert only_copy.exists()
     assert record.local_filename == str(only_copy)
+    assert any(
+        call.args[1:4] == ("check_text", "success", "No embedded text found; deferred to the corpus OCR pass")
+        for call in progress.call_args_list
+    )
+    assert any(
+        call.args[1:4] == ("extract_text", "skipped", "No embedded text available; deferred to the corpus OCR pass")
+        for call in progress.call_args_list
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #1100

## Summary
- finalize the embedded-text check before deferring image-only corpus documents to OCR
- mark local extraction skipped for the deferred pass
- keep the existing durable `needs_ocr` handoff and immutable source retention
- add regression coverage for both terminal step states

## Validation
- targeted regression: 1 passed
- deferred OCR and corpus coordinator suites: 77 passed
- 11 unrelated `test_process_document.py` cases fail locally because the macOS pytest temp directory is outside the configured `/private/tmp` workdir; CI runs them in the supported Linux layout
- Ruff lint and format pass