### PR TITLE
Improve document research event counting

### DIFF
--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -30,6 +30,55 @@ _METADATA_EXCERPT_CHARS = 2_400
 _RESEARCH_DOCUMENT_LIMIT = 50
 _RAG_PROMPT_EXCERPT_BUDGET = 60_000
 _KEYWORD_SCOPE_BATCH_SIZE = 5_000
+_RESEARCH_QUERY_STOPWORDS = {
+    "a",
+    "an",
+    "belegbar",
+    "biggest",
+    "bis",
+    "bisher",
+    "changed",
+    "der",
+    "die",
+    "ein",
+    "eine",
+    "einem",
+    "for",
+    "größte",
+    "habe",
+    "hat",
+    "have",
+    "how",
+    "höchste",
+    "ich",
+    "in",
+    "ist",
+    "jahre",
+    "largest",
+    "many",
+    "mein",
+    "meine",
+    "most",
+    "oft",
+    "often",
+    "over",
+    "per",
+    "sich",
+    "the",
+    "teuerste",
+    "time",
+    "trend",
+    "über",
+    "übernachtet",
+    "verändert",
+    "war",
+    "was",
+    "what",
+    "wie",
+    "wieviele",
+    "years",
+    "jetzt",
+}
 
 
 class KnowledgeSearchRequest(BaseModel):
@@ -306,6 +355,16 @@ def _focused_research_excerpt(text: str | None, query: str) -> str:
     return "\n…\n".join(windows)[:_METADATA_EXCERPT_CHARS]
 
 
+def _research_keyword_query(query: str) -> str:
+    """Remove question scaffolding while retaining domain and entity terms."""
+    tokens = [
+        token
+        for token in _normalized_search_text(query).split()
+        if token not in _RESEARCH_QUERY_STOPWORDS and len(token) >= 2
+    ]
+    return " ".join(tokens[:12]) or query[:512]
+
+
 def _keyword_research_results(
     request: Request,
     db: Session,
@@ -315,6 +374,7 @@ def _keyword_research_results(
     try:
         from app.utils.meilisearch_client import search_documents
 
+        keyword_query = _research_keyword_query(query)
         user = request.session.get("user")
         requires_owner_scope = settings.multi_user_enabled and not (isinstance(user, dict) and user.get("is_admin"))
         if requires_owner_scope:
@@ -324,7 +384,7 @@ def _keyword_research_results(
             ]
             keyword_pages = [
                 search_documents(
-                    query[:512],
+                    keyword_query,
                     file_ids=accessible_ids[offset : offset + _KEYWORD_SCOPE_BATCH_SIZE],
                     page=1,
                     per_page=100,
@@ -332,7 +392,7 @@ def _keyword_research_results(
                 for offset in range(0, len(accessible_ids), _KEYWORD_SCOPE_BATCH_SIZE)
             ]
         else:
-            keyword_pages = [search_documents(query[:512], page=1, per_page=100)]
+            keyword_pages = [search_documents(keyword_query, page=1, per_page=100)]
     except Exception as exc:
         logger.warning("Keyword research retrieval failed: %s", exc)
         return [], 0, False
@@ -438,6 +498,10 @@ def _rag_messages(
         "Cite every material claim with one or more source numbers such as [1] or [2]. If the sources "
         "do not support an answer, say so clearly and do not guess. Preserve dates, amounts, names, and "
         "uncertainty exactly. For counts, maxima, or trends, deduplicate events and show the evidence used. "
+        "Count real-world occurrences, not documents or transport legs. Treat an outbound and return flight as "
+        "one trip or stay unless the user explicitly asks for flight segments. Merge duplicate receipts, itinerary "
+        "copies, and expense bundles that share dates, booking references, order numbers, or the same event. State "
+        "what was counted and the deduplication key. "
         "Never describe a result as corpus-complete when COVERAGE says truncated=true; in that case use wording "
         "such as 'at least' or 'among the retrieved evidence'. Answer in the user's language."
     )
@@ -459,6 +523,20 @@ def _no_results_answer(request: Request, message: str) -> str:
     if preferred_language.startswith("de") or looks_german:
         return "Ich konnte keine zugänglichen Dokumente finden, die eine Antwort belegen."
     return "I could not find any accessible documents that support an answer."
+
+
+def _cited_sources(answer: str, sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return only sources explicitly cited by the grounded answer."""
+    available_numbers = {int(source["number"]) for source in sources}
+    cited_numbers: set[int] = set()
+    for citation in re.findall(r"\[([\d\s,;–-]+)\]", answer):
+        cited_numbers.update(int(value) for value in re.findall(r"\d+", citation))
+        for start_value, end_value in re.findall(r"(\d+)\s*[-–]\s*(\d+)", citation):
+            start, end = int(start_value), int(end_value)
+            if start <= end and end - start <= len(available_numbers):
+                cited_numbers.update(range(start, end + 1))
+    cited_numbers.intersection_update(available_numbers)
+    return [source for source in sources if source["number"] in cited_numbers]
 
 
 @router.post("/chat")
@@ -526,7 +604,7 @@ def chat_with_knowledge(request: Request, body: KnowledgeChatRequest, db: DbSess
         "answer": answer,
         "model": model,
         "retrieved_count": len(results),
-        "sources": sources,
+        "sources": _cited_sources(answer, sources),
         "coverage": coverage,
     }
 

--- a/frontend/templates/search.html
+++ b/frontend/templates/search.html
@@ -538,7 +538,7 @@
     if (data && role === 'assistant') {
       const meta = document.createElement('div');
       meta.className = 'knowledge-chat-meta';
-      meta.textContent = searchI18n.chatModel + ': ' + data.model + ' · ' + searchI18n.chatSources + ': ' + data.retrieved_count;
+      meta.textContent = searchI18n.chatModel + ': ' + data.model + ' · ' + searchI18n.chatSources + ': ' + (Array.isArray(data.sources) ? data.sources.length : 0);
       if (data.coverage && data.coverage.truncated) {
         meta.textContent += ' · ' + searchI18n.chatCoverageLimited;
       }

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -354,7 +354,22 @@ def test_keyword_research_scopes_meilisearch_before_ranking(db_session):
     assert [result["document_id"] for result in results] == [101]
     assert total == 1
     assert truncated is False
-    search.assert_called_once_with("London flight", file_ids=[101], page=1, per_page=100)
+    search.assert_called_once_with("london flight", file_ids=[101], page=1, per_page=100)
+
+
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        ("Wie hat sich mein HbA1c über die Jahre verändert?", "hba1c"),
+        ("Wie oft war ich in London per Flugzeug belegbar?", "london flugzeug"),
+        ("Wie oft habe ich in einem Motel One Hotel übernachtet?", "motel one hotel"),
+        ("Was war der teuerste Amazon Kauf bis jetzt?", "amazon kauf"),
+    ],
+)
+def test_research_keyword_query_keeps_domain_terms(question, expected):
+    from app.api.knowledge import _research_keyword_query
+
+    assert _research_keyword_query(question) == expected
 
 
 def test_search_returns_cited_authoritative_document(client, db_session):
@@ -550,7 +565,7 @@ def test_document_chat_uses_cross_document_research_for_counts(client, db_sessio
         "keyword_matches": 125,
         "truncated": True,
     }
-    keyword_search.assert_called_once_with("Wie oft war ich in London per Flugzeug?", page=1, per_page=100)
+    keyword_search.assert_called_once_with("london flugzeug", page=1, per_page=100)
     assert "Never describe a result as corpus-complete" in completion.call_args.kwargs["messages"][0]["content"]
     assert "'truncated': True" in completion.call_args.kwargs["messages"][-1]["content"]
 
@@ -577,6 +592,20 @@ def test_rag_prompt_has_aggregate_excerpt_budget():
     prompt = messages[-1]["content"]
     assert prompt.count("SOURCE [") == 50
     assert prompt.count("x") - prompt.count("Excerpt") == 60_000
+
+
+def test_document_chat_returns_only_sources_cited_by_answer():
+    from app.api.knowledge import _cited_sources
+
+    sources = [{"number": number, "document_id": number} for number in range(1, 6)]
+
+    assert _cited_sources("Supported by [2] and again by [4].", sources) == [sources[1], sources[3]]
+    assert _cited_sources("Supported by [1, 3] and [4-5].", sources) == [
+        sources[0],
+        sources[2],
+        sources[3],
+        sources[4],
+    ]
 
 
 def test_no_results_answer_uses_browser_or_question_language(client):

--- a/tests/test_views_search.py
+++ b/tests/test_views_search.py
@@ -43,7 +43,7 @@ class TestSearchPage:
         assert 'id="knowledge-chat-input"' in text
         assert "/api/knowledge/chat" in text
         assert "source.source_url" in text
-        assert "data.retrieved_count" in text
+        assert "data.sources.length" in text
 
     def test_search_page_query_too_long(self, client):
         """GET /search?q=<very long> returns 422 for exceeding max_length."""


### PR DESCRIPTION
## Summary
- reduce corpus-wide keyword queries to domain and entity terms
- instruct RAG counting to deduplicate trips, stays, orders, and duplicate documents
- return and display only sources explicitly cited by the answer

## Validation
- 123 focused tests pass
- Ruff passes
- mypy passes

Follow-up to #1104 and the Preprod Chrome E2E finding on London trip counting.