### PR TITLE
fix: prevent provider SDK prompt logging

### DIFF
--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -4,11 +4,18 @@ import logging
 import os
 
 from celery import Celery
-from celery.signals import task_failure, worker_ready
+from celery.signals import after_setup_logger, after_setup_task_logger, task_failure, worker_ready
 
 from app.config import settings
+from app.utils.log_safety import restrict_sensitive_provider_logging
 
 logger = logging.getLogger(__name__)
+
+# Celery replaces/configures loggers during worker startup, so apply the
+# safeguard both now and after Celery has installed its handlers.
+restrict_sensitive_provider_logging()
+after_setup_logger.connect(restrict_sensitive_provider_logging)
+after_setup_task_logger.connect(restrict_sensitive_provider_logging)
 
 celery = Celery(
     "document_processor",

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.middleware.rate_limit import create_limiter, get_rate_limit_exceeded_ha
 from app.middleware.request_size_limit import RequestSizeLimitMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
 from app.utils.config_validator import check_all_configs
+from app.utils.log_safety import restrict_sensitive_provider_logging
 from app.utils.notification import init_apprise, notify_shutdown, notify_startup
 from app.utils.sentry import init_sentry
 
@@ -58,7 +59,8 @@ from app.views.files import router as files_router
 # traditional (non-container) deployments and centralised SIEM ingestion.
 #
 # Noisy third-party loggers (httpx, httpcore, authlib, etc.) are pinned to
-# WARNING when the app-level is DEBUG to keep output useful.
+# WARNING when the app-level is DEBUG to keep output useful. Provider SDKs
+# that can include prompts or document text are always pinned to WARNING.
 # ---------------------------------------------------------------------------
 _explicit_log_level = os.environ.get("LOG_LEVEL")
 if settings.debug and _explicit_log_level is None:
@@ -137,6 +139,8 @@ if _effective_level_int <= logging.DEBUG:
         "watchfiles",
     ):
         logging.getLogger(_noisy).setLevel(logging.WARNING)
+
+restrict_sensitive_provider_logging()
 
 _startup_logger = logging.getLogger(__name__)
 _startup_logger.info(

--- a/app/utils/log_safety.py
+++ b/app/utils/log_safety.py
@@ -1,0 +1,11 @@
+"""Logging safeguards for providers that may include user content in DEBUG output."""
+
+import logging
+
+SENSITIVE_PROVIDER_LOGGERS = ("openai", "openai._base_client")
+
+
+def restrict_sensitive_provider_logging(*_args: object, **_kwargs: object) -> None:
+    """Prevent third-party SDKs from logging prompts, documents, or credentials."""
+    for logger_name in SENSITIVE_PROVIDER_LOGGERS:
+        logging.getLogger(logger_name).setLevel(logging.WARNING)

--- a/tests/utils/test_log_safety.py
+++ b/tests/utils/test_log_safety.py
@@ -1,0 +1,28 @@
+import logging
+
+import pytest
+
+from app.utils.log_safety import restrict_sensitive_provider_logging
+
+
+@pytest.fixture
+def openai_loggers():
+    parent = logging.getLogger("openai")
+    request_logger = logging.getLogger("openai._base_client")
+    previous_levels = (parent.level, request_logger.level)
+    yield parent, request_logger
+    parent.setLevel(previous_levels[0])
+    request_logger.setLevel(previous_levels[1])
+
+
+@pytest.mark.unit
+def test_sensitive_provider_logging_never_includes_debug_prompts(openai_loggers):
+    parent, request_logger = openai_loggers
+    parent.setLevel(logging.DEBUG)
+    request_logger.setLevel(logging.DEBUG)
+
+    restrict_sensitive_provider_logging()
+
+    assert parent.getEffectiveLevel() == logging.WARNING
+    assert request_logger.getEffectiveLevel() == logging.WARNING
+    assert not request_logger.isEnabledFor(logging.DEBUG)


### PR DESCRIPTION
## What changed

- Pins the OpenAI SDK logger hierarchy to `WARNING` even when DocuElevate runs with application-level `DEBUG` logging.
- Applies the safeguard in the API process and in Celery workers after Celery configures its loggers.
- Adds a regression test proving OpenAI DEBUG request payloads are disabled.

## Why

The OpenAI Python SDK can log complete request payloads at DEBUG level. RAG requests and metadata extraction may include personal document text, so those payloads must never be written to pod logs. Normal DocuElevate audit and application logs remain available.

## Validation

- Ruff lint and formatting
- 20 focused logging tests
- Mypy on the changed application modules

Closes #1107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Reduced the risk of sensitive prompts, documents, and credentials appearing in debug logs from third-party providers.
  * Applied logging safeguards during application and background worker startup.

* **Tests**
  * Added coverage confirming sensitive provider debug logging is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->