### PR TITLE
fix(research): version evidence-faithful corpus answers

### DIFF
--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -22,6 +22,8 @@ from app.utils.user_scope import apply_owner_filter, get_current_owner_id
 
 logger = logging.getLogger(__name__)
 
+# Bump whenever retrieval, reduction, or synthesis semantics change so a
+# deployment cannot serve answers produced by an older research algorithm.
 _RESEARCH_CACHE_VERSION = 2
 router = APIRouter(prefix="/knowledge", tags=["knowledge"])
 DbSession = Annotated[Session, Depends(get_db)]


### PR DESCRIPTION
Follow-up to #1112.

The correctness fix was squash-merged with a non-conventional subject, so semantic-release correctly left the application at 0.184.1. This documents the research cache-version invariant and restores the conventional `fix` signal so automation can publish a patch version.

No production deployment is authorized; the resulting image remains preprod-only.