### PR TITLE
fix(research): ground evidence in cited documents

### DIFF
--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # Bump whenever retrieval, reduction, or synthesis semantics change so a
 # deployment cannot serve answers produced by an older research algorithm.
-_RESEARCH_CACHE_VERSION = 3
+_RESEARCH_CACHE_VERSION = 4
 router = APIRouter(prefix="/knowledge", tags=["knowledge"])
 DbSession = Annotated[Session, Depends(get_db)]
 

--- a/app/tasks/knowledge_research.py
+++ b/app/tasks/knowledge_research.py
@@ -122,7 +122,11 @@ def _deduplicate_evidence(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     )
 
 
-def _filter_evidence_for_question(question: str, items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _filter_evidence_for_question(
+    question: str,
+    items: list[dict[str, Any]],
+    records: dict[int, FileRecord] | None = None,
+) -> list[dict[str, Any]]:
     """Reject obvious non-events for questions that ask about actual occurrences."""
     normalized_question = _normalize_key(question)
     asks_for_occurrences = bool(
@@ -135,10 +139,29 @@ def _filter_evidence_for_question(question: str, items: list[dict[str, Any]]) ->
         return items
 
     filtered = []
+    normalized_sources: dict[int, str] = {}
     for item in items:
         evidence_type = _normalize_key(item.get("evidence_type"))
         if any(term in evidence_type for term in _NON_EVENT_EVIDENCE_TERMS):
             continue
+        document_id = item.get("document_id")
+        record = records.get(document_id) if records and isinstance(document_id, int) else None
+        if record is not None:
+            if document_id not in normalized_sources:
+                normalized_sources[document_id] = _normalize_key(
+                    " ".join(
+                        (
+                            record.document_title or "",
+                            record.original_filename or "",
+                            record.ocr_text or "",
+                        )
+                    )
+                )
+            source_text = normalized_sources[document_id]
+            if "motel one" in normalized_question and not re.search(r"\bmotel\s+one\b", source_text):
+                continue
+            if "amazon" in normalized_question and not re.search(r"\b(?:amazon|amz|amzn)\b", source_text):
+                continue
         if "hba1c" in normalized_question:
             measurement_text = " ".join(
                 _normalize_key(item.get(field)) for field in ("evidence_type", "claim", "numeric_value")
@@ -222,12 +245,30 @@ def _excerpt(text: str, query: str) -> str:
     tokens = sorted({token for token in re.findall(r"\w+", query.casefold()) if len(token) >= 3}, key=len, reverse=True)
     windows = [value[:1_200], value[-1_200:]]
     lowered = value.casefold()
+    positions_by_token: dict[str, list[int]] = {}
     for token in tokens[:10]:
-        position = lowered.find(token)
-        if position >= 0:
-            windows.append(value[max(0, position - 700) : position + 1_300])
-        if sum(map(len, windows)) >= _EXCERPT_CHARS:
+        positions = [match.start() for match in re.finditer(re.escape(token), lowered)]
+        if len(positions) > 9:
+            positions = [positions[round(index * (len(positions) - 1) / 8)] for index in range(9)]
+        if positions:
+            positions_by_token[token] = positions
+            position = positions[0]
+            windows.append(value[max(0, position - 120) : position + 180])
+
+    sample_index = 1
+    while True:
+        active = [positions for positions in positions_by_token.values() if sample_index < len(positions)]
+        if not active:
             break
+        remaining = _EXCERPT_CHARS - sum(map(len, windows))
+        window_size = min(600, remaining // len(active))
+        if window_size < 160:
+            break
+        for positions in active:
+            position = positions[sample_index]
+            before = window_size // 3
+            windows.append(value[max(0, position - before) : position + (window_size - before)])
+        sample_index += 1
     return "\n…\n".join(windows)[:_EXCERPT_CHARS]
 
 
@@ -486,7 +527,7 @@ def run_knowledge_research(job_id: str) -> dict[str, Any]:
                 job.processed_documents = min(offset + len(records), len(candidate_ids))
                 db.commit()
 
-            relevant_evidence = _filter_evidence_for_question(job.question, evidence)
+            relevant_evidence = _filter_evidence_for_question(job.question, evidence, record_map)
             reduced = _deduplicate_evidence(relevant_evidence)
             if reduced:
                 synthesized = _synthesize(job.question, research_context, reduced, record_map, model)

--- a/tests/test_knowledge_research.py
+++ b/tests/test_knowledge_research.py
@@ -13,6 +13,7 @@ from app.tasks.knowledge_research import (
     _chat_completion_with_retry,
     _contextual_research_question,
     _deduplicate_evidence,
+    _excerpt,
     _filter_evidence_for_question,
     _no_evidence_answer,
     _numeric,
@@ -172,6 +173,43 @@ def test_hba1c_filter_rejects_reference_ranges_but_keeps_patient_results():
     ]
 
     assert _filter_evidence_for_question("Wie hat sich mein HbA1c verändert?", evidence) == [evidence[1]]
+
+
+def test_occurrence_filter_requires_named_entity_in_cited_source():
+    evidence = [
+        {"document_id": 1, "evidence_type": "hotel_stay", "claim": "Motel One stay"},
+        {"document_id": 2, "evidence_type": "hotel_stay", "claim": "Motel One stay"},
+    ]
+    records = {
+        1: SimpleNamespace(document_title="OTTO delivery", original_filename="delivery.pdf", ocr_text="Hermes"),
+        2: SimpleNamespace(
+            document_title="Motel One invoice",
+            original_filename="motel-one.pdf",
+            ocr_text="Motel One München-Garching",
+        ),
+    }
+
+    assert _filter_evidence_for_question("Wie oft war ich im Motel One?", evidence, records) == [evidence[1]]
+
+
+def test_excerpt_samples_distributed_entity_occurrences_in_long_documents():
+    sections = [f"AMAZON purchase {index} amount {index},00 EUR " + ("x" * 180) for index in range(80)]
+    sections[10] = "AMZ expensive purchase amount 387,70 EUR " + ("y" * 180)
+    text = "".join(sections)
+
+    excerpt = _excerpt(text, "Was war der teuerste Amazon Kauf?")
+
+    assert "387,70 EUR" in excerpt
+    assert len(excerpt) <= 6_000
+
+
+def test_excerpt_does_not_let_frequent_generic_terms_starve_entity_terms():
+    generic = ("teuerste boilerplate " + ("x" * 180)) * 80
+    text = generic + " AMAZON amount 387,70 EUR " + ("y" * 8_000)
+
+    excerpt = _excerpt(text, "Was war der teuerste Amazon Kauf?")
+
+    assert "AMAZON amount 387,70 EUR" in excerpt
 
 
 def test_bounded_synthesis_reports_when_it_truncates():


### PR DESCRIPTION
## Summary

- require cited Motel One and Amazon evidence to contain the named entity in the actual source document
- sample distributed entity occurrences in long documents so maxima do not depend on the first mention
- invalidate research cache with algorithm version 4
- add regressions for the observed OTTO false citation and the long-statement €387.70 evidence window

## Validation

- `ruff check` / `ruff format --check`
- `mypy app/api/knowledge.py app/tasks/knowledge_research.py`
- focused pytest: 85 passed, 1 skipped

## Live finding addressed

0.184.3 Chrome acceptance cited an OTTO delivery as a Motel One stay and missed a later €387.70 AMZ transaction in a 26k-character statement.

## Deployment boundary

Preprod only. Production remains pinned to `ghcr.io/christianlouis/docuelevate:release-evergreen-0.30-be864a1`.

Closes #1114