### PR TITLE
fix(research): isolate interactive jobs from backfill queue

### DIFF
--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -38,6 +38,9 @@ celery.conf.broker_transport_options = {
 # Set the default queue and routing so that tasks are enqueued on "document_processor"
 celery.conf.task_default_queue = "document_processor"
 celery.conf.task_routes = {
+    "app.tasks.knowledge_research.run_knowledge_research": {
+        "queue": "knowledge_research"
+    },
     "app.tasks.*": {"queue": "document_processor"},
 }
 

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -38,9 +38,7 @@ celery.conf.broker_transport_options = {
 # Set the default queue and routing so that tasks are enqueued on "document_processor"
 celery.conf.task_default_queue = "document_processor"
 celery.conf.task_routes = {
-    "app.tasks.knowledge_research.run_knowledge_research": {
-        "queue": "knowledge_research"
-    },
+    "app.tasks.knowledge_research.run_knowledge_research": {"queue": "knowledge_research"},
     "app.tasks.*": {"queue": "document_processor"},
 }
 

--- a/app/celery_worker.py
+++ b/app/celery_worker.py
@@ -75,6 +75,9 @@ logger = logging.getLogger(__name__)
 register_settings_reload_signal()
 
 celery.conf.task_routes = {
+    "app.tasks.knowledge_research.run_knowledge_research": {
+        "queue": "knowledge_research"
+    },
     "app.tasks.*": {"queue": "default"},
 }
 

--- a/app/celery_worker.py
+++ b/app/celery_worker.py
@@ -75,9 +75,7 @@ logger = logging.getLogger(__name__)
 register_settings_reload_signal()
 
 celery.conf.task_routes = {
-    "app.tasks.knowledge_research.run_knowledge_research": {
-        "queue": "knowledge_research"
-    },
+    "app.tasks.knowledge_research.run_knowledge_research": {"queue": "knowledge_research"},
     "app.tasks.*": {"queue": "default"},
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -54,6 +54,22 @@ services:
     volumes:
       - /var/docparse/workdir:/workdir
 
+  knowledge-research-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    working_dir: /workdir
+    command: ["celery", "-A", "app.celery_worker", "worker", "--loglevel=info", "--concurrency=1", "-Q", "knowledge_research"]
+    env_file:
+      - .env
+    environment:
+      - PYTHONPATH=/app
+    depends_on:
+      - redis
+    volumes:
+      - /var/docparse/workdir:/workdir
+
   gotenberg:
     image: gotenberg/gotenberg:latest
     container_name: gotenberg

--- a/docs/ProductionReadiness.md
+++ b/docs/ProductionReadiness.md
@@ -317,13 +317,14 @@ worker:
 
 ### Worker Queue Tuning
 
-Celery workers process three queues with different priorities:
+Celery workers process four queues with different priorities:
 
 | Queue | Purpose |
 |-------|---------|
 | `document_processor` | Main document processing tasks (OCR, conversion) |
 | `default` | Metadata extraction, storage uploads |
 | `celery` | Built-in Celery management tasks |
+| `knowledge_research` | Interactive, exhaustive document research jobs |
 
 To dedicate workers to specific queues in high-volume deployments:
 
@@ -333,7 +334,15 @@ celery -A app.celery_worker worker -Q document_processor --concurrency=4
 
 # General worker — everything else
 celery -A app.celery_worker worker -Q default,celery --concurrency=2
+
+# Interactive research worker — isolate user-facing analysis from backfills
+celery -A app.celery_worker worker -Q knowledge_research --concurrency=1
 ```
+
+Run at least one `knowledge_research` worker wherever the knowledge chat API is
+enabled. Keep its concurrency deliberately low and scale it independently;
+otherwise long corpus imports can delay an interactive research job before it
+even starts.
 
 ---
 

--- a/helm/docuelevate/templates/knowledge-research-worker-deployment.yaml
+++ b/helm/docuelevate/templates/knowledge-research-worker-deployment.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.knowledgeResearchWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "docuelevate.fullname" . }}-knowledge-research-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "docuelevate.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledge-research-worker
+spec:
+  replicas: {{ .Values.knowledgeResearchWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "docuelevate.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: knowledge-research-worker
+  template:
+    metadata:
+      labels:
+        {{- include "docuelevate.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: knowledge-research-worker
+      {{- with .Values.knowledgeResearchWorker.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "docuelevate.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.knowledgeResearchWorker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: knowledge-research-worker
+          image: {{ include "docuelevate.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - celery
+            - -A
+            - app.celery_worker
+            - worker
+            - --loglevel=info
+            - --concurrency={{ .Values.knowledgeResearchWorker.concurrency }}
+            - -Q
+            - knowledge_research
+          envFrom:
+            - configMapRef:
+                name: {{ include "docuelevate.fullname" . }}-config
+            - secretRef:
+                name: {{ include "docuelevate.fullname" . }}-secret
+          {{- with .Values.knowledgeResearchWorker.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.knowledgeResearchWorker.resources | nindent 12 }}
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+      volumes:
+        - name: workdir
+          {{- if .Values.workdir.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.workdir.persistence.existingClaim | default (printf "%s-workdir" (include "docuelevate.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.knowledgeResearchWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.knowledgeResearchWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.knowledgeResearchWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/docuelevate/values.yaml
+++ b/helm/docuelevate/values.yaml
@@ -190,6 +190,31 @@ worker:
     capabilities:
       drop: ["ALL"]
 
+knowledgeResearchWorker:
+  enabled: true
+  replicaCount: 1
+  concurrency: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: ["ALL"]
+
 # ---------------------------------------------------------------------------
 # Shared workdir volume (api + worker mount the same PVC)
 # ---------------------------------------------------------------------------

--- a/tests/test_celery_app.py
+++ b/tests/test_celery_app.py
@@ -41,6 +41,9 @@ class TestCeleryAppConfig:
         assert celery.conf.task_routes is not None
         assert "app.tasks.*" in celery.conf.task_routes
         assert celery.conf.task_routes["app.tasks.*"]["queue"] == "document_processor"
+        assert celery.conf.task_routes[
+            "app.tasks.knowledge_research.run_knowledge_research"
+        ]["queue"] == "knowledge_research"
 
     def test_broker_connection_retry_on_startup(self):
         """Test that broker connection retry on startup is enabled."""

--- a/tests/test_celery_app.py
+++ b/tests/test_celery_app.py
@@ -41,9 +41,10 @@ class TestCeleryAppConfig:
         assert celery.conf.task_routes is not None
         assert "app.tasks.*" in celery.conf.task_routes
         assert celery.conf.task_routes["app.tasks.*"]["queue"] == "document_processor"
-        assert celery.conf.task_routes[
-            "app.tasks.knowledge_research.run_knowledge_research"
-        ]["queue"] == "knowledge_research"
+        assert (
+            celery.conf.task_routes["app.tasks.knowledge_research.run_knowledge_research"]["queue"]
+            == "knowledge_research"
+        )
 
     def test_broker_connection_retry_on_startup(self):
         """Test that broker connection retry on startup is enabled."""

--- a/tests/test_celery_worker.py
+++ b/tests/test_celery_worker.py
@@ -47,10 +47,7 @@ class TestCeleryWorkerConfig:
         """Test that task routes are set."""
         mod = _reload_celery_worker()
         routes = mod.celery.conf.task_routes
-        assert (
-            routes["app.tasks.knowledge_research.run_knowledge_research"]["queue"]
-            == "knowledge_research"
-        )
+        assert routes["app.tasks.knowledge_research.run_knowledge_research"]["queue"] == "knowledge_research"
         assert routes is not None
         assert "app.tasks.*" in routes
 

--- a/tests/test_celery_worker.py
+++ b/tests/test_celery_worker.py
@@ -47,6 +47,10 @@ class TestCeleryWorkerConfig:
         """Test that task routes are set."""
         mod = _reload_celery_worker()
         routes = mod.celery.conf.task_routes
+        assert (
+            routes["app.tasks.knowledge_research.run_knowledge_research"]["queue"]
+            == "knowledge_research"
+        )
         assert routes is not None
         assert "app.tasks.*" in routes
 


### PR DESCRIPTION
## Summary

- route exhaustive knowledge research to a dedicated `knowledge_research` Celery queue
- add a separately scalable Compose worker for interactive research
- document production queue isolation and cover routing in configuration tests

## Why

An authenticated HbA1c research request remained queued with no progress for more than 45 seconds while the preprod corpus backfill saturated the general worker. The research algorithm is correct, but conversational clients need the job to start independently from bulk indexing.

## Validation

- `git diff --check`
- Compose structure inspected for separate worker command and shared workdir
- focused Celery routing tests added (full dependency environment will run in CI)

Closes #1122


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated processing for knowledge research jobs, helping interactive research run independently from document processing.
  - Added a specialized worker configuration for the new research workload.
- **Documentation**
  - Updated production guidance to cover four processing queues.
  - Added recommendations for running a dedicated interactive research worker when knowledge chat is enabled.
- **Tests**
  - Added coverage to verify research jobs are assigned to the correct queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->