### PR TITLE
Fix large-corpus search index reconciliation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,12 +72,17 @@ release. Delivery is split into independently reversible slices:
    - Keep the existing whole-document embedding for duplicate detection; vector export is
      optional and idempotent.
    - Provide explicit backfill and health/status operations for the existing corpus.
-5. **P0 — DearConcierge retrieval contract**
+5. **P0 — Complete lexical corpus index**
+   - Reconcile every processed, non-duplicate document into Meilisearch without a
+     fixed corpus-size ceiling.
+   - Use bounded, resumable bulk updates on a dedicated worker and expose the
+     remaining gap so exhaustive answers cannot silently claim incomplete coverage.
+6. **P0 — DearConcierge retrieval contract**
    - Expose authenticated semantic search and cited full-text retrieval with DocuElevate's
      existing owner/share checks applied to every result.
    - Support OAuth browser sessions and personal Bearer tokens first; add an MCP adapter as
      a thin client over the same API rather than duplicating authorization logic.
-6. **P0 — Preprod acceptance and promotion gate**
+7. **P0 — Preprod acceptance and promotion gate**
    - Prove retry/idempotency, owner isolation, Dropbox resume, vector backfill, citation
      retrieval, and end-to-end DearConcierge queries in preprod.
    - Do not change the production image or enable the Evergreen sender without a separate,

--- a/app/api/scheduled_jobs.py
+++ b/app/api/scheduled_jobs.py
@@ -223,7 +223,7 @@ DEFAULT_JOBS: list[dict[str, Any]] = [
             "Indexes documents that have OCR text or AI metadata but are missing "
             "from the Meilisearch search index. Useful after enabling search on "
             "an existing installation or after an index rebuild. "
-            "Processes up to 100 documents per run. "
+            "Processes up to 500 documents per run using bounded bulk updates. "
             "Runs hourly by default."
         ),
         "task_name": "app.tasks.batch_tasks.sync_search_index",

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -39,6 +39,7 @@ celery.conf.broker_transport_options = {
 celery.conf.task_default_queue = "document_processor"
 celery.conf.task_routes = {
     "app.tasks.knowledge_research.run_knowledge_research": {"queue": "knowledge_research"},
+    "app.tasks.batch_tasks.sync_search_index": {"queue": "search_index"},
     "app.tasks.*": {"queue": "document_processor"},
 }
 

--- a/app/celery_worker.py
+++ b/app/celery_worker.py
@@ -76,6 +76,7 @@ register_settings_reload_signal()
 
 celery.conf.task_routes = {
     "app.tasks.knowledge_research.run_knowledge_research": {"queue": "knowledge_research"},
+    "app.tasks.batch_tasks.sync_search_index": {"queue": "search_index"},
     "app.tasks.*": {"queue": "default"},
 }
 

--- a/app/tasks/batch_tasks.py
+++ b/app/tasks/batch_tasks.py
@@ -581,6 +581,8 @@ _SEARCH_SYNC_BATCH_SIZE: int = 500
 _SEARCH_ID_PAGE_SIZE: int = 1000
 #: Keep individual Meilisearch update payloads bounded because OCR text can be large.
 _SEARCH_INDEX_CHUNK_SIZE: int = 50
+#: Approximate character ceiling per update (well below Meilisearch's HTTP payload limit).
+_SEARCH_INDEX_CHUNK_CHAR_LIMIT: int = 5_000_000
 
 
 def _get_all_search_index_ids(index: object) -> set[int]:
@@ -676,6 +678,7 @@ def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE, continue_until_
 
         batches: list[list[tuple[FileRecord, str, dict]]] = []
         current_batch: list[tuple[FileRecord, str, dict]] = []
+        current_batch_characters = 0
         skipped = 0
         for record in candidates:
             metadata: dict = {}
@@ -685,10 +688,17 @@ def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE, continue_until_
                 except (json.JSONDecodeError, ValueError):
                     pass
 
-            current_batch.append((record, record.ocr_text or "", metadata))
+            text = record.ocr_text or ""
+            if current_batch and current_batch_characters + len(text) > _SEARCH_INDEX_CHUNK_CHAR_LIMIT:
+                batches.append(current_batch)
+                current_batch = []
+                current_batch_characters = 0
+            current_batch.append((record, text, metadata))
+            current_batch_characters += len(text)
             if len(current_batch) == _SEARCH_INDEX_CHUNK_SIZE:
                 batches.append(current_batch)
                 current_batch = []
+                current_batch_characters = 0
         if current_batch:
             batches.append(current_batch)
 

--- a/app/tasks/batch_tasks.py
+++ b/app/tasks/batch_tasks.py
@@ -576,11 +576,39 @@ def backfill_missing_metadata(batch_size: int = _METADATA_BACKFILL_BATCH_SIZE) -
 # ---------------------------------------------------------------------------
 
 #: Maximum documents to index per sync run.
-_SEARCH_SYNC_BATCH_SIZE: int = 100
+_SEARCH_SYNC_BATCH_SIZE: int = 500
+#: Page size used while reading IDs already committed to Meilisearch.
+_SEARCH_ID_PAGE_SIZE: int = 1000
+#: Keep individual Meilisearch update payloads bounded because OCR text can be large.
+_SEARCH_INDEX_CHUNK_SIZE: int = 50
+
+
+def _get_all_search_index_ids(index: object) -> set[int]:
+    """Return every numeric file ID currently committed to Meilisearch."""
+    existing_ids: set[int] = set()
+    offset = 0
+    while True:
+        result = index.get_documents(
+            {
+                "fields": ["file_id"],
+                "limit": _SEARCH_ID_PAGE_SIZE,
+                "offset": offset,
+            }
+        )
+        documents = result.results
+        existing_ids.update(
+            int(document["file_id"])
+            for document in documents
+            if "file_id" in document and str(document["file_id"]).isdigit()
+        )
+        if len(documents) < _SEARCH_ID_PAGE_SIZE:
+            break
+        offset += _SEARCH_ID_PAGE_SIZE
+    return existing_ids
 
 
 @celery.task(name="app.tasks.batch_tasks.sync_search_index")
-def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE) -> dict:
+def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE, continue_until_complete: bool = False) -> dict:
     """
     Index documents in Meilisearch that have OCR text or AI metadata but are
     not yet present in the search index.
@@ -595,14 +623,17 @@ def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE) -> dict:
     ``ai_metadata``) but are absent from the index, and re-indexes them.
 
     A configurable *batch_size* caps the number of documents indexed per run.
+    When *continue_until_complete* is true, another bounded task is scheduled
+    after a successful batch until the index is reconciled.
 
     Args:
-        batch_size: Maximum number of documents to index per run (default 100).
+        batch_size: Maximum number of documents to index per run (default 500).
+        continue_until_complete: Continue with another bounded task while gaps remain.
 
     Returns:
-        A summary dict with ``indexed`` and ``skipped`` counts.
+        A summary dict with ``indexed``, ``skipped``, and ``remaining`` counts.
     """
-    from app.utils.meilisearch_client import get_meilisearch_client, index_document
+    from app.utils.meilisearch_client import get_meilisearch_client, index_documents
 
     job_name = "sync-search-index"
     logger.info("[batch] Starting sync_search_index (batch_size=%s)", batch_size)
@@ -615,11 +646,10 @@ def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE) -> dict:
         return {"indexed": 0, "skipped": 0, "reason": "meilisearch_not_configured"}
 
     try:
-        # Fetch the set of file_ids already in the Meilisearch index.
+        # Fetch every file_id already committed to Meilisearch. A fixed ceiling
+        # silently breaks reconciliation once an installation grows past it.
         index = client.get_index(settings.meilisearch_index_name)
-        # Fetch up to 10 000 IDs — sufficient to determine gaps for most installs.
-        existing_result = index.get_documents({"fields": ["file_id"], "limit": 10000})
-        existing_ids: set[int] = {doc["file_id"] for doc in existing_result.results if "file_id" in doc}
+        existing_ids = _get_all_search_index_ids(index)
     except Exception as exc:
         detail = f"Error fetching existing Meilisearch IDs: {exc}"
         logger.error("[batch] sync_search_index: %s", detail)
@@ -629,19 +659,27 @@ def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE) -> dict:
     try:
         with SessionLocal() as db:
             # Files with indexable content that are not already in the index.
-            candidates = (
+            indexable_query = (
                 db.query(FileRecord)
                 .filter(FileRecord.is_duplicate.is_(False))
                 .filter(
                     (FileRecord.ocr_text.isnot(None) & (FileRecord.ocr_text != ""))
                     | (FileRecord.ai_metadata.isnot(None) & (FileRecord.ai_metadata != ""))
                 )
-                .filter(~FileRecord.id.in_(existing_ids) if existing_ids else True)  # type: ignore[arg-type]
+            )
+            indexable_count = indexable_query.count()
+            missing_query = indexable_query.filter(
+                ~FileRecord.id.in_(existing_ids) if existing_ids else True  # type: ignore[arg-type]
+            )
+            missing_count = missing_query.count()
+            candidates = (
+                missing_query.order_by(FileRecord.id.asc())
                 .limit(batch_size)
                 .all()
             )
 
-        indexed = 0
+        batches: list[list[tuple[FileRecord, str, dict]]] = []
+        current_batch: list[tuple[FileRecord, str, dict]] = []
         skipped = 0
         for record in candidates:
             metadata: dict = {}
@@ -651,16 +689,46 @@ def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE) -> dict:
                 except (json.JSONDecodeError, ValueError):
                     pass
 
-            success = index_document(record, record.ocr_text or "", metadata)
-            if success:
-                indexed += 1
-            else:
-                skipped += 1
+            current_batch.append((record, record.ocr_text or "", metadata))
+            if len(current_batch) == _SEARCH_INDEX_CHUNK_SIZE:
+                batches.append(current_batch)
+                current_batch = []
+        if current_batch:
+            batches.append(current_batch)
 
-        detail = f"Indexed {indexed} document(s) into Meilisearch; {skipped} skipped (indexing error)."
+        indexed = 0
+        for documents in batches:
+            committed = index_documents(documents)
+            indexed += committed
+            if committed != len(documents):
+                skipped += len(documents) - committed
+                # Do not continue after a failed chunk. The next run can safely
+                # resume from the IDs already committed before the failure.
+                break
+
+        remaining = max(missing_count - indexed, 0)
+        continued = False
+        if continue_until_complete and remaining > 0 and indexed > 0 and skipped == 0:
+            sync_search_index.apply_async(
+                kwargs={"batch_size": batch_size, "continue_until_complete": True},
+                countdown=2,
+            )
+            continued = True
+
+        detail = (
+            f"Indexed {indexed} document(s) into Meilisearch; {skipped} skipped; "
+            f"approximately {remaining} remain."
+        )
         logger.info("[batch] sync_search_index: %s", detail)
         _update_job_status(job_name, "success", detail)
-        return {"indexed": indexed, "skipped": skipped}
+        return {
+            "indexed": indexed,
+            "skipped": skipped,
+            "remaining": remaining,
+            "indexable": indexable_count,
+            "already_indexed": len(existing_ids),
+            "continued": continued,
+        }
 
     except Exception as exc:
         detail = f"Error: {exc}"

--- a/app/tasks/batch_tasks.py
+++ b/app/tasks/batch_tasks.py
@@ -672,11 +672,7 @@ def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE, continue_until_
                 ~FileRecord.id.in_(existing_ids) if existing_ids else True  # type: ignore[arg-type]
             )
             missing_count = missing_query.count()
-            candidates = (
-                missing_query.order_by(FileRecord.id.asc())
-                .limit(batch_size)
-                .all()
-            )
+            candidates = missing_query.order_by(FileRecord.id.asc()).limit(batch_size).all()
 
         batches: list[list[tuple[FileRecord, str, dict]]] = []
         current_batch: list[tuple[FileRecord, str, dict]] = []
@@ -715,10 +711,7 @@ def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE, continue_until_
             )
             continued = True
 
-        detail = (
-            f"Indexed {indexed} document(s) into Meilisearch; {skipped} skipped; "
-            f"approximately {remaining} remain."
-        )
+        detail = f"Indexed {indexed} document(s) into Meilisearch; {skipped} skipped; approximately {remaining} remain."
         logger.info("[batch] sync_search_index: %s", detail)
         _update_job_status(job_name, "success", detail)
         return {

--- a/app/utils/meilisearch_client.py
+++ b/app/utils/meilisearch_client.py
@@ -9,6 +9,7 @@ metadata fields.
 """
 
 import logging
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
@@ -189,6 +190,38 @@ def index_document(file_record: "FileRecord", text: str, metadata: dict) -> bool
         logger.warning(f"Meilisearch indexing failed for file_id={file_record.id}: {exc}")
         return False
 
+
+def index_documents(documents: Sequence[tuple["FileRecord", str, dict]]) -> int:
+    """Index a batch of documents in one Meilisearch update.
+
+    The function waits for Meilisearch to finish the update before returning.
+    This makes a reconciliation run safely resumable: a subsequent run only
+    observes IDs that Meilisearch has actually committed.
+
+    Returns:
+        Number of documents committed to the index, or ``0`` on failure.
+    """
+    if not documents:
+        return 0
+
+    client = get_meilisearch_client()
+    if client is None:
+        return 0
+
+    try:
+        index = _get_or_create_index(client)
+        payload = [_build_document(file_record, text, metadata) for file_record, text, metadata in documents]
+        task = index.add_documents(payload)
+        client.wait_for_task(task.task_uid)
+        logger.info(
+            "Committed %s document(s) to Meilisearch (task_uid=%s)",
+            len(payload),
+            task.task_uid,
+        )
+        return len(payload)
+    except Exception as exc:
+        logger.warning("Meilisearch batch indexing failed for %s document(s): %s", len(documents), exc)
+        return 0
 
 def delete_document(file_id: int) -> bool:
     """Remove a document from the Meilisearch index.

--- a/app/utils/meilisearch_client.py
+++ b/app/utils/meilisearch_client.py
@@ -223,6 +223,7 @@ def index_documents(documents: Sequence[tuple["FileRecord", str, dict]]) -> int:
         logger.warning("Meilisearch batch indexing failed for %s document(s): %s", len(documents), exc)
         return 0
 
+
 def delete_document(file_id: int) -> bool:
     """Remove a document from the Meilisearch index.
 

--- a/app/utils/meilisearch_client.py
+++ b/app/utils/meilisearch_client.py
@@ -212,7 +212,14 @@ def index_documents(documents: Sequence[tuple["FileRecord", str, dict]]) -> int:
         index = _get_or_create_index(client)
         payload = [_build_document(file_record, text, metadata) for file_record, text, metadata in documents]
         task = index.add_documents(payload)
-        client.wait_for_task(task.task_uid)
+        completed_task = client.wait_for_task(task.task_uid, timeout_in_ms=120_000)
+        if completed_task.status != "succeeded":
+            logger.warning(
+                "Meilisearch batch task %s finished with status=%s",
+                task.task_uid,
+                completed_task.status,
+            )
+            return 0
         logger.info(
             "Committed %s document(s) to Meilisearch (task_uid=%s)",
             len(payload),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,6 +70,23 @@ services:
     volumes:
       - /var/docparse/workdir:/workdir
 
+  search-index-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    working_dir: /workdir
+    command: ["celery", "-A", "app.celery_worker", "worker", "--loglevel=info", "--concurrency=1", "-Q", "search_index"]
+    env_file:
+      - .env
+    environment:
+      - PYTHONPATH=/app
+    depends_on:
+      - redis
+      - meilisearch
+    volumes:
+      - /var/docparse/workdir:/workdir
+
   gotenberg:
     image: gotenberg/gotenberg:latest
     container_name: gotenberg

--- a/docs/DearConciergeKnowledgeBridge.md
+++ b/docs/DearConciergeKnowledgeBridge.md
@@ -92,6 +92,8 @@ subsequent polls continue from Dropbox's change cursor.
 - Cross-document questions about counts, maxima, and trends combine semantic and
   full-text candidates. Limited retrieval is disclosed and must not be presented as a
   corpus-complete result.
+- The lexical index reconciler pages through the full Meilisearch corpus and commits
+  missing documents in resumable bulk updates on its own worker queue.
 - A cited document endpoint returns authoritative OCR text and metadata for follow-up.
 - OAuth-authenticated browser clients and Bearer-token clients use the same endpoints.
 - The MCP server is a stateless adapter exposing `search_documents` and `get_document`;
@@ -102,8 +104,9 @@ subsequent polls continue from Dropbox's change cursor.
 - Automated tests cover intake authentication, idempotency, path safety, size/type
   validation, outbound retries, Dropbox resume, chunk overlap, Qdrant replacement,
   authorization filtering, and source citations.
-- A preprod smoke test imports a representative Dropbox subset, rebuilds Qdrant from
-  scratch, and answers agreed DearConcierge questions with traceable source documents.
+- A preprod smoke test imports a representative Dropbox subset, rebuilds Qdrant and
+  Meilisearch from scratch, and answers agreed DearConcierge questions with traceable
+  source documents and explicit coverage.
 - Production deployment, Evergreen enablement, and credential changes require explicit
   approval after the evidence above is reviewed.
 

--- a/docs/ProductionReadiness.md
+++ b/docs/ProductionReadiness.md
@@ -337,12 +337,19 @@ celery -A app.celery_worker worker -Q default,celery --concurrency=2
 
 # Interactive research worker — isolate user-facing analysis from backfills
 celery -A app.celery_worker worker -Q knowledge_research --concurrency=1
+
+# Search reconciliation worker — drain large lexical-index gaps independently
+celery -A app.celery_worker worker -Q search_index --concurrency=1
 ```
 
 Run at least one `knowledge_research` worker wherever the knowledge chat API is
 enabled. Keep its concurrency deliberately low and scale it independently;
 otherwise long corpus imports can delay an interactive research job before it
 even starts.
+
+Run one `search_index` worker wherever Meilisearch is enabled. It processes
+bounded bulk updates and can drain a restored corpus without occupying document
+pipeline or interactive research capacity.
 
 ---
 

--- a/docs/ScheduledJobs.md
+++ b/docs/ScheduledJobs.md
@@ -117,11 +117,17 @@ This is particularly useful when:
 |---|---|
 | **Task** | `app.tasks.batch_tasks.sync_search_index` |
 | **Default schedule** | Hourly (cron `15 */1 * * *`) |
-| **Purpose** | Indexes documents in Meilisearch that have OCR text or AI metadata but are not yet present in the search index. Processes up to 100 documents per run. |
+| **Purpose** | Reconciles documents with OCR text or AI metadata into Meilisearch. It reads all existing IDs page by page and commits up to 500 missing documents per run in bounded bulk updates. |
 
 This is useful after:
 - Enabling Meilisearch for the first time on an existing installation.
 - Recovering from a Meilisearch index wipe or migration.
+
+The task is safe to rerun. Each bulk update is confirmed by Meilisearch before
+the run reports it as indexed. Large one-time reconciliations can call the task
+with `continue_until_complete=true`; the dedicated `search_index` worker then
+continues in bounded batches without blocking document processing or knowledge
+research.
 
 ---
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -168,7 +168,11 @@ This document provides solutions to common problems encountered when using DocuE
    Check `MEILISEARCH_URL` in your `.env` file (default: `http://meilisearch:7700`).
 
 3. **Rebuild the search index**
-   If documents are missing from search results, reprocessing them will re-index their content.
+   Run the scheduled **Sync Search Index** job. It reconciles already processed
+   documents without running OCR or metadata extraction again. For a large
+   restored corpus, enqueue `app.tasks.batch_tasks.sync_search_index` with
+   `continue_until_complete=true` so the dedicated search worker drains the
+   gap in resumable batches.
 
 ## Pipeline & Routing Issues
 

--- a/helm/docuelevate/templates/search-index-worker-deployment.yaml
+++ b/helm/docuelevate/templates/search-index-worker-deployment.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.searchIndexWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "docuelevate.fullname" . }}-search-index-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "docuelevate.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search-index-worker
+spec:
+  replicas: {{ .Values.searchIndexWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "docuelevate.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: search-index-worker
+  template:
+    metadata:
+      labels:
+        {{- include "docuelevate.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: search-index-worker
+      {{- with .Values.searchIndexWorker.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "docuelevate.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.searchIndexWorker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: search-index-worker
+          image: {{ include "docuelevate.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - celery
+            - -A
+            - app.celery_worker
+            - worker
+            - --loglevel=info
+            - --concurrency={{ .Values.searchIndexWorker.concurrency }}
+            - -Q
+            - search_index
+          envFrom:
+            - configMapRef:
+                name: {{ include "docuelevate.fullname" . }}-config
+            - secretRef:
+                name: {{ include "docuelevate.fullname" . }}-secret
+          {{- with .Values.searchIndexWorker.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.searchIndexWorker.resources | nindent 12 }}
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+      volumes:
+        - name: workdir
+          {{- if .Values.workdir.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.workdir.persistence.existingClaim | default (printf "%s-workdir" (include "docuelevate.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.searchIndexWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.searchIndexWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.searchIndexWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/docuelevate/values.yaml
+++ b/helm/docuelevate/values.yaml
@@ -215,6 +215,31 @@ knowledgeResearchWorker:
     capabilities:
       drop: ["ALL"]
 
+searchIndexWorker:
+  enabled: true
+  replicaCount: 1
+  concurrency: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: ["ALL"]
+
 # ---------------------------------------------------------------------------
 # Shared workdir volume (api + worker mount the same PVC)
 # ---------------------------------------------------------------------------

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -128,6 +128,7 @@ class TestMeilisearchIndexDocument:
         mock_task = MagicMock(task_uid=42)
         mock_client.get_index.return_value = mock_index
         mock_index.add_documents.return_value = mock_task
+        mock_client.wait_for_task.return_value = MagicMock(status="succeeded")
 
         class _FakeRecord:
             original_filename = "invoice.pdf"
@@ -150,7 +151,27 @@ class TestMeilisearchIndexDocument:
 
         payload = mock_index.add_documents.call_args.args[0]
         assert [document["file_id"] for document in payload] == [1, 2]
-        mock_client.wait_for_task.assert_called_once_with(42)
+        mock_client.wait_for_task.assert_called_once_with(42, timeout_in_ms=120_000)
+
+    def test_index_documents_rejects_failed_meilisearch_task(self):
+        """An accepted update is not counted when Meilisearch later rejects it."""
+        mock_client = MagicMock()
+        mock_index = MagicMock()
+        mock_index.add_documents.return_value = MagicMock(task_uid=43)
+        mock_client.get_index.return_value = mock_index
+        mock_client.wait_for_task.return_value = MagicMock(status="failed")
+
+        class _FakeRecord:
+            id = 1
+            original_filename = "invoice.pdf"
+            mime_type = "application/pdf"
+            file_size = 2048
+            created_at = None
+
+        with patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client):
+            from app.utils.meilisearch_client import index_documents
+
+            assert index_documents([(_FakeRecord(), "text", {})]) == 0
 
 
 @pytest.mark.unit

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -121,6 +121,37 @@ class TestMeilisearchIndexDocument:
             result = index_document(_FakeRecord(), "some text", {})
             assert result is False
 
+    def test_index_documents_commits_one_bulk_update(self):
+        """Batch indexing waits until the Meilisearch update is committed."""
+        mock_client = MagicMock()
+        mock_index = MagicMock()
+        mock_task = MagicMock(task_uid=42)
+        mock_client.get_index.return_value = mock_index
+        mock_index.add_documents.return_value = mock_task
+
+        class _FakeRecord:
+            original_filename = "invoice.pdf"
+            mime_type = "application/pdf"
+            file_size = 2048
+            created_at = None
+
+            def __init__(self, file_id):
+                self.id = file_id
+
+        documents = [
+            (_FakeRecord(1), "first", {"document_type": "Invoice"}),
+            (_FakeRecord(2), "second", {"document_type": "Invoice"}),
+        ]
+
+        with patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client):
+            from app.utils.meilisearch_client import index_documents
+
+            assert index_documents(documents) == 2
+
+        payload = mock_index.add_documents.call_args.args[0]
+        assert [document["file_id"] for document in payload] == [1, 2]
+        mock_client.wait_for_task.assert_called_once_with(42)
+
 
 @pytest.mark.unit
 class TestMeilisearchSearchDocuments:

--- a/tests/test_celery_app.py
+++ b/tests/test_celery_app.py
@@ -45,6 +45,7 @@ class TestCeleryAppConfig:
             celery.conf.task_routes["app.tasks.knowledge_research.run_knowledge_research"]["queue"]
             == "knowledge_research"
         )
+        assert celery.conf.task_routes["app.tasks.batch_tasks.sync_search_index"]["queue"] == "search_index"
 
     def test_broker_connection_retry_on_startup(self):
         """Test that broker connection retry on startup is enabled."""

--- a/tests/test_celery_worker.py
+++ b/tests/test_celery_worker.py
@@ -48,6 +48,7 @@ class TestCeleryWorkerConfig:
         mod = _reload_celery_worker()
         routes = mod.celery.conf.task_routes
         assert routes["app.tasks.knowledge_research.run_knowledge_research"]["queue"] == "knowledge_research"
+        assert routes["app.tasks.batch_tasks.sync_search_index"]["queue"] == "search_index"
         assert routes is not None
         assert "app.tasks.*" in routes
 

--- a/tests/test_scheduled_jobs.py
+++ b/tests/test_scheduled_jobs.py
@@ -1490,6 +1490,38 @@ class TestSyncSearchIndexAdditional:
         assert index.get_documents.call_args_list[0].args[0]["offset"] == 0
         assert index.get_documents.call_args_list[1].args[0]["offset"] == 2
 
+    def test_splits_bulk_updates_by_ocr_payload_size(self, sj_engine):
+        """Large OCR documents cannot combine into an oversized HTTP payload."""
+        from app.tasks.batch_tasks import sync_search_index
+
+        session = sessionmaker(bind=sj_engine)()
+        _make_file_record(session, filehash="hash_payload_1", ocr_text="1234")
+        _make_file_record(session, filehash="hash_payload_2", ocr_text="5678")
+        session.close()
+
+        mock_client = MagicMock()
+        mock_index = MagicMock()
+        mock_client.get_index.return_value = mock_index
+        mock_index.get_documents.return_value = MagicMock(results=[])
+
+        with (
+            patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client),
+            patch("app.utils.meilisearch_client.index_documents", side_effect=len) as index_documents,
+            patch("app.tasks.batch_tasks._update_job_status"),
+            patch("app.tasks.batch_tasks.SessionLocal") as mock_sl,
+            patch("app.tasks.batch_tasks.settings") as mock_settings,
+            patch("app.tasks.batch_tasks._SEARCH_INDEX_CHUNK_CHAR_LIMIT", 5),
+        ):
+            mock_settings.meilisearch_index_name = "documents"
+            real_session = sessionmaker(bind=sj_engine)()
+            mock_sl.return_value.__enter__ = MagicMock(return_value=real_session)
+            mock_sl.return_value.__exit__ = MagicMock(return_value=False)
+            result = sync_search_index(batch_size=10)
+            real_session.close()
+
+        assert result["indexed"] == 2
+        assert index_documents.call_count == 2
+
 
 @pytest.mark.unit
 class TestReprocessFailedDocumentsMissingFile:

--- a/tests/test_scheduled_jobs.py
+++ b/tests/test_scheduled_jobs.py
@@ -1001,7 +1001,7 @@ class TestSyncSearchIndex:
 
         with (
             patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client),
-            patch("app.utils.meilisearch_client.index_document", return_value=True) as mock_idx,
+            patch("app.utils.meilisearch_client.index_documents", side_effect=len) as mock_idx,
             patch("app.tasks.batch_tasks._update_job_status") as mock_update,
             patch("app.tasks.batch_tasks.SessionLocal") as mock_sl,
             patch("app.tasks.batch_tasks.settings") as mock_settings,
@@ -1015,6 +1015,7 @@ class TestSyncSearchIndex:
 
         assert result["indexed"] == 1
         mock_idx.assert_called_once()
+        assert mock_idx.call_args[0][0][0][2]["document_type"] == "invoice"
         mock_update.assert_called_once()
         assert mock_update.call_args[0][1] == "success"
 
@@ -1036,6 +1037,43 @@ class TestSyncSearchIndex:
         assert "error" in result
         mock_update.assert_called_once()
         assert mock_update.call_args[0][1] == "failed"
+
+    def test_continues_large_reconciliation_after_committed_batch(self, sj_engine):
+        """A bounded successful batch schedules the next resumable batch."""
+        from app.tasks.batch_tasks import sync_search_index
+
+        session = sessionmaker(bind=sj_engine)()
+        _make_file_record(session, filehash="hash_continue_1", ocr_text="first")
+        _make_file_record(session, filehash="hash_continue_2", ocr_text="second")
+        session.close()
+
+        mock_client = MagicMock()
+        mock_index = MagicMock()
+        mock_client.get_index.return_value = mock_index
+        mock_index.get_documents.return_value = MagicMock(results=[])
+
+        with (
+            patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client),
+            patch("app.utils.meilisearch_client.index_documents", side_effect=len),
+            patch("app.tasks.batch_tasks._update_job_status"),
+            patch("app.tasks.batch_tasks.SessionLocal") as mock_sl,
+            patch("app.tasks.batch_tasks.settings") as mock_settings,
+            patch.object(sync_search_index, "apply_async") as apply_async,
+        ):
+            mock_settings.meilisearch_index_name = "documents"
+            real_session = sessionmaker(bind=sj_engine)()
+            mock_sl.return_value.__enter__ = MagicMock(return_value=real_session)
+            mock_sl.return_value.__exit__ = MagicMock(return_value=False)
+            result = sync_search_index(batch_size=1, continue_until_complete=True)
+            real_session.close()
+
+        assert result["indexed"] == 1
+        assert result["remaining"] == 1
+        assert result["continued"] is True
+        apply_async.assert_called_once_with(
+            kwargs={"batch_size": 1, "continue_until_complete": True},
+            countdown=2,
+        )
 
 
 # ===========================================================================
@@ -1360,7 +1398,7 @@ class TestSyncSearchIndexAdditional:
     """Additional coverage tests for sync_search_index."""
 
     def test_counts_skipped_on_indexing_failure(self, sj_engine):
-        """When index_document returns False, the document is counted as skipped."""
+        """When batch indexing fails, the document is counted as skipped."""
         from app.tasks.batch_tasks import sync_search_index
 
         Session = sessionmaker(bind=sj_engine)
@@ -1377,7 +1415,7 @@ class TestSyncSearchIndexAdditional:
 
         with (
             patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client),
-            patch("app.utils.meilisearch_client.index_document", return_value=False),
+            patch("app.utils.meilisearch_client.index_documents", return_value=0),
             patch("app.tasks.batch_tasks._update_job_status") as mock_update,
             patch("app.tasks.batch_tasks.SessionLocal") as mock_sl,
             patch("app.tasks.batch_tasks.settings") as mock_settings,
@@ -1417,7 +1455,7 @@ class TestSyncSearchIndexAdditional:
 
         with (
             patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client),
-            patch("app.utils.meilisearch_client.index_document", return_value=True) as mock_idx,
+            patch("app.utils.meilisearch_client.index_documents", side_effect=len) as mock_idx,
             patch("app.tasks.batch_tasks._update_job_status") as mock_update,
             patch("app.tasks.batch_tasks.SessionLocal") as mock_sl,
             patch("app.tasks.batch_tasks.settings") as mock_settings,
@@ -1432,9 +1470,25 @@ class TestSyncSearchIndexAdditional:
         # The record should still be indexed with empty metadata.
         assert result["indexed"] == 1
         call_args = mock_idx.call_args
-        assert call_args[0][2] == {}  # metadata is empty dict
+        assert call_args[0][0][0][2] == {}  # metadata is empty dict
         mock_update.assert_called_once()
         assert mock_update.call_args[0][1] == "success"
+
+    def test_pages_through_every_existing_document_id(self):
+        """Reconciliation is not capped at the first Meilisearch page."""
+        from app.tasks.batch_tasks import _get_all_search_index_ids
+
+        first_page = MagicMock(results=[{"file_id": 1}, {"file_id": 2}])
+        final_page = MagicMock(results=[{"file_id": 3}])
+        index = MagicMock()
+        index.get_documents.side_effect = [first_page, final_page]
+
+        with patch("app.tasks.batch_tasks._SEARCH_ID_PAGE_SIZE", 2):
+            result = _get_all_search_index_ids(index)
+
+        assert result == {1, 2, 3}
+        assert index.get_documents.call_args_list[0].args[0]["offset"] == 0
+        assert index.get_documents.call_args_list[1].args[0]["offset"] == 2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #1124.

## What changed

- page through every committed Meilisearch document ID instead of stopping at 10,000
- reconcile missing records in bounded bulk updates and wait for Meilisearch confirmation
- make large catch-up runs resumable with explicit remaining/indexable counts
- route reconciliation to a dedicated `search_index` worker in Celery, Compose, and Helm
- align the DearConcierge bridge roadmap, operations documentation, and troubleshooting guidance

## Why

Preprod had more than 24,000 accessible processed documents but only about 1,265 documents in Meilisearch. The previous hourly job handled 100 records and could not see IDs after the first 10,000, so exhaustive count/trend/max research could be honestly marked incomplete but could not become corpus-complete in a reasonable time.

## Impact

Large restored or imported corpora can now catch up without rerunning OCR, blocking upload workers, or blocking interactive knowledge research. A failed bulk update is safely retried on the next run because only confirmed Meilisearch updates count as indexed.

## Validation

- 131 focused tests passed
- Ruff and mypy passed
- Helm lint passed (the existing Redis chart dependency warning remains)
- Helm template requires the repository dependency bundle and was not available in this worktree
- DocuElevate production remains out of scope and pinned to its legacy image