### PR TITLE
fix: recognize Meilisearch SDK documents during reconciliation

### DIFF
--- a/app/tasks/batch_tasks.py
+++ b/app/tasks/batch_tasks.py
@@ -28,6 +28,7 @@ the admin UI can display last-run times and statuses.
 import json
 import logging
 import os
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -598,11 +599,14 @@ def _get_all_search_index_ids(index: object) -> set[int]:
             }
         )
         documents = result.results
-        existing_ids.update(
-            int(document["file_id"])
-            for document in documents
-            if "file_id" in document and str(document["file_id"]).isdigit()
-        )
+        for document in documents:
+            value = document.get("file_id") if isinstance(document, Mapping) else getattr(document, "file_id", None)
+            try:
+                file_id = int(value)
+            except (TypeError, ValueError):
+                continue
+            if file_id > 0:
+                existing_ids.add(file_id)
         if len(documents) < _SEARCH_ID_PAGE_SIZE:
             break
         offset += _SEARCH_ID_PAGE_SIZE

--- a/tests/test_scheduled_jobs.py
+++ b/tests/test_scheduled_jobs.py
@@ -1476,9 +1476,11 @@ class TestSyncSearchIndexAdditional:
 
     def test_pages_through_every_existing_document_id(self):
         """Reconciliation is not capped at the first Meilisearch page."""
+        from meilisearch.models.document import Document
+
         from app.tasks.batch_tasks import _get_all_search_index_ids
 
-        first_page = MagicMock(results=[{"file_id": 1}, {"file_id": 2}])
+        first_page = MagicMock(results=[{"file_id": 1}, Document({"file_id": "2"})])
         final_page = MagicMock(results=[{"file_id": 3}])
         index = MagicMock()
         index.get_documents.side_effect = [first_page, final_page]


### PR DESCRIPTION
## What changed
- read `file_id` from both mapping results and Meilisearch SDK `Document` objects
- ignore malformed and non-positive IDs safely
- exercise the real SDK result type in the pagination regression test

## Root cause
The live client returns `meilisearch.models.document.Document` instances. The reconciler only recognized dictionaries, so it treated every run as an empty index and repeatedly upserted the first batch instead of advancing through the corpus.

## Impact
The dedicated preprod search-index worker can resume the full, bounded, idempotent corpus reconciliation without restarting at the first records.

Closes #1124

## Validation
- Ruff format/check
- mypy on `app/tasks/batch_tasks.py`
- `tests/test_scheduled_jobs.py`: 67 passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of search index records in scheduled processing.
  * Valid positive file IDs are now recognized across different record formats, while invalid or non-positive values are ignored.

* **Tests**
  * Added coverage for mixed search result formats and pagination across document boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->