### PR TITLE
perf: batch search reconciliation updates

### DIFF
--- a/app/tasks/batch_tasks.py
+++ b/app/tasks/batch_tasks.py
@@ -580,8 +580,9 @@ def backfill_missing_metadata(batch_size: int = _METADATA_BACKFILL_BATCH_SIZE) -
 _SEARCH_SYNC_BATCH_SIZE: int = 500
 #: Page size used while reading IDs already committed to Meilisearch.
 _SEARCH_ID_PAGE_SIZE: int = 1000
-#: Keep individual Meilisearch update payloads bounded because OCR text can be large.
-_SEARCH_INDEX_CHUNK_SIZE: int = 50
+#: Keep each update bounded to one reconciliation run; the character ceiling
+#: remains the primary guard for large OCR documents.
+_SEARCH_INDEX_CHUNK_SIZE: int = _SEARCH_SYNC_BATCH_SIZE
 #: Approximate character ceiling per update (well below Meilisearch's HTTP payload limit).
 _SEARCH_INDEX_CHUNK_CHAR_LIMIT: int = 5_000_000
 

--- a/tests/test_scheduled_jobs.py
+++ b/tests/test_scheduled_jobs.py
@@ -1524,6 +1524,37 @@ class TestSyncSearchIndexAdditional:
         assert result["indexed"] == 2
         assert index_documents.call_count == 2
 
+    def test_commits_small_reconciliation_run_in_one_update(self, sj_engine):
+        """Small documents use one update instead of paying per-chunk task latency."""
+        from app.tasks.batch_tasks import sync_search_index
+
+        session = sessionmaker(bind=sj_engine)()
+        for index in range(51):
+            _make_file_record(session, filehash=f"hash_bulk_{index}", ocr_text="searchable")
+        session.close()
+
+        mock_client = MagicMock()
+        mock_index = MagicMock()
+        mock_client.get_index.return_value = mock_index
+        mock_index.get_documents.return_value = MagicMock(results=[])
+
+        with (
+            patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client),
+            patch("app.utils.meilisearch_client.index_documents", side_effect=len) as index_documents,
+            patch("app.tasks.batch_tasks._update_job_status"),
+            patch("app.tasks.batch_tasks.SessionLocal") as mock_sl,
+            patch("app.tasks.batch_tasks.settings") as mock_settings,
+        ):
+            mock_settings.meilisearch_index_name = "documents"
+            real_session = sessionmaker(bind=sj_engine)()
+            mock_sl.return_value.__enter__ = MagicMock(return_value=real_session)
+            mock_sl.return_value.__exit__ = MagicMock(return_value=False)
+            result = sync_search_index(batch_size=51)
+            real_session.close()
+
+        assert result["indexed"] == 51
+        index_documents.assert_called_once()
+
 
 @pytest.mark.unit
 class TestReprocessFailedDocumentsMissingFile:


### PR DESCRIPTION
## What changed
- allow one reconciliation run to use a single Meilisearch update when its payload remains below the existing 5,000,000-character ceiling
- retain the 500-document run bound and 120-second explicit commit wait
- add a regression test proving 51 small documents use one update while oversized OCR content still splits by payload size

## Why
Live preprod verification proved correctness, but the conservative 50-document chunks paid Meilisearch task latency ten times per 500-document run (about 82 seconds). The character guard already bounds the material risk: a run can now commit in one task when small enough, while large OCR documents continue to split automatically.

Refs #1124

## Validation
- Ruff format/check
- mypy
- 68 scheduled-job tests passed
- `git diff --check`