### PR TITLE
fix: align research scope with indexed corpus

### DIFF
--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -163,6 +163,7 @@ def _queue_research_job(request: Request, body: KnowledgeChatRequest, db: Sessio
     accessible_rows = (
         apply_owner_filter(
             db.query(FileRecord.id, FileRecord.filehash, func.length(FileRecord.ocr_text)).filter(
+                FileRecord.is_duplicate.is_(False),
                 FileRecord.ocr_text.isnot(None),
                 func.length(func.trim(FileRecord.ocr_text)) > 0,
             ),

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -532,6 +532,20 @@ def test_document_chat_uses_cross_document_research_for_counts(client, db_sessio
         )
         for file_id in (30, 31)
     ]
+    records.append(
+        FileRecord(
+            id=32,
+            owner_id=None,
+            filehash="flight-duplicate",
+            original_filename="flight-duplicate.pdf",
+            document_title="Duplicate London flight",
+            local_filename="/tmp/flight-duplicate.pdf",
+            file_size=1,
+            mime_type="application/pdf",
+            ocr_text="Duplicate flight booking to London",
+            is_duplicate=True,
+        )
+    )
     db_session.add_all(records)
     db_session.commit()
     with patch("app.tasks.knowledge_research.run_knowledge_research.delay") as delay:


### PR DESCRIPTION
## What changed
- exclude duplicate file records from the immutable research scope, matching the corpus that Meilisearch reconciliation intentionally indexes
- add an integration regression proving duplicate OCR records are not snapshotted into an exhaustive job

## Why
`index_complete` compared indexed, non-duplicate documents against an authorized scope that still contained duplicates. A complete corpus could therefore be reported as permanently incomplete, and duplicate evidence could waste model work. The research watermark now describes the same canonical corpus used by retrieval.

Refs #1124

## Validation
- Ruff format/check
- mypy
- vector knowledge + exhaustive research suites: 59 passed
- `git diff --check`