### PR TITLE
Fix exhaustive research coverage cap

### DIFF
--- a/app/tasks/knowledge_research.py
+++ b/app/tasks/knowledge_research.py
@@ -17,7 +17,10 @@ from app.models import FileRecord, KnowledgeResearchJob
 
 logger = logging.getLogger(__name__)
 
-_SCOPE_BATCH = 5_000
+# Meilisearch caps search totals and pagination at 1,000 hits by default.
+# Keep every authorized scope within that boundary so coverage counts and
+# exhaustive keyword pagination cannot silently truncate a larger corpus.
+_SCOPE_BATCH = 1_000
 _SEARCH_PAGE = 100
 _MAP_BATCH = 10
 _EXCERPT_CHARS = 6_000

--- a/tests/test_knowledge_research.py
+++ b/tests/test_knowledge_research.py
@@ -73,6 +73,38 @@ def test_candidate_retrieval_pages_every_authorized_match():
     assert indexed == 3
 
 
+def test_candidate_retrieval_splits_scopes_at_search_result_cap():
+    scopes = []
+
+    def search(query, *, file_ids, page, per_page):
+        scopes.append((query, file_ids, page, per_page))
+        if query == "":
+            return {"results": [], "total": len(file_ids), "pages": 1}
+        return {
+            "results": [{"file_id": file_id} for file_id in file_ids],
+            "total": len(file_ids),
+            "pages": 1,
+        }
+
+    with (
+        patch("app.tasks.knowledge_research._SCOPE_BATCH", 2),
+        patch("app.utils.meilisearch_client.search_documents", side_effect=search),
+        patch("app.utils.vector_index.QdrantVectorIndex.search", return_value=[]),
+    ):
+        candidates, indexed = _candidate_ids(
+            [1, 2, 3, 4, 5],
+            "Wie oft war ich in London per Flugzeug?",
+        )
+
+    assert candidates == [1, 2, 3, 4, 5]
+    assert indexed == 5
+    assert [file_ids for query, file_ids, _page, _per_page in scopes if query == ""] == [
+        [1, 2],
+        [3, 4],
+        [5],
+    ]
+
+
 def test_deduplication_merges_transport_legs_and_duplicate_documents():
     evidence = [
         {"document_id": 1, "evidence_type": "flight_trip", "event_key": "BA-ABC123", "claim": "Outbound"},


### PR DESCRIPTION
## What changed

- keep every authorized Meilisearch research scope at or below the default 1,000-hit pagination cap
- add a regression test proving a larger authorized corpus is split and counted completely

## Root cause

Exhaustive research previously queried 5,000 IDs per scope. Meilisearch caps search totals and pagination at 1,000 by default, so a six-scope corpus reported exactly 6,000 indexed documents and could omit keyword matches after the first 1,000 in each scope.

## Impact

Coverage and candidate retrieval now enumerate the complete authorized canonical corpus without changing global index settings or weakening owner isolation.

## Validation

- 27 focused knowledge-research tests pass
- Ruff passes for both changed files
- `git diff --check` passes

Closes #1129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved knowledge research retrieval to avoid silently truncating results when many authorized scopes are searched.
  * Ensured all eligible candidate IDs are retrieved across multiple search batches.

* **Tests**
  * Added coverage verifying correct batching and complete candidate retrieval at the search result limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->