### PR TITLE
Prefer exact entities in document research

### DIFF
--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 # Bump whenever retrieval, reduction, or synthesis semantics change so a
 # deployment cannot serve answers produced by an older research algorithm.
-_RESEARCH_CACHE_VERSION = 6
+_RESEARCH_CACHE_VERSION = 7
 router = APIRouter(prefix="/knowledge", tags=["knowledge"])
 DbSession = Annotated[Session, Depends(get_db)]
 

--- a/app/tasks/knowledge_research.py
+++ b/app/tasks/knowledge_research.py
@@ -331,18 +331,16 @@ def _fallback_research_plan(query: str) -> dict[str, Any]:
     }
 
 
-def _entity_first_lexical_queries(
-    payload: dict[str, Any], lexical_queries: list[str]
-) -> list[str]:
+def _entity_first_lexical_queries(payload: dict[str, Any], lexical_queries: list[str]) -> list[str]:
     """Prefer exact named entities over planner-generated compound AND queries."""
     raw_entities = payload.get("hard_entities", [])
     if isinstance(raw_entities, str):
         raw_entities = [raw_entities]
-    entities = [
-        " ".join(value.split()).strip('"')[:120]
-        for value in raw_entities
-        if isinstance(value, str) and value.strip()
-    ] if isinstance(raw_entities, list) else []
+    entities = (
+        [" ".join(value.split()).strip('"')[:120] for value in raw_entities if isinstance(value, str) and value.strip()]
+        if isinstance(raw_entities, list)
+        else []
+    )
     for query in lexical_queries:
         entities.extend(re.findall(r'"([^"\r\n]{2,120})"', query))
 
@@ -553,9 +551,7 @@ def _subject_hint_from_history(history_json: str) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
 
 
-def _no_evidence_answer(
-    question: str, *, index_complete: bool, analysis_truncated: bool = False
-) -> str:
+def _no_evidence_answer(question: str, *, index_complete: bool, analysis_truncated: bool = False) -> str:
     """Return a localized fallback that accurately qualifies index coverage."""
     looks_german = bool(re.search(r"\b(wie|was|wann|wo|welche|mein|meine|über|belegbar)\b", question, re.IGNORECASE))
     if looks_german:

--- a/app/tasks/knowledge_research.py
+++ b/app/tasks/knowledge_research.py
@@ -332,7 +332,7 @@ def _fallback_research_plan(query: str) -> dict[str, Any]:
 
 
 def _entity_first_lexical_queries(payload: dict[str, Any], lexical_queries: list[str]) -> list[str]:
-    """Prefer exact named entities over planner-generated compound AND queries."""
+    """Probe exact named entities first, then retain qualified planner queries."""
     raw_entities = payload.get("hard_entities", [])
     if isinstance(raw_entities, str):
         raw_entities = [raw_entities]
@@ -352,7 +352,8 @@ def _entity_first_lexical_queries(payload: dict[str, Any], lexical_queries: list
         exact_query = f'"{normalized}"' if " " in normalized else normalized
         if exact_query not in exact_queries:
             exact_queries.append(exact_query)
-    return exact_queries[:3] or lexical_queries
+    prioritized_queries = exact_queries + [query for query in lexical_queries if query not in exact_queries]
+    return prioritized_queries[:3]
 
 
 def _plan_research(query: str, model: str) -> dict[str, Any]:

--- a/app/tasks/knowledge_research.py
+++ b/app/tasks/knowledge_research.py
@@ -331,14 +331,41 @@ def _fallback_research_plan(query: str) -> dict[str, Any]:
     }
 
 
+def _entity_first_lexical_queries(
+    payload: dict[str, Any], lexical_queries: list[str]
+) -> list[str]:
+    """Prefer exact named entities over planner-generated compound AND queries."""
+    raw_entities = payload.get("hard_entities", [])
+    if isinstance(raw_entities, str):
+        raw_entities = [raw_entities]
+    entities = [
+        " ".join(value.split()).strip('"')[:120]
+        for value in raw_entities
+        if isinstance(value, str) and value.strip()
+    ] if isinstance(raw_entities, list) else []
+    for query in lexical_queries:
+        entities.extend(re.findall(r'"([^"\r\n]{2,120})"', query))
+
+    exact_queries: list[str] = []
+    for entity in entities:
+        normalized = " ".join(entity.split()).strip('"')
+        if not normalized:
+            continue
+        exact_query = f'"{normalized}"' if " " in normalized else normalized
+        if exact_query not in exact_queries:
+            exact_queries.append(exact_query)
+    return exact_queries[:3] or lexical_queries
+
+
 def _plan_research(query: str, model: str) -> dict[str, Any]:
     """Use one small structured request to plan lexical and semantic retrieval."""
     from app.utils.ai_provider import get_ai_provider
 
     prompt = (
         "Plan document retrieval for the question below. Do not answer it and do not request document text. "
-        "Return JSON only with: lexical_queries (1-3 short Meilisearch queries), semantic_query, aggregation, "
-        'evidence_types, exclude_terms. Preserve exact named entities as quoted phrases, for example "Motel One". '
+        "Return JSON only with: hard_entities, lexical_queries (1-3 short Meilisearch queries), semantic_query, "
+        "aggregation, evidence_types, exclude_terms. Put exact named entities such as Motel One, Amazon, London or "
+        "HbA1c in hard_entities without descriptive words. Preserve them as quoted phrases in lexical_queries. "
         "Remove conversational filler and generic counting words. Prefer booking confirmations, invoices, tickets, "
         "lab results or receipts that prove the requested real-world event; exclude advertising and generic reference text.\n\n"
         f"QUESTION:\n{query[-2_000:]}"
@@ -368,6 +395,7 @@ def _plan_research(query: str, model: str) -> dict[str, Any]:
         lexical_queries = [
             " ".join(value.split())[:180] for value in raw_lexical_queries if isinstance(value, str) and value.strip()
         ][:3]
+        lexical_queries = _entity_first_lexical_queries(payload, lexical_queries)
         semantic_query = payload.get("semantic_query")
         evidence_types = payload.get("evidence_types", [])
         if isinstance(evidence_types, str):
@@ -525,11 +553,19 @@ def _subject_hint_from_history(history_json: str) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
 
 
-def _no_evidence_answer(question: str, *, index_complete: bool) -> str:
+def _no_evidence_answer(
+    question: str, *, index_complete: bool, analysis_truncated: bool = False
+) -> str:
     """Return a localized fallback that accurately qualifies index coverage."""
     looks_german = bool(re.search(r"\b(wie|was|wann|wo|welche|mein|meine|über|belegbar)\b", question, re.IGNORECASE))
     if looks_german:
         if index_complete:
+            if analysis_truncated:
+                return (
+                    "Ich konnte in der begrenzten Auswertung des vollständig indexierten, zugänglichen "
+                    "Dokumentbestands keine belastbaren Belege finden. Der Index ist vollständig, aber die "
+                    "Auswertung nutzte nur begrenzte Textausschnitte; das Ergebnis ist daher nicht abschließend."
+                )
             return (
                 "Ich konnte im vollständig indexierten, zugänglichen Dokumentbestand keine belastbaren Belege finden."
             )
@@ -538,6 +574,12 @@ def _no_evidence_answer(question: str, *, index_complete: bool) -> str:
             "Der Index ist noch unvollständig; das Ergebnis ist daher nicht abschließend."
         )
     if index_complete:
+        if analysis_truncated:
+            return (
+                "I could not find reliable evidence in the bounded analysis of the fully indexed, accessible "
+                "document corpus. The index is complete, but only bounded text excerpts were analyzed, so this "
+                "result is not final."
+            )
         return "I could not find reliable evidence in the fully indexed, accessible document corpus."
     return (
         "I could not find reliable evidence in the currently indexed, accessible documents. "
@@ -799,7 +841,8 @@ def run_knowledge_research(self: Any, job_id: str) -> dict[str, Any]:
             else:
                 answer = _no_evidence_answer(
                     job.question,
-                    index_complete=indexed_scope >= len(accessible_ids) and not truncated,
+                    index_complete=indexed_scope >= len(accessible_ids),
+                    analysis_truncated=truncated,
                 )
                 sources = []
             result = {

--- a/tests/test_knowledge_research.py
+++ b/tests/test_knowledge_research.py
@@ -111,8 +111,12 @@ def test_research_planner_keeps_exact_entity_and_returns_small_plan():
         )
 
     assert plan["lexical_queries"][0] == '"Motel One"'
+    assert plan["lexical_queries"][1:] == [
+        "Motel One Buchungen Aufenthalte Nächte",
+        '"Motel One" Buchungen Belege',
+    ]
     assert plan["aggregation"] == "count stays and nights"
-    assert len(plan["lexical_queries"]) == 1
+    assert len(plan["lexical_queries"]) == 3
     assert calls[0]["reasoning_effort"] == "minimal"
     assert calls[0]["max_completion_tokens"] == 300
 

--- a/tests/test_knowledge_research.py
+++ b/tests/test_knowledge_research.py
@@ -94,7 +94,9 @@ def test_research_planner_keeps_exact_entity_and_returns_small_plan():
         chat_completion=lambda **kwargs: (
             calls.append(kwargs)
             or (
-                '{"lexical_queries":["\\"Motel One\\"","Motel One Rechnung"],'
+                '{"hard_entities":["Motel One"],'
+                '"lexical_queries":["Motel One Buchungen Aufenthalte Nächte",'
+                '"\\"Motel One\\" Buchungen Belege"],'
                 '"semantic_query":"Motel One booking confirmation hotel stay",'
                 '"aggregation":"count stays and nights","evidence_types":["hotel_booking"],'
                 '"exclude_terms":["advertising"]}'
@@ -110,7 +112,7 @@ def test_research_planner_keeps_exact_entity_and_returns_small_plan():
 
     assert plan["lexical_queries"][0] == '"Motel One"'
     assert plan["aggregation"] == "count stays and nights"
-    assert len(plan["lexical_queries"]) == 2
+    assert len(plan["lexical_queries"]) == 1
     assert calls[0]["reasoning_effort"] == "minimal"
     assert calls[0]["max_completion_tokens"] == 300
 
@@ -349,6 +351,18 @@ def test_empty_research_answer_is_localized_and_qualifies_incomplete_index():
     assert "noch unvollständig" in answer
     assert "nicht abschließend" in answer
     assert _no_evidence_answer("How many London trips?", index_complete=True).startswith("I could not")
+
+
+def test_empty_research_answer_separates_complete_index_from_bounded_analysis():
+    answer = _no_evidence_answer(
+        "Wie oft war ich im Motel One?",
+        index_complete=True,
+        analysis_truncated=True,
+    )
+
+    assert "Index ist vollständig" in answer
+    assert "begrenzte Textausschnitte" in answer
+    assert "Index ist noch unvollständig" not in answer
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1131.

## What changed

- reduces planner-generated compound AND searches to exact hard-entity queries such as `"Motel One"`
- accepts explicit `hard_entities` from the short retrieval-planning request and also recovers quoted entities from lexical queries
- distinguishes a complete index from a bounded/truncated evidence analysis in no-evidence answers

## Root cause

The authenticated DearConcierge Chrome E2E generated three broad Meilisearch queries such as `Motel One Buchungen Aufenthalte Nächte`. The known source invoices did not satisfy those compound terms, even though an exact `"Motel One"` query ranks them near the top. The run examined 63 candidates for 103.9 seconds and returned no evidence while reporting contradictory complete/incomplete index messages.

## Validation

- `69 passed` across `tests/test_knowledge_research.py` and `tests/test_vector_knowledge.py`
- Ruff clean for the changed files
- Mypy clean for `app/tasks/knowledge_research.py`
- live pre-fix reproduction recorded against the complete 27,125-document Preprod index


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved research retrieval by prioritizing key entities in search queries.
  * Limited duplicate retrieval queries for more focused results.

* **Bug Fixes**
  * Improved “no evidence found” messages by distinguishing complete indexes from analyses limited by text bounds.
  * More accurately reports when the available document index is complete.

* **Tests**
  * Added coverage for entity-prioritized retrieval and clearer no-evidence messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->