### PR TITLE
Enforce Qdrant tenant isolation

### DIFF
--- a/app/api/files.py
+++ b/app/api/files.py
@@ -42,6 +42,22 @@ router = APIRouter()
 DbSession = Annotated[Session, Depends(get_db)]
 
 
+def _delete_vector_chunks(file_records: list[FileRecord]) -> None:
+    """Remove derived Qdrant data with owner-scoped filters before DB deletion."""
+    if not settings.vector_index_enabled or not file_records:
+        return
+    from collections import defaultdict
+
+    from app.utils.vector_index import QdrantVectorIndex
+
+    documents_by_owner: dict[str | None, list[int]] = defaultdict(list)
+    for record in file_records:
+        documents_by_owner[record.owner_id].append(record.id)
+    index = QdrantVectorIndex()
+    for owner_id, document_ids in documents_by_owner.items():
+        index.delete_documents(document_ids, owner_id=owner_id)
+
+
 class BulkPipelineAssignment(BaseModel):
     """Request body for assigning selected files to a processing pipeline."""
 
@@ -483,6 +499,11 @@ def delete_file_record(request: Request, file_id: int, db: DbSession):
         # Log the deletion
         logger.info(f"Deleting file record: ID={file_id}, Filename={file_record.original_filename}")
 
+        # Derived vector chunks contain source text and must be removed before
+        # the authoritative record disappears. Owner scope is retained in the
+        # Qdrant delete filter as defense in depth.
+        _delete_vector_chunks([file_record])
+
         # Delete the record
         db.delete(file_record)
         db.commit()
@@ -553,6 +574,8 @@ def bulk_delete_files(request: Request, file_ids: List[int], db: DbSession):
 
         # Log the deletion
         logger.info(f"Bulk deleting {deleted_count} file records: IDs={deleted_ids}")
+
+        _delete_vector_chunks(file_records)
 
         # Delete the selected records in one statement after access checks.
         query.delete(synchronize_session=False)

--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import Session
 from app.auth import get_current_user, require_login
 from app.config import settings
 from app.database import get_db
-from app.models import FileRecord, KnowledgeResearchJob
+from app.models import FileRecord, FileShare, KnowledgeResearchJob
 from app.utils.user_scope import apply_owner_filter, get_current_owner_id
 
 logger = logging.getLogger(__name__)
@@ -296,6 +296,30 @@ def _accessible_records(db: Session, request: Request, document_ids: list[int]) 
     return {record.id: record for record in records}
 
 
+def _qdrant_authorization_scope(db: Session, request: Request) -> dict[str, Any]:
+    """Build a pre-ranking Qdrant scope matching relational access rules."""
+    if not settings.multi_user_enabled:
+        return {}
+    user = get_current_user(request)
+    if isinstance(user, dict) and user.get("is_admin"):
+        return {}
+    owner_id = get_current_owner_id(request)
+    if owner_id is None:
+        return {"document_ids": []}
+    shared_document_ids = [
+        row[0]
+        for row in db.query(FileShare.file_id)
+        .filter(FileShare.shared_with_user_id == owner_id)
+        .order_by(FileShare.file_id.asc())
+        .all()
+    ]
+    return {
+        "owner_id": owner_id,
+        "shared_document_ids": shared_document_ids,
+        "include_unowned": settings.unowned_docs_visible_to_all,
+    }
+
+
 def _normalized_search_text(value: str | None) -> str:
     """Return comparable Unicode words without punctuation or filename separators."""
     return " ".join(_SEARCH_TOKEN_RE.findall((value or "").casefold()))
@@ -421,12 +445,14 @@ def _search_knowledge(request: Request, body: KnowledgeSearchRequest, db: Sessio
     try:
         from app.utils.vector_index import QdrantVectorIndex
 
-        # Over-fetch because Qdrant ranks globally; DocuElevate applies its
-        # authoritative owner/share checks before returning any payload.
+        # Filter inside Qdrant before ranking so another tenant cannot crowd
+        # out this caller's results. The relational check below remains the
+        # authoritative defense-in-depth boundary.
         raw_hits = QdrantVectorIndex().search(
             body.query,
             limit=min(max(body.limit * 10, 50), 250),
             score_threshold=body.score_threshold,
+            **_qdrant_authorization_scope(db, request),
         )
     except Exception as exc:
         logger.exception("Knowledge search failed: %s", exc)
@@ -886,7 +912,7 @@ def reindex_knowledge(
 
 @router.get("/status")
 @require_login
-def knowledge_status(request: Request) -> dict[str, Any]:
+def knowledge_status(request: Request, db: DbSession) -> dict[str, Any]:
     """Report configuration and Qdrant collection health without secrets."""
     if not settings.vector_index_enabled:
         return {"enabled": False, "collection": settings.vector_index_collection}
@@ -897,7 +923,7 @@ def knowledge_status(request: Request) -> dict[str, Any]:
     except Exception as exc:
         logger.warning("Vector index status check failed: %s", exc)
         index_status = {"available": False, "collection_exists": False, "points_count": 0}
-    return {
+    result = {
         "enabled": True,
         "collection": settings.vector_index_collection,
         "embedding_model": settings.embedding_model,
@@ -905,3 +931,12 @@ def knowledge_status(request: Request) -> dict[str, Any]:
         "chunk_overlap_tokens": settings.vector_chunk_overlap_tokens,
         **index_status,
     }
+    user = get_current_user(request)
+    is_admin = isinstance(user, dict) and bool(user.get("is_admin"))
+    if settings.multi_user_enabled and not is_admin:
+        # Qdrant reports the global point count for the shared collection.
+        # Ordinary users receive only the size of their relationally
+        # authorized document scope, never another tenant's corpus metrics.
+        result.pop("points_count", None)
+        result["documents_accessible"] = apply_owner_filter(db.query(FileRecord.id), request).count()
+    return result

--- a/app/tasks/upload_to_user_integration.py
+++ b/app/tasks/upload_to_user_integration.py
@@ -715,6 +715,7 @@ def _upload_vector_database(
     task_id: str,
     *,
     file_id: int | None,
+    integration_owner_id: str,
 ) -> dict[str, Any]:
     """Index one processed document in the operator-managed Qdrant collection."""
     provider = str(cfg.get("provider") or "qdrant").lower()
@@ -732,6 +733,8 @@ def _upload_vector_database(
         record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
         if record is None:
             raise ValueError(f"FileRecord {file_id} not found")
+        if settings.multi_user_enabled and record.owner_id != integration_owner_id:
+            raise ValueError("Vector destination owner does not match the document owner")
         count = QdrantVectorIndex().index_document(record)
 
     logger.info("[%s] Indexed %d Qdrant chunks for file %s", task_id, count, file_id)
@@ -857,7 +860,14 @@ def upload_to_user_integration(self, file_path: str, integration_id: int, file_i
 
     try:
         if itype == IntegrationType.VECTOR_DATABASE:
-            result = handler(file_path, cfg, creds, task_id, file_id=file_id)
+            result = handler(
+                file_path,
+                cfg,
+                creds,
+                task_id,
+                file_id=file_id,
+                integration_owner_id=owner_id,
+            )
         else:
             result = handler(file_path, cfg, creds, task_id)
 

--- a/app/utils/vector_index.py
+++ b/app/utils/vector_index.py
@@ -174,15 +174,47 @@ class QdrantVectorIndex:
                 {"vectors": {"size": dimensions, "distance": "Cosine"}},
                 expected=(200, 201),
             )
-            return
+        else:
+            config = response.json().get("result", {}).get("config", {}).get("params", {}).get("vectors", {})
+            current_size = config.get("size") if isinstance(config, dict) else None
+            if current_size is not None and int(current_size) != dimensions:
+                raise VectorIndexError(
+                    f"Collection {self.collection!r} uses {current_size} dimensions, but "
+                    f"{settings.embedding_model!r} returned {dimensions}"
+                )
 
-        config = response.json().get("result", {}).get("config", {}).get("params", {}).get("vectors", {})
-        current_size = config.get("size") if isinstance(config, dict) else None
-        if current_size is not None and int(current_size) != dimensions:
-            raise VectorIndexError(
-                f"Collection {self.collection!r} uses {current_size} dimensions, but "
-                f"{settings.embedding_model!r} returned {dimensions}"
+        # Qdrant needs payload indexes to evaluate tenant and document filters
+        # before vector ranking without scanning the whole shared collection.
+        for field_name, field_schema in (("owner_id", "keyword"), ("document_id", "integer")):
+            self._request(
+                "PUT",
+                f"/collections/{self.collection}/index?wait=true",
+                {"field_name": field_name, "field_schema": field_schema},
+                expected=(200, 201),
             )
+
+    @staticmethod
+    def _owner_condition(owner_id: str | None) -> dict[str, Any]:
+        if owner_id is None:
+            return {"is_null": {"key": "owner_id"}}
+        return {"key": "owner_id", "match": {"value": owner_id}}
+
+    @classmethod
+    def _authorization_filter(
+        cls,
+        *,
+        owner_id: str | None,
+        shared_document_ids: list[int] | None,
+        include_unowned: bool,
+    ) -> dict[str, Any] | None:
+        conditions: list[dict[str, Any]] = []
+        if owner_id is not None:
+            conditions.append(cls._owner_condition(owner_id))
+        if shared_document_ids:
+            conditions.append({"key": "document_id", "match": {"any": shared_document_ids}})
+        if include_unowned:
+            conditions.append(cls._owner_condition(None))
+        return {"should": conditions} if conditions else None
 
     def index_document(self, file_record: Any) -> int:
         """Replace all indexed chunks for one FileRecord and return their count."""
@@ -264,12 +296,33 @@ class QdrantVectorIndex:
             f"/collections/{self.collection}/points/delete?wait=true",
             {
                 "filter": {
-                    "must": [{"key": "document_id", "match": {"value": file_record.id}}],
+                    "must": [
+                        {"key": "document_id", "match": {"value": file_record.id}},
+                        self._owner_condition(file_record.owner_id),
+                    ],
                     "must_not": [{"key": "index_version", "match": {"value": index_version}}],
                 }
             },
         )
         return len(points)
+
+    def delete_documents(self, document_ids: list[int], *, owner_id: str | None) -> None:
+        """Delete derived chunks for owner-scoped documents."""
+        if not document_ids:
+            return
+        self._request(
+            "POST",
+            f"/collections/{self.collection}/points/delete?wait=true",
+            {
+                "filter": {
+                    "must": [
+                        {"key": "document_id", "match": {"any": document_ids}},
+                        self._owner_condition(owner_id),
+                    ]
+                }
+            },
+            expected=(200, 404),
+        )
 
     def search(
         self,
@@ -278,6 +331,9 @@ class QdrantVectorIndex:
         limit: int,
         score_threshold: float | None = None,
         document_ids: list[int] | None = None,
+        owner_id: str | None = None,
+        shared_document_ids: list[int] | None = None,
+        include_unowned: bool = False,
     ) -> list[dict[str, Any]]:
         vector = generate_embeddings([query])[0]
         body: dict[str, Any] = {
@@ -288,10 +344,22 @@ class QdrantVectorIndex:
         }
         if score_threshold is not None:
             body["score_threshold"] = score_threshold
+        authorization_filter = self._authorization_filter(
+            owner_id=owner_id,
+            shared_document_ids=shared_document_ids,
+            include_unowned=include_unowned,
+        )
         if document_ids is not None:
             if not document_ids:
                 return []
-            body["filter"] = {"must": [{"key": "document_id", "match": {"any": document_ids}}]}
+            document_filter = {"key": "document_id", "match": {"any": document_ids}}
+            body["filter"] = (
+                {"must": [document_filter, authorization_filter]}
+                if authorization_filter
+                else {"must": [document_filter]}
+            )
+        elif authorization_filter is not None:
+            body["filter"] = authorization_filter
 
         response = self._request(
             "POST",

--- a/docs/API.md
+++ b/docs/API.md
@@ -197,9 +197,12 @@ operator-managed vector-index connection, so the user integration needs only
 
 #### Source-backed semantic retrieval
 
-Vector retrieval is available only when `VECTOR_INDEX_ENABLED=true`. Qdrant results
-are always checked against DocuElevate's authoritative owner/share rules before any
-passage is returned.
+Vector retrieval is available only when `VECTOR_INDEX_ENABLED=true`. A SaaS deployment
+uses one private Qdrant collection with indexed `owner_id` and `document_id` payloads.
+Owner, explicit-share, and optional unowned-document filters are applied inside Qdrant
+before ranking. Results are then checked again against DocuElevate's authoritative
+relational owner/share rules before any passage is returned. Ordinary users never see
+the collection's global point count through the status endpoint.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -51,6 +51,12 @@ secret manager; do not store them in `.env` files committed to source control.
 | `DOCUMENT_BRIDGE_SHARED_SECRET` | Dedicated intake-secret fallback when no Bearer token is used. | unset |
 | `DOCUMENT_BRIDGE_SOURCE` | Provenance label included in deliveries. | `docuelevate-legacy` |
 
+In multi-user mode, DocuElevate keeps a single operator-managed Qdrant collection and
+isolates tenants with indexed `owner_id` and `document_id` payload filters before
+ranking. Explicitly shared document IDs are added to the caller's filter. Relational
+authorization is checked again before source text is returned, and ordinary users do
+not receive global collection sizes from the knowledge status API.
+
 Example preproduction service configuration (secret values omitted):
 
 ```dotenv

--- a/docs/DearConciergeKnowledgeBridge.md
+++ b/docs/DearConciergeKnowledgeBridge.md
@@ -25,9 +25,12 @@ DearConcierge MCP adapter --------------------------> retrieval API
 ```
 
 The relational database and document work directory remain authoritative. Qdrant is
-a derived index that can be deleted and rebuilt. Search results are never trusted for
-authorization: document IDs returned by Qdrant are checked against the relational
-owner/share model before any text is returned.
+a derived index that can be deleted and rebuilt. Multi-user installations use one
+private collection with payload indexes for `owner_id` and `document_id`. Owner and
+explicit-share filters run before vector ranking; the document IDs returned by Qdrant
+are then checked against the relational owner/share model again before any text is
+returned. Owner-scoped cleanup removes derived chunks before a document record is
+deleted.
 
 Qdrant is configured as a normal `VECTOR_DATABASE` destination on the user's
 integration dashboard. The connection remains operator-managed, while destination
@@ -83,6 +86,8 @@ subsequent polls continue from Dropbox's change cursor.
 - Replacement is idempotent and retains the old index if embedding generation fails.
 - An explicit corpus backfill and a health endpoint exist.
 - Qdrant is private to the cluster and protected by its own API key.
+- In multi-user mode, pre-ranking owner/share filters isolate tenants in the shared
+  collection; ordinary status responses omit global corpus sizes.
 
 ### KB-5: Retrieval and MCP
 

--- a/tests/test_vector_destination.py
+++ b/tests/test_vector_destination.py
@@ -28,7 +28,7 @@ def test_vector_connection_uses_operator_qdrant(monkeypatch):
 def test_vector_upload_indexes_file_record(monkeypatch, tmp_path):
     monkeypatch.setattr("app.tasks.upload_to_user_integration.settings.vector_index_enabled", True)
     monkeypatch.setattr("app.tasks.upload_to_user_integration.settings.vector_index_collection", "DocuElevate Preprod")
-    record = SimpleNamespace(id=42, ocr_text="project plan")
+    record = SimpleNamespace(id=42, owner_id="owner-1", ocr_text="project plan")
     db = MagicMock()
     db.query.return_value.filter.return_value.first.return_value = record
     db_context = MagicMock()
@@ -42,12 +42,49 @@ def test_vector_upload_indexes_file_record(monkeypatch, tmp_path):
     ):
         from app.tasks.upload_to_user_integration import _upload_vector_database
 
-        result = _upload_vector_database(str(file_path), {"provider": "qdrant"}, {}, "task-1", file_id=42)
+        result = _upload_vector_database(
+            str(file_path),
+            {"provider": "qdrant"},
+            {},
+            "task-1",
+            file_id=42,
+            integration_owner_id="owner-1",
+        )
 
     index_document.assert_called_once_with(record)
     assert result["status"] == "Completed"
     assert result["chunks_indexed"] == 3
     assert result["collection"] == "DocuElevate Preprod"
+
+
+def test_vector_upload_rejects_cross_tenant_destination(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.tasks.upload_to_user_integration.settings.vector_index_enabled", True)
+    monkeypatch.setattr("app.tasks.upload_to_user_integration.settings.multi_user_enabled", True)
+    record = SimpleNamespace(id=42, owner_id="julia", ocr_text="private")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = record
+    db_context = MagicMock()
+    db_context.__enter__.return_value = db
+    file_path = tmp_path / "document.pdf"
+    file_path.write_bytes(b"%PDF")
+
+    with (
+        patch("app.tasks.upload_to_user_integration.SessionLocal", return_value=db_context),
+        patch("app.utils.vector_index.QdrantVectorIndex.index_document") as index_document,
+    ):
+        from app.tasks.upload_to_user_integration import _upload_vector_database
+
+        with pytest.raises(ValueError, match="owner does not match"):
+            _upload_vector_database(
+                str(file_path),
+                {"provider": "qdrant"},
+                {},
+                "task-1",
+                file_id=42,
+                integration_owner_id="christian",
+            )
+
+    index_document.assert_not_called()
 
 
 def test_automatic_index_defers_to_vector_destination(monkeypatch):

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -8,7 +8,7 @@ import pytest
 import requests
 from starlette.requests import Request
 
-from app.models import FileRecord, KnowledgeResearchJob
+from app.models import FileRecord, FileShare, KnowledgeResearchJob
 
 
 def _file(file_id: int = 7, owner_id: str | None = None) -> SimpleNamespace:
@@ -61,6 +61,10 @@ def test_index_replaces_document_after_embeddings_are_ready():
     assert all(point["payload"]["document_id"] == 7 for point in upsert["points"])
     index_version = upsert["points"][0]["payload"]["index_version"]
     cleanup = request.call_args_list[1].args[2]["filter"]
+    assert cleanup["must"] == [
+        {"key": "document_id", "match": {"value": 7}},
+        {"is_null": {"key": "owner_id"}},
+    ]
     assert cleanup["must_not"] == [{"key": "index_version", "match": {"value": index_version}}]
 
 
@@ -215,7 +219,14 @@ def test_qdrant_collection_creation_and_dimension_guard():
 
     missing = SimpleNamespace(status_code=404)
     with patch.object(
-        QdrantVectorIndex, "_request", side_effect=[missing, SimpleNamespace(status_code=201)]
+        QdrantVectorIndex,
+        "_request",
+        side_effect=[
+            missing,
+            SimpleNamespace(status_code=201),
+            SimpleNamespace(status_code=200),
+            SimpleNamespace(status_code=200),
+        ],
     ) as request:
         QdrantVectorIndex().ensure_collection(1536)
     assert request.call_args_list == [
@@ -224,6 +235,18 @@ def test_qdrant_collection_creation_and_dimension_guard():
             "PUT",
             "/collections/docuelevate_documents",
             {"vectors": {"size": 1536, "distance": "Cosine"}},
+            expected=(200, 201),
+        ),
+        call(
+            "PUT",
+            "/collections/docuelevate_documents/index?wait=true",
+            {"field_name": "owner_id", "field_schema": "keyword"},
+            expected=(200, 201),
+        ),
+        call(
+            "PUT",
+            "/collections/docuelevate_documents/index?wait=true",
+            {"field_name": "document_id", "field_schema": "integer"},
             expected=(200, 201),
         ),
     ]
@@ -262,6 +285,47 @@ def test_qdrant_search_uses_legacy_fallback_and_normalizes_results():
     assert request.call_args_list[0].args[2]["filter"] == {"must": [{"key": "document_id", "match": {"any": [7, 8]}}]}
     assert request.call_args_list[1].args[2]["vector"] == [0.1, 0.2]
     assert "query" not in request.call_args_list[1].args[2]
+
+
+def test_qdrant_search_filters_owner_shares_and_unowned_before_ranking():
+    from app.utils.vector_index import QdrantVectorIndex
+
+    response = SimpleNamespace(status_code=200, json=lambda: {"result": {"points": []}})
+    with (
+        patch("app.utils.vector_index.generate_embeddings", return_value=[[0.1, 0.2]]),
+        patch.object(QdrantVectorIndex, "_request", return_value=response) as request,
+    ):
+        QdrantVectorIndex().search(
+            "query",
+            limit=5,
+            owner_id="alice@example.com",
+            shared_document_ids=[8, 9],
+            include_unowned=True,
+        )
+
+    assert request.call_args.args[2]["filter"] == {
+        "should": [
+            {"key": "owner_id", "match": {"value": "alice@example.com"}},
+            {"key": "document_id", "match": {"any": [8, 9]}},
+            {"is_null": {"key": "owner_id"}},
+        ]
+    }
+
+
+def test_qdrant_document_cleanup_is_owner_scoped():
+    from app.utils.vector_index import QdrantVectorIndex
+
+    with patch.object(QdrantVectorIndex, "_request") as request:
+        QdrantVectorIndex().delete_documents([7, 8], owner_id="alice@example.com")
+
+    assert request.call_args.args[2] == {
+        "filter": {
+            "must": [
+                {"key": "document_id", "match": {"any": [7, 8]}},
+                {"key": "owner_id", "match": {"value": "alice@example.com"}},
+            ]
+        }
+    }
 
 
 def test_qdrant_status_handles_missing_and_existing_collection():
@@ -318,6 +382,98 @@ def test_owner_filter_removes_unauthorized_vector_hits(db_session):
         accessible = _accessible_records(db_session, request, [1, 2])
 
     assert list(accessible) == [1]
+
+
+def test_knowledge_search_passes_authorized_scope_to_qdrant(db_session):
+    own = FileRecord(
+        id=11,
+        owner_id="alice@example.com",
+        filehash="alice-owned",
+        original_filename="owned.pdf",
+        local_filename="/tmp/owned.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="owned evidence",
+    )
+    shared = FileRecord(
+        id=12,
+        owner_id="bob@example.com",
+        filehash="bob-shared",
+        original_filename="shared.pdf",
+        local_filename="/tmp/shared.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="shared evidence",
+    )
+    denied = FileRecord(
+        id=13,
+        owner_id="bob@example.com",
+        filehash="bob-denied",
+        original_filename="denied.pdf",
+        local_filename="/tmp/denied.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+        ocr_text="denied evidence",
+    )
+    db_session.add_all([own, shared, denied])
+    db_session.add(
+        FileShare(
+            file_id=12,
+            owner_id="bob@example.com",
+            shared_with_user_id="alice@example.com",
+            role="viewer",
+        )
+    )
+    db_session.commit()
+    request = Request({"type": "http", "headers": []})
+    request.scope["session"] = {"user": {"email": "alice@example.com"}}
+    hits = [
+        {"score": 0.9, "payload": {"document_id": 11, "text": "owned"}},
+        {"score": 0.8, "payload": {"document_id": 12, "text": "shared"}},
+        {"score": 1.0, "payload": {"document_id": 13, "text": "must be removed"}},
+    ]
+
+    with (
+        patch("app.api.knowledge.settings.vector_index_enabled", True),
+        patch("app.api.knowledge.settings.multi_user_enabled", True),
+        patch("app.api.knowledge.settings.unowned_docs_visible_to_all", False),
+        patch("app.utils.vector_index.QdrantVectorIndex.search", return_value=hits) as search,
+    ):
+        from app.api.knowledge import KnowledgeSearchRequest, _search_knowledge
+
+        result = _search_knowledge(request, KnowledgeSearchRequest(query="evidence", limit=5), db_session)
+
+    assert search.call_args.kwargs["owner_id"] == "alice@example.com"
+    assert search.call_args.kwargs["shared_document_ids"] == [12]
+    assert search.call_args.kwargs["include_unowned"] is False
+    assert [item["document_id"] for item in result["results"]] == [11, 12]
+
+
+def test_knowledge_status_hides_global_point_count_from_tenant(db_session):
+    record = FileRecord(
+        owner_id="alice@example.com",
+        filehash="alice-status",
+        original_filename="status.pdf",
+        local_filename="/tmp/status.pdf",
+        file_size=1,
+        mime_type="application/pdf",
+    )
+    db_session.add(record)
+    db_session.commit()
+    request = Request({"type": "http", "headers": []})
+    request.scope["session"] = {"user": {"email": "alice@example.com"}}
+
+    with (
+        patch("app.api.knowledge.settings.vector_index_enabled", True),
+        patch("app.api.knowledge.settings.multi_user_enabled", True),
+        patch("app.utils.vector_index.QdrantVectorIndex.status", return_value={"points_count": 999}),
+    ):
+        from app.api.knowledge import knowledge_status
+
+        result = knowledge_status(request=request, db=db_session)
+
+    assert "points_count" not in result
+    assert result["documents_accessible"] == 1
 
 
 def test_keyword_research_scopes_meilisearch_before_ranking(db_session):


### PR DESCRIPTION
Closes #1047

## What changed

- applies owner, explicit-share, and optional unowned-document filters inside Qdrant before vector ranking
- creates Qdrant payload indexes for `owner_id` and `document_id`
- retains the relational owner/share authorization check as a second boundary
- rejects vector-destination jobs whose integration owner differs from the document owner
- scopes replacement and deletion cleanup by owner and removes derived chunks before database deletion
- hides global Qdrant point counts from ordinary multi-user status responses
- documents the shared-collection payload-isolation architecture

## Why

Post-ranking filtering allowed another tenant's vectors to crowd out authorized results and exposed a global corpus size through status. The vector destination also did not assert owner equality.

## Validation

- 301 focused multi-user, file, vector, and deletion tests passed
- 45 vector-specific tests passed after the final changes
- Ruff lint and formatting checks passed
- live local Qdrant smoke verified that pre-ranking filters return own, explicitly shared, and permitted unowned documents while excluding another tenant's private document
