### PR TITLE
Keep RAG lexical retrieval precise

### DIFF
--- a/app/tasks/knowledge_research.py
+++ b/app/tasks/knowledge_research.py
@@ -438,6 +438,7 @@ def _search_lexical_scope(scope: list[int], lexical_queries: list[str]) -> tuple
                 file_ids=scope,
                 page=page,
                 per_page=_LEXICAL_RESULTS_PER_SCOPE,
+                matching_strategy="all",
             )
             page_scores = []
             for hit in result.get("results", []):

--- a/app/utils/meilisearch_client.py
+++ b/app/utils/meilisearch_client.py
@@ -291,7 +291,8 @@ def search_documents(
         sort_by: Relevance or a supported sortable document field.
         sort_order: Ascending or descending when ``sort_by`` is not relevance.
         matching_strategy: Optional Meilisearch term-matching strategy. Use
-            ``"all"`` for precision-sensitive retrieval planning.
+            ``"all"`` to require every query term, or ``"last"`` to retain
+            Meilisearch's fallback behavior.
         page: 1-based page number.
         per_page: Results per page (max 100).
 

--- a/app/utils/meilisearch_client.py
+++ b/app/utils/meilisearch_client.py
@@ -270,6 +270,7 @@ def search_documents(
     date_to: Optional[int] = None,
     sort_by: str = "relevance",
     sort_order: str = "desc",
+    matching_strategy: str | None = None,
     page: int = 1,
     per_page: int = 20,
 ) -> dict:
@@ -289,6 +290,8 @@ def search_documents(
         date_to: Optional upper bound Unix timestamp for created_at.
         sort_by: Relevance or a supported sortable document field.
         sort_order: Ascending or descending when ``sort_by`` is not relevance.
+        matching_strategy: Optional Meilisearch term-matching strategy. Use
+            ``"all"`` for precision-sensitive retrieval planning.
         page: 1-based page number.
         per_page: Results per page (max 100).
 
@@ -359,6 +362,8 @@ def search_documents(
 
         if filters:
             search_params["filter"] = " AND ".join(filters)
+        if matching_strategy in {"all", "last"}:
+            search_params["matchingStrategy"] = matching_strategy
 
         sort_fields = {
             "created_at": "created_at_ts",

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -270,6 +270,13 @@ class TestMeilisearchSearchDocuments:
         search_params = mock_index.search.call_args.args[1]
         assert search_params["matchingStrategy"] == "all"
 
+        mock_index.search.reset_mock()
+        with patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client):
+            search_documents("invoice")
+
+        default_search_params = mock_index.search.call_args.args[1]
+        assert "matchingStrategy" not in default_search_params
+
     def test_search_with_tags_filter(self):
         """search_documents passes tags filter to Meilisearch."""
         mock_client, mock_index = self._make_mock_client(hits=[], total=0)

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -258,6 +258,18 @@ class TestMeilisearchSearchDocuments:
         search_params = mock_index.search.call_args.args[1]
         assert search_params["filter"] == "file_id IN [12, 42]"
 
+    def test_search_can_require_all_query_terms(self):
+        """Research retrieval can prevent broad fallback term matching."""
+        mock_client, mock_index = self._make_mock_client(hits=[], total=0)
+
+        with patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client):
+            from app.utils.meilisearch_client import search_documents
+
+            search_documents('"Motel One" booking stay', matching_strategy="all")
+
+        search_params = mock_index.search.call_args.args[1]
+        assert search_params["matchingStrategy"] == "all"
+
     def test_search_with_tags_filter(self):
         """search_documents passes tags filter to Meilisearch."""
         mock_client, mock_index = self._make_mock_client(hits=[], total=0)

--- a/tests/test_knowledge_research.py
+++ b/tests/test_knowledge_research.py
@@ -61,9 +61,10 @@ def test_research_retries_transient_database_disconnect():
 def test_candidate_retrieval_pages_qualified_matches_per_scope():
     calls = []
 
-    def search(query, *, file_ids, page, per_page):
+    def search(query, *, file_ids, page, per_page, matching_strategy=None):
         calls.append((query, page, per_page))
         assert file_ids == [1, 2, 3]
+        assert matching_strategy == (None if query == "" else "all")
         if query == "":
             return {"results": [], "total": 3, "pages": 3}
         if page == 1:
@@ -138,7 +139,7 @@ def test_research_planner_omits_gpt5_only_kwargs_for_other_models():
 
 
 def test_candidate_retrieval_uses_adaptive_relevance_threshold():
-    def search(query, *, file_ids, page, per_page):
+    def search(query, *, file_ids, page, per_page, matching_strategy=None):
         if query == "":
             return {"results": [], "total": len(file_ids), "pages": 1}
         return {
@@ -165,7 +166,7 @@ def test_candidate_retrieval_uses_adaptive_relevance_threshold():
 
 
 def test_candidate_retrieval_prioritizes_documents_matching_qualified_queries():
-    def search(query, *, file_ids, page, per_page):
+    def search(query, *, file_ids, page, per_page, matching_strategy=None):
         if query == "":
             return {"results": [], "total": len(file_ids), "pages": 1}
         if query == '"Motel One"':
@@ -203,7 +204,7 @@ def test_candidate_retrieval_prioritizes_documents_matching_qualified_queries():
 def test_candidate_retrieval_runs_qualified_query_after_broad_query_saturates():
     queries = []
 
-    def search(query, *, file_ids, page, per_page):
+    def search(query, *, file_ids, page, per_page, matching_strategy=None):
         queries.append((query, page))
         if query == "":
             return {"results": [], "total": len(file_ids), "pages": 1}
@@ -249,7 +250,7 @@ def test_candidate_retrieval_uses_relative_semantic_threshold():
         {"score": 0.60, "payload": {"document_id": 3}},
     ]
 
-    def search(query, *, file_ids, page, per_page):
+    def search(query, *, file_ids, page, per_page, matching_strategy=None):
         if query == "":
             return {"results": [], "total": len(file_ids), "pages": 1}
         return {"results": [], "total": 0, "pages": 1}
@@ -277,7 +278,7 @@ def test_candidate_retrieval_uses_relative_semantic_threshold():
 
 
 def test_candidate_retrieval_reports_technical_safety_truncation():
-    def search(query, *, file_ids, page, per_page):
+    def search(query, *, file_ids, page, per_page, matching_strategy=None):
         if query == "":
             return {"results": [], "total": len(file_ids), "pages": 1}
         return {
@@ -333,7 +334,7 @@ def test_truncated_research_result_is_not_reused_as_complete():
 def test_candidate_retrieval_splits_scopes_at_search_result_cap():
     scopes = []
 
-    def search(query, *, file_ids, page, per_page):
+    def search(query, *, file_ids, page, per_page, matching_strategy=None):
         scopes.append((query, file_ids, page, per_page))
         if query == "":
             return {"results": [], "total": len(file_ids), "pages": 1}


### PR DESCRIPTION
## What changed

- adds an explicit Meilisearch `matching_strategy` option
- makes cross-document RAG planning require all terms in each planned lexical query
- preserves normal interactive search behavior unchanged

## Why

Meilisearch's fallback term matching can turn a seemingly precise planner query into a broad match. In two Chrome runs of the identical Motel One question, the planner produced 41 candidates once and 687 candidates the next time. That variability makes the one-minute p90 target impossible to hold even though the UI correctly shows progress and elapsed time.

The fix improves query precision instead of imposing an arbitrary candidate budget. On the live preprod corpus:

- `"Motel One"`: 41 matches with either strategy
- `"Motel One" booking confirmation`: 41 fallback matches, 0 all-term matches
- `"Motel One" invoice`: 41 fallback matches, 3 all-term matches

This retains the exact entity probe while preventing broad descriptive queries from expanding to unrelated documents.

## Validation

- 70 knowledge-research and search tests passed
- Ruff lint and formatting passed
- live Meilisearch comparison confirmed the intended candidate narrowing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lexical knowledge searches to return results matching all search terms, reducing less-relevant matches.

* **Search Improvements**
  * Added support for selecting search matching behavior, including matching all terms or the last term, while preserving existing defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->