### PR TITLE
Mask database credentials in setup UI

### DIFF
--- a/app/utils/config_validator/masking.py
+++ b/app/utils/config_validator/masking.py
@@ -2,6 +2,8 @@
 Module for masking sensitive information in configuration values
 """
 
+from sqlalchemy.engine import make_url
+
 
 def mask_sensitive_value(value: str | None) -> str | None:
     """
@@ -11,3 +13,16 @@ def mask_sensitive_value(value: str | None) -> str | None:
     if value and isinstance(value, str) and len(value) > 8:
         return value[:4] + "*" * (len(value) - 4)
     return value
+
+
+def mask_database_url(value: str | None) -> str | None:
+    """Preserve useful database location details while hiding credentials."""
+    if not value or not isinstance(value, str):
+        return value
+    try:
+        parsed = make_url(value)
+        return parsed.render_as_string(hide_password=True)
+    except Exception:
+        # Malformed connection strings may still contain credentials. Never
+        # echo them back merely because SQLAlchemy cannot parse the value.
+        return mask_sensitive_value(value)

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -26,7 +26,7 @@ SETTING_METADATA = {
         "category": "Core",
         "description": "Database connection URL (e.g., sqlite:///path/to/db.sqlite). Use the Database Wizard for guided setup.",
         "type": "string",
-        "sensitive": False,
+        "sensitive": True,
         "required": True,
         "restart_required": True,
         "help_link": "/database-wizard",

--- a/app/views/db_wizard.py
+++ b/app/views/db_wizard.py
@@ -11,6 +11,7 @@ from fastapi import Request
 from fastapi.responses import Response
 
 from app.config import settings
+from app.utils.config_validator.masking import mask_database_url
 from app.views.base import APIRouter, templates
 
 logger = logging.getLogger(__name__)
@@ -24,6 +25,6 @@ async def database_wizard(request: Request) -> Response:
         "db_wizard.html",
         {
             "request": request,
-            "current_database_url": settings.database_url,
+            "current_database_url": mask_database_url(settings.database_url),
         },
     )

--- a/app/views/settings.py
+++ b/app/views/settings.py
@@ -11,7 +11,7 @@ from fastapi import Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
-from app.utils.config_validator.masking import mask_sensitive_value
+from app.utils.config_validator.masking import mask_database_url, mask_sensitive_value
 from app.utils.settings_service import (
     SETTING_METADATA,
     get_all_settings_from_db,
@@ -97,7 +97,9 @@ async def settings_page(request: Request, db: Session = Depends(get_db)):
 
                 # Mask sensitive values
                 display_value = value
-                if metadata.get("sensitive") and value:
+                if key == "database_url" and value:
+                    display_value = mask_database_url(str(value))
+                elif metadata.get("sensitive") and value:
                     display_value = mask_sensitive_value(value)
 
                 settings_data[category].append(

--- a/app/views/wizard.py
+++ b/app/views/wizard.py
@@ -43,6 +43,7 @@ async def setup_wizard(request: Request, step: int = 1, db: Session = Depends(ge
 
     # Enrich settings with current live values
     from app.config import settings as app_settings
+    from app.utils.config_validator.masking import mask_database_url
     from app.utils.settings_service import get_setting_from_db
 
     enriched_settings = []
@@ -63,6 +64,8 @@ async def setup_wizard(request: Request, step: int = 1, db: Session = Depends(ge
         else:
             current_value = ""
             value_source = "none"
+        if key == "database_url" and current_value:
+            current_value = mask_database_url(str(current_value))
         enriched_settings.append({**s, "current_value": current_value, "value_source": value_source})
     current_settings = enriched_settings
 

--- a/frontend/templates/db_wizard.html
+++ b/frontend/templates/db_wizard.html
@@ -310,13 +310,8 @@
                    :placeholder="currentDbUrl || 'sqlite:///./app/database.db'"
                    aria-describedby="mig_source_help" />
             <p id="mig_source_help" class="text-xs text-gray-500 mt-1">
-              This is your current database. Pre-filled with the running configuration.
+              Re-enter the source credentials. The current database is shown only as a masked placeholder.
             </p>
-            <button @click="migrate.source = currentDbUrl"
-                    class="mt-1 text-xs text-indigo-600 hover:underline focus:outline-none"
-                    type="button">
-              <i class="fas fa-sync-alt mr-1" aria-hidden="true"></i> Use current database
-            </button>
           </div>
 
           {# Target URL #}
@@ -490,7 +485,7 @@ function dbWizard() {
     copied: false,
 
     migrate: {
-      source: '{{ current_database_url | default("", true) }}',
+      source: '',
       target: '',
       sourceTest: null,
       targetTest: null,

--- a/tests/test_database_url_masking.py
+++ b/tests/test_database_url_masking.py
@@ -1,0 +1,54 @@
+"""Regression tests for connection-string credential disclosure."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+def test_database_url_mask_preserves_location_without_password():
+    from app.utils.config_validator.masking import mask_database_url
+
+    value = "postgresql+psycopg://docuelevate:top-secret@database.internal:5432/docuelevate"
+    masked = mask_database_url(value)
+
+    assert masked == "postgresql+psycopg://docuelevate:***@database.internal:5432/docuelevate"
+    assert "top-secret" not in masked
+
+
+@pytest.mark.unit
+def test_database_url_mask_handles_sqlite_and_malformed_values():
+    from app.utils.config_validator.masking import mask_database_url
+
+    assert mask_database_url("sqlite:////workdir/docuelevate.db") == "sqlite:////workdir/docuelevate.db"
+    malformed = "not-a-url-with-a-secret-value"
+    masked = mask_database_url(malformed)
+    assert masked != malformed
+    assert masked.startswith("not-")
+
+
+@pytest.mark.unit
+def test_database_url_is_sensitive_settings_metadata():
+    from app.utils.settings_service import SETTING_METADATA
+
+    assert SETTING_METADATA["database_url"]["sensitive"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_database_wizard_never_renders_raw_database_password():
+    from app.views.db_wizard import database_wizard
+
+    request = Mock()
+    with (
+        patch(
+            "app.views.db_wizard.settings.database_url",
+            "postgresql://docuelevate:top-secret@database.internal/docuelevate",
+        ),
+        patch("app.views.db_wizard.templates") as templates,
+    ):
+        await database_wizard(request)
+
+    context = templates.TemplateResponse.call_args.args[1]
+    assert context["current_database_url"] == "postgresql://docuelevate:***@database.internal/docuelevate"
+    assert "top-secret" not in context["current_database_url"]


### PR DESCRIPTION
Addresses the browser-rendering and onboarding portion of #1138.

## What changed

- marks `database_url` as sensitive settings metadata so database-persisted values are encrypted and audit output is redacted
- renders PostgreSQL/MySQL-style URLs with the password replaced by `***` while retaining driver, username, host, port, and database
- applies the same masking to the main settings page, setup journey, and database wizard
- removes the database wizard's unsafe pre-filled migration credential and asks the admin to re-enter it
- safely falls back to full masking for malformed connection strings

## Why

The preprod onboarding audit showed an embedded PostgreSQL password in the rendered settings page and accessibility output. Other credentials were already masked, but connection strings were classified as non-sensitive.

## Validation

- 163 settings, wizard, audit, and persistence tests passed
- Ruff lint and formatting passed
- dedicated regression tests cover PostgreSQL, SQLite, malformed URLs, metadata, and database-wizard template context

The broader policy for downloadable configuration exports remains tracked in #1138 and is intentionally not changed in this focused UI fix.
