### PR TITLE
Add owner-controlled document privacy

### DIFF
--- a/app/api/comments.py
+++ b/app/api/comments.py
@@ -165,7 +165,9 @@ def list_comments(request: Request, file_id: int, db: DbSession):
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
-    if not is_admin and not has_file_role(file_record, user_id, db, minimum_role=FILE_SHARE_ROLE_VIEWER):
+    if not (is_admin and not file_record.is_private) and not has_file_role(
+        file_record, user_id, db, minimum_role=FILE_SHARE_ROLE_VIEWER
+    ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     comments = (
@@ -215,7 +217,9 @@ def create_comment(
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
-    if not is_admin and not has_file_role(file_record, owner_id, db, minimum_role=FILE_SHARE_ROLE_VIEWER):
+    if not (is_admin and not file_record.is_private) and not has_file_role(
+        file_record, owner_id, db, minimum_role=FILE_SHARE_ROLE_VIEWER
+    ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     if not isinstance(body, str) or not body.strip():
@@ -259,7 +263,7 @@ def create_comment(
         # Auto-share the file with mentioned users that don't have access yet.
         # Only do this in multi-user mode and only when the file has an owner
         # (unowned files are already visible to all authenticated users).
-        if mentions and file_record.owner_id is not None:
+        if mentions and file_record.owner_id is not None and not file_record.is_private:
             from app.config import settings as _settings
 
             if _settings.multi_user_enabled:
@@ -480,7 +484,9 @@ def list_annotations(request: Request, file_id: int, db: DbSession):
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
-    if not is_admin and not has_file_role(file_record, user_id, db, minimum_role=FILE_SHARE_ROLE_VIEWER):
+    if not (is_admin and not file_record.is_private) and not has_file_role(
+        file_record, user_id, db, minimum_role=FILE_SHARE_ROLE_VIEWER
+    ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     annotations = (
@@ -540,7 +546,9 @@ def create_annotation(
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
-    if not is_admin and not has_file_role(file_record, owner_id, db, minimum_role=FILE_SHARE_ROLE_VIEWER):
+    if not (is_admin and not file_record.is_private) and not has_file_role(
+        file_record, owner_id, db, minimum_role=FILE_SHARE_ROLE_VIEWER
+    ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     if not isinstance(content, str) or not content.strip():

--- a/app/api/duplicates.py
+++ b/app/api/duplicates.py
@@ -18,6 +18,7 @@ from app.auth import require_login
 from app.config import settings
 from app.database import get_db
 from app.models import FileRecord
+from app.utils.user_scope import apply_owner_filter
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,9 @@ def list_duplicate_groups(
     ```
     """
     # Find all hashes that have at least one duplicate record
-    dup_hashes_query = db.query(FileRecord.filehash).filter(FileRecord.is_duplicate.is_(True)).distinct()
+    dup_hashes_query = apply_owner_filter(
+        db.query(FileRecord.filehash).filter(FileRecord.is_duplicate.is_(True)), request
+    ).distinct()
     total_groups = dup_hashes_query.count()
 
     # Paginate hash groups
@@ -76,7 +79,10 @@ def list_duplicate_groups(
     if dup_hashes:
         # Fetch all matching files (both original and duplicates) in a single batch query
         all_records = (
-            db.query(FileRecord).filter(FileRecord.filehash.in_(dup_hashes)).order_by(FileRecord.id.asc()).all()
+            apply_owner_filter(db.query(FileRecord), request)
+            .filter(FileRecord.filehash.in_(dup_hashes))
+            .order_by(FileRecord.id.asc())
+            .all()
         )
 
         # Group records by hash
@@ -165,14 +171,15 @@ def get_file_duplicates(
     }
     ```
     """
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    accessible_query = apply_owner_filter(db.query(FileRecord), request)
+    file_record = accessible_query.filter(FileRecord.id == file_id).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     # --- Exact duplicates ---
     # Case 1: This file is the original — find all records that are duplicates of it
     exact_duplicates_of_this = (
-        db.query(FileRecord)
+        apply_owner_filter(db.query(FileRecord), request)
         .filter(FileRecord.filehash == file_record.filehash, FileRecord.id != file_id)
         .order_by(FileRecord.id.asc())
         .all()
@@ -182,7 +189,7 @@ def get_file_duplicates(
     is_self_duplicate = file_record.is_duplicate
     duplicate_of_original: FileRecord | None = None
     if is_self_duplicate and file_record.duplicate_of_id:
-        duplicate_of_original = db.query(FileRecord).filter(FileRecord.id == file_record.duplicate_of_id).first()
+        duplicate_of_original = accessible_query.filter(FileRecord.id == file_record.duplicate_of_id).first()
 
     exact_duplicate_dicts = [_file_record_to_dict(f) for f in exact_duplicates_of_this]
 
@@ -196,11 +203,13 @@ def get_file_duplicates(
         try:
             from app.utils.similarity import find_similar_documents
 
+            accessible_ids = [row[0] for row in apply_owner_filter(db.query(FileRecord.id), request).all()]
             near_duplicates = find_similar_documents(
                 db,
                 file_id,
                 limit=near_duplicate_limit,
                 threshold=effective_threshold,
+                accessible_file_ids=accessible_ids,
             )
         except Exception as e:
             logger.warning(f"Near-duplicate detection failed for file {file_id}: {e}")

--- a/app/api/files.py
+++ b/app/api/files.py
@@ -23,7 +23,7 @@ from app.auth import require_login
 from app.config import settings
 from app.database import get_db
 from app.middleware.upload_rate_limit import require_upload_rate_limit
-from app.models import BulkOperation, FileProcessingStep, FileRecord, ProcessingLog
+from app.models import BulkOperation, FileProcessingStep, FileRecord, ProcessingLog, SharedLink
 from app.tasks.convert_to_pdf import convert_to_pdf
 from app.tasks.process_document import process_document
 from app.utils.allowed_types import ALLOWED_EXTENSIONS, ALLOWED_MIME_TYPES, IMAGE_MIME_TYPES
@@ -483,10 +483,27 @@ def set_file_privacy(request: Request, file_id: int, body: FilePrivacyRequest, d
             detail="Only the file owner can change privacy",
         )
 
+    revoked_links = 0
+    if body.is_private and not file_record.is_private:
+        revoked_at = datetime.now(timezone.utc)
+        revoked_links = (
+            db.query(SharedLink)
+            .filter(SharedLink.file_id == file_id, SharedLink.is_active.is_(True))
+            .update(
+                {SharedLink.is_active: False, SharedLink.revoked_at: revoked_at},
+                synchronize_session="fetch",
+            )
+        )
+
     file_record.is_private = body.is_private
     db.commit()
     db.refresh(file_record)
-    logger.info("File privacy changed: file_id=%s is_private=%s", file_id, body.is_private)
+    logger.info(
+        "File privacy changed: file_id=%s is_private=%s revoked_links=%s",
+        file_id,
+        body.is_private,
+        revoked_links,
+    )
     return {"file_id": file_record.id, "is_private": file_record.is_private}
 
 

--- a/app/api/files.py
+++ b/app/api/files.py
@@ -73,6 +73,12 @@ class BulkTagRequest(BaseModel):
     mode: Literal["add", "replace"] = "add"
 
 
+class FilePrivacyRequest(BaseModel):
+    """Owner-controlled document privacy state."""
+
+    is_private: bool
+
+
 def _bulk_action_status(
     action: str,
     updated_count: int,
@@ -362,6 +368,7 @@ def list_files_api(
                 "file_size": f.file_size,
                 "mime_type": f.mime_type,
                 "legal_hold": f.legal_hold,
+                "is_private": f.is_private,
                 "created_at": f.created_at.isoformat() if f.created_at else None,
                 "processing_status": statuses.get(
                     f.id,
@@ -453,12 +460,34 @@ def get_file_details(request: Request, file_id: int, db: DbSession):
             "file_size": file_record.file_size,
             "mime_type": file_record.mime_type,
             "legal_hold": file_record.legal_hold,
+            "is_private": file_record.is_private,
             "created_at": (file_record.created_at.isoformat() if file_record.created_at else None),
         },
         "processing_status": processing_status,
         "logs": log_list,
         "files_on_disk": files_on_disk,
     }
+
+
+@router.put("/files/{file_id}/privacy")
+@require_login
+def set_file_privacy(request: Request, file_id: int, body: FilePrivacyRequest, db: DbSession):
+    """Set the canonical privacy flag; only the document owner may do so."""
+    owner_id = get_current_owner_id(request)
+    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    if file_record is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+    if get_file_role(file_record, owner_id, db) != "owner":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the file owner can change privacy",
+        )
+
+    file_record.is_private = body.is_private
+    db.commit()
+    db.refresh(file_record)
+    logger.info("File privacy changed: file_id=%s is_private=%s", file_id, body.is_private)
+    return {"file_id": file_record.id, "is_private": file_record.is_private}
 
 
 @router.delete("/files/{file_id}")
@@ -1926,7 +1955,7 @@ def claim_file(request: Request, file_id: int, db: DbSession):
     if owner_id is None:
         raise HTTPException(status_code=401, detail="Authentication required to claim a document")
 
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
     if not file_record:
         raise HTTPException(status_code=404, detail=f"File record with ID {file_id} not found")
 
@@ -1963,7 +1992,7 @@ def bulk_claim_files(request: Request, file_ids: list[int], db: DbSession):
     if owner_id is None:
         raise HTTPException(status_code=401, detail="Authentication required to claim documents")
 
-    file_records = db.query(FileRecord).filter(FileRecord.id.in_(file_ids)).all()
+    file_records = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id.in_(file_ids)), request).all()
     if not file_records:
         raise HTTPException(status_code=404, detail="No files found with the provided IDs")
 
@@ -2018,14 +2047,14 @@ def assign_owner(request: Request, db: DbSession, owner_id: str = Query(...), fi
         # Assign to specific files
         updated = (
             db.query(FileRecord)
-            .filter(FileRecord.id.in_(file_ids))
+            .filter(FileRecord.id.in_(file_ids), FileRecord.is_private.is_(False))
             .update({FileRecord.owner_id: owner_id}, synchronize_session="fetch")
         )
     else:
         # Assign to all currently unowned documents
         updated = (
             db.query(FileRecord)
-            .filter(FileRecord.owner_id.is_(None))
+            .filter(FileRecord.owner_id.is_(None), FileRecord.is_private.is_(False))
             .update({FileRecord.owner_id: owner_id}, synchronize_session="fetch")
         )
 
@@ -2082,7 +2111,7 @@ def assign_pipeline_to_file(
 
     is_admin_user = bool(user and user.get("is_admin"))
 
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 

--- a/app/api/graphql_api.py
+++ b/app/api/graphql_api.py
@@ -16,6 +16,7 @@ from typing import Annotated, Any
 
 import strawberry
 from fastapi import Depends, Request
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 from strawberry.fastapi import GraphQLRouter
 
@@ -275,8 +276,10 @@ class Query:
             if not is_admin:
                 # Non-admins can only see their own documents
                 query = query.filter(FileRecord.owner_id == current_user_id)
-            elif owner_id:
-                query = query.filter(FileRecord.owner_id == owner_id)
+            else:
+                query = query.filter(or_(FileRecord.owner_id == current_user_id, FileRecord.is_private.is_(False)))
+                if owner_id:
+                    query = query.filter(FileRecord.owner_id == owner_id)
         elif owner_id:
             query = query.filter(FileRecord.owner_id == owner_id)
 
@@ -296,7 +299,7 @@ class Query:
         if settings.auth_enabled and user:
             is_admin = user.get("is_admin", False)
             current_user_id = _get_current_user_id(user)
-            if not is_admin and rec.owner_id != current_user_id:
+            if rec.owner_id != current_user_id and (not is_admin or rec.is_private):
                 return None
 
         return _document_from_record(rec)

--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -302,14 +302,20 @@ def _qdrant_authorization_scope(db: Session, request: Request) -> dict[str, Any]
         return {}
     user = get_current_user(request)
     if isinstance(user, dict) and user.get("is_admin"):
-        return {}
+        return {
+            "document_ids": [
+                row[0]
+                for row in apply_owner_filter(db.query(FileRecord.id), request).order_by(FileRecord.id.asc()).all()
+            ]
+        }
     owner_id = get_current_owner_id(request)
     if owner_id is None:
         return {"document_ids": []}
     shared_document_ids = [
         row[0]
         for row in db.query(FileShare.file_id)
-        .filter(FileShare.shared_with_user_id == owner_id)
+        .join(FileRecord, FileRecord.id == FileShare.file_id)
+        .filter(FileShare.shared_with_user_id == owner_id, FileRecord.is_private.is_(False))
         .order_by(FileShare.file_id.asc())
         .all()
     ]

--- a/app/api/logs.py
+++ b/app/api/logs.py
@@ -10,9 +10,11 @@ from sqlalchemy import desc
 from sqlalchemy.orm import Session
 
 from app.auth import require_login
+from app.config import settings
 from app.database import get_db
 from app.models import FileRecord, ProcessingLog
 from app.utils.input_validation import validate_task_id
+from app.utils.user_scope import apply_owner_filter
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -55,6 +57,9 @@ def list_processing_logs(
     ]
     """
     query = db.query(ProcessingLog)
+    if settings.multi_user_enabled:
+        accessible_ids = apply_owner_filter(db.query(FileRecord.id), request).subquery()
+        query = query.filter(ProcessingLog.file_id.in_(db.query(accessible_ids.c.id)))
 
     # Apply filters
     if file_id is not None:
@@ -93,7 +98,7 @@ def get_file_processing_logs(request: Request, file_id: int, db: DbSession):
     Also includes file metadata if the file exists.
     """
     # Check if file exists
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
     if not file_record:
         raise HTTPException(status_code=404, detail=f"File with ID {file_id} not found")
 
@@ -136,7 +141,11 @@ def get_task_processing_logs(request: Request, task_id: str, db: DbSession):
     """
     validate_task_id(task_id)
     # Get all logs for this task
-    logs = db.query(ProcessingLog).filter(ProcessingLog.task_id == task_id).order_by(ProcessingLog.timestamp).all()
+    query = db.query(ProcessingLog).filter(ProcessingLog.task_id == task_id)
+    if settings.multi_user_enabled:
+        accessible_ids = apply_owner_filter(db.query(FileRecord.id), request).subquery()
+        query = query.filter(ProcessingLog.file_id.in_(db.query(accessible_ids.c.id)))
+    logs = query.order_by(ProcessingLog.timestamp).all()
 
     if not logs:
         raise HTTPException(status_code=404, detail=f"No logs found for task {task_id}")

--- a/app/api/shared_links.py
+++ b/app/api/shared_links.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models import FileRecord, SharedLink
-from app.utils.user_scope import apply_owner_filter, get_current_owner_id
+from app.utils.user_scope import apply_owner_filter, get_current_owner_id, get_file_role
 
 logger = logging.getLogger(__name__)
 
@@ -269,6 +269,8 @@ async def create_shared_link(
     q = apply_owner_filter(q, request)
     file_record = q.first()
     if not file_record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+    if get_file_role(file_record, owner_id, db) != "owner":
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     token = _generate_token()

--- a/app/api/sharing.py
+++ b/app/api/sharing.py
@@ -128,6 +128,12 @@ def create_share(
 
     _require_owner(file_record, owner_id, db)
 
+    if file_record.is_private:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Private files are owner-only; make the file tribe-visible before sharing it with a user",
+        )
+
     if role not in FILE_SHARE_ROLES:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -336,7 +342,7 @@ def list_shared_with(request: Request, file_id: int, db: DbSession):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     role = get_file_role(file_record, user_id, db)
-    if role is None and not is_admin:
+    if role is None and not (is_admin and not file_record.is_private):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     shares = db.query(FileShare).filter(FileShare.file_id == file_id).all()

--- a/app/api/similarity.py
+++ b/app/api/similarity.py
@@ -16,6 +16,7 @@ from app.auth import require_login
 from app.config import settings
 from app.database import get_db
 from app.models import FileRecord
+from app.utils.user_scope import apply_owner_filter
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,8 @@ def get_similar_documents(
     ```
     """
     # Verify the file exists
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    accessible_query = apply_owner_filter(db.query(FileRecord), request)
+    file_record = accessible_query.filter(FileRecord.id == file_id).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
@@ -98,7 +100,14 @@ def get_similar_documents(
     try:
         from app.utils.similarity import find_similar_documents
 
-        similar = find_similar_documents(db, file_id, limit=limit, threshold=threshold)
+        accessible_ids = [row[0] for row in apply_owner_filter(db.query(FileRecord.id), request).all()]
+        similar = find_similar_documents(
+            db,
+            file_id,
+            limit=limit,
+            threshold=threshold,
+            accessible_file_ids=accessible_ids,
+        )
 
         return {
             "file_id": file_id,
@@ -142,7 +151,7 @@ def get_embedding_status(
     }
     ```
     """
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
@@ -190,7 +199,7 @@ def trigger_compute_embedding(
     }
     ```
     """
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
@@ -259,11 +268,14 @@ def get_embeddings_overview(
     """
     # Use column-only query to avoid loading full ORM objects into memory
     all_files = (
-        db.query(
-            FileRecord.id,
-            FileRecord.original_filename,
-            FileRecord.ocr_text,
-            FileRecord.embedding,
+        apply_owner_filter(
+            db.query(
+                FileRecord.id,
+                FileRecord.original_filename,
+                FileRecord.ocr_text,
+                FileRecord.embedding,
+            ),
+            request,
         )
         .order_by(FileRecord.id.desc())
         .all()
@@ -331,7 +343,7 @@ def trigger_compute_all_embeddings(
     ```
     """
     candidates = (
-        db.query(FileRecord)
+        apply_owner_filter(db.query(FileRecord), request)
         .filter(
             FileRecord.ocr_text.isnot(None),
             FileRecord.ocr_text != "",
@@ -397,13 +409,16 @@ def get_similarity_pairs(
 
     # Load all files that have embeddings (columns only for efficiency)
     rows = (
-        db.query(
-            FileRecord.id,
-            FileRecord.original_filename,
-            FileRecord.document_title,
-            FileRecord.mime_type,
-            FileRecord.created_at,
-            FileRecord.embedding,
+        apply_owner_filter(
+            db.query(
+                FileRecord.id,
+                FileRecord.original_filename,
+                FileRecord.document_title,
+                FileRecord.mime_type,
+                FileRecord.created_at,
+                FileRecord.embedding,
+            ),
+            request,
         )
         .filter(
             FileRecord.embedding.isnot(None),
@@ -446,7 +461,7 @@ def get_similarity_pairs(
     offset = (page - 1) * limit
     page_pairs = all_pairs[offset : offset + limit]
 
-    total_files = db.query(FileRecord).count()
+    total_files = apply_owner_filter(db.query(FileRecord), request).count()
 
     return {
         "pairs": page_pairs,

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -202,7 +202,7 @@ def trigger_pipeline_from_webhook(
     file_record = db.query(FileRecord).filter(FileRecord.id == body.file_id).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
-    if not is_admin and file_record.owner_id is not None and file_record.owner_id != owner_id:
+    if file_record.owner_id != owner_id and (not is_admin or file_record.is_private):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     pipeline = db.query(Pipeline).filter(Pipeline.id == pipeline_id).first()

--- a/app/models.py
+++ b/app/models.py
@@ -78,6 +78,11 @@ class FileRecord(Base):
     # Legal hold prevents destructive deletion while records are under review or retention.
     legal_hold = Column(Boolean, default=False, nullable=False, index=True)
 
+    # Owner-controlled privacy boundary.  False means the document may be
+    # visible to other authorised members of its tenant/tribe; True means
+    # only the document owner (or an explicit public share link) may read it.
+    is_private = Column(Boolean, default=False, server_default="0", nullable=False, index=True)
+
     # If this is a duplicate, record the ID of the original file for reference
     duplicate_of_id = Column(Integer, ForeignKey(_FILES_ID_FK), nullable=True)
 

--- a/app/utils/meilisearch_client.py
+++ b/app/utils/meilisearch_client.py
@@ -39,6 +39,7 @@ _INDEX_SETTINGS = {
         "file_id",
         "ocr_text_length",
         "confidence_score",
+        "is_private",
     ],
     "sortableAttributes": [
         "created_at_ts",
@@ -62,6 +63,7 @@ _INDEX_SETTINGS = {
         "created_at_ts",
         "ocr_text",
         "ocr_text_length",
+        "is_private",
     ],
     "rankingRules": [
         "words",
@@ -162,6 +164,7 @@ def _build_document(file_record: "FileRecord", text: str, metadata: dict) -> dic
         "created_at_ts": created_at_ts,
         "ocr_text": text or "",
         "ocr_text_length": len(text) if text else 0,
+        "is_private": bool(getattr(file_record, "is_private", False)),
     }
 
 

--- a/app/utils/similarity.py
+++ b/app/utils/similarity.py
@@ -250,6 +250,7 @@ def find_similar_documents(
     file_id: int,
     limit: int = 5,
     threshold: float = 0.3,
+    accessible_file_ids: list[int] | None = None,
 ) -> list[dict[str, Any]]:
     """Find documents similar to the given file using **pre-computed** embeddings.
 
@@ -293,22 +294,21 @@ def find_similar_documents(
     # Fetch only the columns needed for scoring to minimise memory use.
     # yield_per streams rows in chunks so we never materialise all 100k+
     # records at once.
-    candidates = (
-        db.query(
-            FileRecord.id,
-            FileRecord.original_filename,
-            FileRecord.document_title,
-            FileRecord.mime_type,
-            FileRecord.created_at,
-            FileRecord.embedding,
-        )
-        .filter(
-            FileRecord.id != file_id,
-            FileRecord.embedding.isnot(None),
-            FileRecord.embedding != "",
-        )
-        .yield_per(500)
+    candidates = db.query(
+        FileRecord.id,
+        FileRecord.original_filename,
+        FileRecord.document_title,
+        FileRecord.mime_type,
+        FileRecord.created_at,
+        FileRecord.embedding,
+    ).filter(
+        FileRecord.id != file_id,
+        FileRecord.embedding.isnot(None),
+        FileRecord.embedding != "",
     )
+    if accessible_file_ids is not None:
+        candidates = candidates.filter(FileRecord.id.in_(accessible_file_ids))
+    candidates = candidates.yield_per(500)
 
     results: list[dict[str, Any]] = []
     for row in candidates:

--- a/app/utils/user_scope.py
+++ b/app/utils/user_scope.py
@@ -10,7 +10,7 @@ documents are visible to all users (single-user / shared mode).
 import logging
 
 from fastapi import Request
-from sqlalchemy import or_
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Query, Session
 from sqlalchemy.sql import false
 
@@ -102,7 +102,8 @@ def apply_owner_filter(query: Query, request: Request) -> Query:
     When multi-user mode is enabled, only files whose ``owner_id``
     matches the authenticated user are returned, **plus** any files that
     have been explicitly shared with the user via ``FileShare``.  Admin
-    users bypass the filter and see all documents.
+    users may see non-private documents, but never another owner's private
+    documents.
 
     When ``unowned_docs_visible_to_all`` is ``True`` (default), documents
     with ``owner_id IS NULL`` (unclaimed) are also included for every
@@ -121,26 +122,33 @@ def apply_owner_filter(query: Query, request: Request) -> Query:
         return query
 
     user = request.session.get("user")
-    if isinstance(user, dict) and user.get("is_admin"):
-        # Admins see all documents in multi-user mode
-        return query
-
     owner_id = get_current_owner_id(request)
     if owner_id is None:
         # No authenticated user — return empty result set
         return query.filter(false())
 
-    # Build filter: user's own documents + documents shared with them
+    # A private document is owner-only.  This condition intentionally also
+    # applies to administrators: an operational role must not silently
+    # override a user's privacy choice.
+    if isinstance(user, dict) and user.get("is_admin"):
+        return query.filter(or_(FileRecord.owner_id == owner_id, FileRecord.is_private.is_(False)))
+
+    # Build filter: user's own documents + non-private documents shared with them
     conditions = [FileRecord.owner_id == owner_id]
 
     # Include files explicitly shared with this user
     from sqlalchemy import select as sa_select
 
-    conditions.append(FileRecord.id.in_(sa_select(FileShare.file_id).where(FileShare.shared_with_user_id == owner_id)))
+    conditions.append(
+        and_(
+            FileRecord.is_private.is_(False),
+            FileRecord.id.in_(sa_select(FileShare.file_id).where(FileShare.shared_with_user_id == owner_id)),
+        )
+    )
 
     # Optionally include unclaimed (owner_id IS NULL) documents
     if settings.unowned_docs_visible_to_all:
-        conditions.append(FileRecord.owner_id.is_(None))
+        conditions.append(and_(FileRecord.is_private.is_(False), FileRecord.owner_id.is_(None)))
 
     return query.filter(or_(*conditions))
 
@@ -177,6 +185,11 @@ def get_file_role(file_record: FileRecord, user_id: str | None, db: Session) -> 
     # Owner always has full access
     if file_record.owner_id == user_id:
         return "owner"
+
+    # Privacy is an owner-only boundary and wins over named shares and
+    # unclaimed-document discovery.
+    if file_record.is_private:
+        return None
 
     # Unclaimed document — limited access when setting allows it
     if file_record.owner_id is None and settings.unowned_docs_visible_to_all:

--- a/app/utils/vector_index.py
+++ b/app/utils/vector_index.py
@@ -185,7 +185,11 @@ class QdrantVectorIndex:
 
         # Qdrant needs payload indexes to evaluate tenant and document filters
         # before vector ranking without scanning the whole shared collection.
-        for field_name, field_schema in (("owner_id", "keyword"), ("document_id", "integer")):
+        for field_name, field_schema in (
+            ("owner_id", "keyword"),
+            ("document_id", "integer"),
+            ("is_private", "bool"),
+        ):
             self._request(
                 "PUT",
                 f"/collections/{self.collection}/index?wait=true",
@@ -213,7 +217,14 @@ class QdrantVectorIndex:
         if shared_document_ids:
             conditions.append({"key": "document_id", "match": {"any": shared_document_ids}})
         if include_unowned:
-            conditions.append(cls._owner_condition(None))
+            conditions.append(
+                {
+                    "must": [
+                        cls._owner_condition(None),
+                        {"key": "is_private", "match": {"value": False}},
+                    ]
+                }
+            )
         return {"should": conditions} if conditions else None
 
     def index_document(self, file_record: Any) -> int:
@@ -263,6 +274,7 @@ class QdrantVectorIndex:
                     "payload": {
                         "document_id": file_record.id,
                         "owner_id": file_record.owner_id,
+                        "is_private": bool(getattr(file_record, "is_private", False)),
                         "file_hash": file_record.filehash,
                         "content_hash": digest,
                         "index_version": index_version,

--- a/app/views/filemanager.py
+++ b/app/views/filemanager.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.models import FileRecord
+from app.utils.user_scope import apply_owner_filter
 from app.views.base import APIRouter, get_db, require_login, templates
 from app.views.settings import require_admin_access
 
@@ -56,17 +57,20 @@ def _safe_path(workdir: str, rel_path: str) -> Path:
     return target
 
 
-def _db_path_set(db: Session) -> Set[str]:
+def _db_path_set(db: Session, request: Request | None = None) -> Set[str]:
     """
     Return the set of all absolute, normalised paths that the DB references
     across local_filename, original_file_path, and processed_file_path.
     """
     paths: Set[str] = set()
-    for row in db.query(
+    query = db.query(
         FileRecord.local_filename,
         FileRecord.original_file_path,
         FileRecord.processed_file_path,
-    ).all():
+    )
+    if request is not None:
+        query = apply_owner_filter(query, request)
+    for row in query.all():
         for p in row:
             if p:
                 paths.add(str(Path(p).resolve()))
@@ -88,7 +92,12 @@ def _file_icon(mime_type: str, is_dir: bool) -> str:
     return "fas fa-file text-gray-400"
 
 
-def _scan_dir(target: Path, workdir_base: Path, db_paths: Set[str]) -> List[Dict[str, Any]]:
+def _scan_dir(
+    target: Path,
+    workdir_base: Path,
+    db_paths: Set[str],
+    hidden_paths: Set[str] | None = None,
+) -> List[Dict[str, Any]]:
     """
     List one directory level; annotate each file with its DB status.
 
@@ -98,6 +107,7 @@ def _scan_dir(target: Path, workdir_base: Path, db_paths: Set[str]) -> List[Dict
       ""        – directories (not checked against DB)
     """
     entries = []
+    hidden_paths = hidden_paths or set()
     for item in sorted(target.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
         try:
             stat = item.stat()
@@ -106,6 +116,8 @@ def _scan_dir(target: Path, workdir_base: Path, db_paths: Set[str]) -> List[Dict
             continue
 
         item_rel = str(item.relative_to(workdir_base))
+        if not item.is_dir() and str(item.resolve()) in hidden_paths:
+            continue
         mime_type, _ = mimetypes.guess_type(item.name)
         mime_type = mime_type or ""
 
@@ -132,14 +144,21 @@ def _scan_dir(target: Path, workdir_base: Path, db_paths: Set[str]) -> List[Dict
     return entries
 
 
-def _walk_all_files(base: Path, db_paths: Set[str]) -> List[Dict[str, Any]]:
+def _walk_all_files(
+    base: Path,
+    db_paths: Set[str],
+    hidden_paths: Set[str] | None = None,
+) -> List[Dict[str, Any]]:
     """
     Walk the entire workdir tree and return every file (not directory).
     Used for the reconciliation view.
     """
     entries = []
+    hidden_paths = hidden_paths or set()
     for item in sorted(base.rglob("*"), key=lambda p: str(p).lower()):
         if item.is_dir():
+            continue
+        if str(item.resolve()) in hidden_paths:
             continue
         try:
             stat = item.stat()
@@ -166,12 +185,15 @@ def _walk_all_files(base: Path, db_paths: Set[str]) -> List[Dict[str, Any]]:
     return entries
 
 
-def _db_records(db: Session, workdir_base: Path) -> List[Dict[str, Any]]:
+def _db_records(db: Session, workdir_base: Path, request: Request | None = None) -> List[Dict[str, Any]]:
     """
     Return every FileRecord annotated with on-disk existence for each stored path.
     """
     rows = []
-    for rec in db.query(FileRecord).order_by(FileRecord.id.desc()).all():
+    query = db.query(FileRecord)
+    if request is not None:
+        query = apply_owner_filter(query, request)
+    for rec in query.order_by(FileRecord.id.desc()).all():
 
         def _check(p: str | None) -> Dict[str, Any]:
             if not p:
@@ -229,7 +251,9 @@ async def filemanager(request: Request, db: Session = Depends(get_db)):
     view = request.query_params.get("view", "filesystem")
 
     # Build the DB path set once (used by all views)
-    db_paths = _db_path_set(db)
+    all_db_paths = _db_path_set(db)
+    db_paths = _db_path_set(db, request)
+    hidden_paths = all_db_paths - db_paths
 
     # ── Filesystem view ───────────────────────────────────────────────────
     rel_path = request.query_params.get("path", "").lstrip("/").lstrip(".")
@@ -246,7 +270,7 @@ async def filemanager(request: Request, db: Session = Depends(get_db)):
 
     fs_entries: List[Dict[str, Any]] = []
     if view == "filesystem" and target.is_dir():
-        fs_entries = _scan_dir(target, workdir_base, db_paths)
+        fs_entries = _scan_dir(target, workdir_base, db_paths, hidden_paths)
 
     # Breadcrumb for filesystem view
     breadcrumbs = []
@@ -264,13 +288,13 @@ async def filemanager(request: Request, db: Session = Depends(get_db)):
     # ── Database view ─────────────────────────────────────────────────────
     db_records: List[Dict[str, Any]] = []
     if view in ("database", "reconcile"):
-        db_records = _db_records(db, workdir_base)
+        db_records = _db_records(db, workdir_base, request)
 
     # ── Reconciliation view ───────────────────────────────────────────────
     orphan_files: List[Dict[str, Any]] = []
     ghost_records: List[Dict[str, Any]] = []
     if view == "reconcile":
-        all_disk = _walk_all_files(workdir_base, db_paths)
+        all_disk = _walk_all_files(workdir_base, db_paths, hidden_paths)
         orphan_files = [f for f in all_disk if f["db_status"] == "orphan"]
         ghost_records = [r for r in db_records if r["health"] == "missing"]
 
@@ -281,7 +305,7 @@ async def filemanager(request: Request, db: Session = Depends(get_db)):
         total_disk = sum(1 for p in workdir_base.rglob("*") if p.is_file())
     else:
         total_disk = None  # deferred; not shown on filesystem tab header
-    total_db = db.query(FileRecord).count()
+    total_db = apply_owner_filter(db.query(FileRecord), request).count()
 
     return templates.TemplateResponse(
         "filemanager.html",
@@ -311,7 +335,7 @@ async def filemanager(request: Request, db: Session = Depends(get_db)):
 @router.get("/admin/files/download")
 @require_login
 @require_admin_access
-async def filemanager_download(request: Request):
+async def filemanager_download(request: Request, db: Session = Depends(get_db)):
     """
     Admin-only endpoint to download a file from workdir.
     """
@@ -324,6 +348,10 @@ async def filemanager_download(request: Request):
         raise HTTPException(status_code=400, detail="Invalid path")
 
     if not target.exists() or not target.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    target_path = str(target.resolve())
+    if target_path in (_db_path_set(db) - _db_path_set(db, request)):
         raise HTTPException(status_code=404, detail="File not found")
 
     mime_type, _ = mimetypes.guess_type(target.name)

--- a/app/views/filemanager.py
+++ b/app/views/filemanager.py
@@ -77,6 +77,19 @@ def _db_path_set(db: Session, request: Request | None = None) -> Set[str]:
     return paths
 
 
+def _hidden_db_path_set(db: Session, request: Request) -> Set[str]:
+    """Return paths referenced by at least one document inaccessible to the caller."""
+    accessible_ids = {row[0] for row in apply_owner_filter(db.query(FileRecord.id), request).all()}
+    paths: Set[str] = set()
+    for record in db.query(FileRecord).all():
+        if record.id in accessible_ids:
+            continue
+        for path in (record.local_filename, record.original_file_path, record.processed_file_path):
+            if path:
+                paths.add(str(Path(path).resolve()))
+    return paths
+
+
 def _file_icon(mime_type: str, is_dir: bool) -> str:
     """Return a Font Awesome class for a file/directory."""
     if is_dir:
@@ -251,9 +264,8 @@ async def filemanager(request: Request, db: Session = Depends(get_db)):
     view = request.query_params.get("view", "filesystem")
 
     # Build the DB path set once (used by all views)
-    all_db_paths = _db_path_set(db)
     db_paths = _db_path_set(db, request)
-    hidden_paths = all_db_paths - db_paths
+    hidden_paths = _hidden_db_path_set(db, request)
 
     # ── Filesystem view ───────────────────────────────────────────────────
     rel_path = request.query_params.get("path", "").lstrip("/").lstrip(".")
@@ -351,7 +363,7 @@ async def filemanager_download(request: Request, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="File not found")
 
     target_path = str(target.resolve())
-    if target_path in (_db_path_set(db) - _db_path_set(db, request)):
+    if target_path in _hidden_db_path_set(db, request):
         raise HTTPException(status_code=404, detail="File not found")
 
     mime_type, _ = mimetypes.guess_type(target.name)

--- a/app/views/files.py
+++ b/app/views/files.py
@@ -20,6 +20,7 @@ from app.utils.pipeline_stages import (
     normalize_stage_name,
     stage_keys_for_pipeline_steps,
 )
+from app.utils.user_scope import apply_owner_filter
 from app.views.base import APIRouter, get_db, logger, require_login, templates
 
 router = APIRouter()
@@ -46,10 +47,9 @@ def _resolve_owner_context(request: Request, file_record, db: Session) -> dict:
     user_session = request.session.get("user")
     is_admin = isinstance(user_session, dict) and bool(user_session.get("is_admin"))
 
-    if is_admin:
-        current_user_role: str | None = "owner"
-    else:
-        current_user_role = get_file_role(file_record, current_owner_id, db)
+    current_user_role = get_file_role(file_record, current_owner_id, db)
+    if is_admin and current_user_role is None and not file_record.is_private:
+        current_user_role = "admin"
 
     # Build a human-readable owner label
     if file_record.owner_id:
@@ -95,7 +95,7 @@ def files_page(
         from app.models import FileProcessingStep, FileRecord
 
         # Start with base query
-        query = db.query(FileRecord)
+        query = apply_owner_filter(db.query(FileRecord), request)
 
         # Apply search filter
         if search:
@@ -262,7 +262,7 @@ def file_summary_page(request: Request, file_id: int, db: Session = Depends(get_
 
         from app.models import FileRecord
 
-        file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+        file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
 
         if not file_record:
             return templates.TemplateResponse(
@@ -346,7 +346,7 @@ def file_view_page(request: Request, file_id: int, db: Session = Depends(get_db)
 
         from app.models import FileRecord
 
-        file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+        file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
 
         if not file_record:
             return templates.TemplateResponse(
@@ -437,7 +437,7 @@ def file_detail_page(request: Request, file_id: int, db: Session = Depends(get_d
         from app.models import FileRecord, ProcessingLog
 
         # Find the file record
-        file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+        file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
 
         if not file_record:
             return templates.TemplateResponse(
@@ -522,7 +522,7 @@ def file_annotations_page(request: Request, file_id: int, db: Session = Depends(
 
         from app.models import FileRecord
 
-        file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+        file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
 
         if not file_record:
             return templates.TemplateResponse(
@@ -956,7 +956,7 @@ def preview_original_file(request: Request, file_id: int, db: Session = Depends(
 
     from app.models import FileRecord
 
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_FILE_NOT_FOUND)
 
@@ -983,7 +983,7 @@ def preview_processed_file(request: Request, file_id: int, db: Session = Depends
 
     from app.models import FileRecord
 
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_FILE_NOT_FOUND)
 
@@ -1010,7 +1010,7 @@ def get_original_text(request: Request, file_id: int, db: Session = Depends(get_
 
     from app.models import FileRecord
 
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_FILE_NOT_FOUND)
 
@@ -1050,7 +1050,7 @@ def get_processed_text(request: Request, file_id: int, db: Session = Depends(get
 
     from app.models import FileRecord
 
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_FILE_NOT_FOUND)
 
@@ -1086,7 +1086,7 @@ def get_default_language_text(request: Request, file_id: int, db: Session = Depe
 
     from app.models import FileRecord
 
-    file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
+    file_record = apply_owner_filter(db.query(FileRecord).filter(FileRecord.id == file_id), request).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_FILE_NOT_FOUND)
 
@@ -1123,7 +1123,9 @@ def duplicates_page(
 
     try:
         # Find hashes that have at least one is_duplicate=True record
-        dup_hashes_query = db.query(FileRecord.filehash).filter(FileRecord.is_duplicate.is_(True)).distinct()
+        dup_hashes_query = apply_owner_filter(
+            db.query(FileRecord.filehash).filter(FileRecord.is_duplicate.is_(True)), request
+        ).distinct()
         total_groups = dup_hashes_query.count()
 
         offset = (page - 1) * per_page
@@ -1134,13 +1136,13 @@ def duplicates_page(
 
         for filehash in dup_hashes:
             original = (
-                db.query(FileRecord)
+                apply_owner_filter(db.query(FileRecord), request)
                 .filter(FileRecord.filehash == filehash, FileRecord.is_duplicate.is_(False))
                 .order_by(FileRecord.id.asc())
                 .first()
             )
             duplicates = (
-                db.query(FileRecord)
+                apply_owner_filter(db.query(FileRecord), request)
                 .filter(FileRecord.filehash == filehash, FileRecord.is_duplicate.is_(True))
                 .order_by(FileRecord.id.asc())
                 .all()
@@ -1218,11 +1220,12 @@ def similarity_dashboard_page(
     from app.models import FileRecord
 
     try:
-        total_files = db.query(FileRecord).count()
-        files_with_embedding = (
-            db.query(FileRecord).filter(FileRecord.embedding.isnot(None), FileRecord.embedding != "").count()
-        )
-        files_with_ocr = db.query(FileRecord).filter(FileRecord.ocr_text.isnot(None), FileRecord.ocr_text != "").count()
+        accessible_files = apply_owner_filter(db.query(FileRecord), request)
+        total_files = accessible_files.count()
+        files_with_embedding = accessible_files.filter(
+            FileRecord.embedding.isnot(None), FileRecord.embedding != ""
+        ).count()
+        files_with_ocr = accessible_files.filter(FileRecord.ocr_text.isnot(None), FileRecord.ocr_text != "").count()
 
         return templates.TemplateResponse(
             "similarity_dashboard.html",

--- a/frontend/templates/file_view.html
+++ b/frontend/templates/file_view.html
@@ -320,6 +320,12 @@
           <span class="info-key">{{ _("file.owner_label") }}</span>
           <span class="info-val">{{ owner_display or _("file.owner_unowned") }}</span>
         </div>
+        <div class="info-row">
+          <span class="info-key">Sichtbarkeit</span>
+          <span class="info-val" id="privacy-state">
+            {% if file.is_private %}<i class="fas fa-lock" aria-hidden="true"></i> Privat{% else %}<i class="fas fa-users" aria-hidden="true"></i> Im Tribe sichtbar{% endif %}
+          </span>
+        </div>
         {% endif %}
       </div>
 
@@ -346,9 +352,17 @@
             <i class="fas fa-external-link-alt" aria-hidden="true"></i> Open original
           </a>
           {% endif %}
+          {% if current_user_role == "owner" %}
           <a href="/shared-links?file_id={{ file.id }}" class="action-btn btn-secondary">
             <i class="fas fa-share-alt" aria-hidden="true"></i> Share
           </a>
+          {% endif %}
+          {% if multi_user_enabled and current_user_role == "owner" %}
+          <button type="button" class="action-btn btn-secondary" id="privacy-toggle" onclick="setFilePrivacy({{ file.id }}, {{ 'false' if file.is_private else 'true' }})">
+            <i class="fas fa-{{ 'users' if file.is_private else 'lock' }}" aria-hidden="true"></i>
+            {{ 'Im Tribe sichtbar machen' if file.is_private else 'Als privat markieren' }}
+          </button>
+          {% endif %}
           {% if multi_user_enabled and file.owner_id is none %}
           <button
             class="action-btn btn-primary"
@@ -943,6 +957,27 @@
   }
 
   // ── Initialise on load ──
+  function setFilePrivacy(fileId, isPrivate) {
+    var button = document.getElementById('privacy-toggle');
+    if (button) button.disabled = true;
+    var csrfToken = document.querySelector('meta[name="csrf-token"]');
+    var headers = {'Content-Type': 'application/json'};
+    if (csrfToken && csrfToken.content) headers['X-CSRF-Token'] = csrfToken.content;
+    fetch('/api/files/' + fileId + '/privacy', {
+      method: 'PUT',
+      headers: headers,
+      body: JSON.stringify({is_private: isPrivate})
+    }).then(function(response) {
+      if (!response.ok) return response.json().then(function(data) { throw new Error(data.detail || 'Privacy update failed'); });
+      return response.json();
+    }).then(function() {
+      window.location.reload();
+    }).catch(function(error) {
+      if (button) button.disabled = false;
+      window.alert(error.message);
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', function() {
     {% if (processed_file_exists or original_file_exists) and file %}
       {% set pv = 'processed' if processed_file_exists else 'original' %}

--- a/frontend/templates/files.html
+++ b/frontend/templates/files.html
@@ -712,7 +712,12 @@
             <input type="checkbox" class="file-checkbox" value="{{ file.id }}" onchange="updateBulkActionsBar()">
           </td>
           <td>{{ file.id }}</td>
-          <td>{{ file.original_filename }}</td>
+          <td>
+            {{ file.original_filename }}
+            {% if file.is_private %}
+            <span title="Nur für den Dateiinhaber sichtbar" aria-label="Privates Dokument" style="margin-left:0.35rem;color:#7c3aed;"><i class="fas fa-lock" aria-hidden="true"></i></span>
+            {% endif %}
+          </td>
           <td>{{ (file.file_size / 1024) | round(2) }} KB</td>
           <td>{{ file.mime_type }}</td>
           <td>
@@ -757,7 +762,10 @@
     >
       <div class="flex items-start justify-between gap-2">
         <div class="flex-1 min-w-0">
-          <p class="font-semibold text-gray-800 truncate">{{ file.original_filename }}</p>
+          <p class="font-semibold text-gray-800 truncate">
+            {{ file.original_filename }}
+            {% if file.is_private %}<i class="fas fa-lock" aria-label="Privates Dokument" title="Nur für den Dateiinhaber sichtbar" style="color:#7c3aed;margin-left:0.25rem;"></i>{% endif %}
+          </p>
           <p class="text-xs text-gray-500 mt-1">ID: {{ file.id }} &middot; {{ (file.file_size / 1024) | round(2) }} KB</p>
           <p class="text-xs text-gray-500 mt-0.5">{{ file.mime_type }}</p>
           <p class="text-xs text-gray-400 mt-0.5">{{ file.created_at.strftime('%Y-%m-%d %H:%M') if file.created_at else _('common.not_available') }}</p>

--- a/migrations/versions/058_add_file_private_flag.py
+++ b/migrations/versions/058_add_file_private_flag.py
@@ -1,0 +1,38 @@
+"""Add owner-controlled document privacy.
+
+Revision ID: 058_add_file_private_flag
+Revises: 057_knowledge_research_jobs
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "058_add_file_private_flag"
+down_revision: Union[str, None] = "057_knowledge_research_jobs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    columns = {column["name"] for column in inspector.get_columns("files")}
+    indexes = {index["name"] for index in inspector.get_indexes("files")}
+    if "is_private" not in columns:
+        op.add_column(
+            "files",
+            sa.Column("is_private", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+    if "ix_files_is_private" not in indexes:
+        op.create_index("ix_files_is_private", "files", ["is_private"])
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    indexes = {index["name"] for index in inspector.get_indexes("files")}
+    columns = {column["name"] for column in inspector.get_columns("files")}
+    if "ix_files_is_private" in indexes:
+        op.drop_index("ix_files_is_private", table_name="files")
+    if "is_private" in columns:
+        op.drop_column("files", "is_private")

--- a/tests/test_file_privacy.py
+++ b/tests/test_file_privacy.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from app.models import FileRecord
+from app.models import FileRecord, SharedLink
 
 
 def _file(db_session, owner_id="alice") -> FileRecord:
@@ -25,6 +25,9 @@ def _file(db_session, owner_id="alice") -> FileRecord:
 @pytest.mark.unit
 def test_owner_can_set_and_clear_private_flag(client, db_session):
     record = _file(db_session)
+    link = SharedLink(token="privacy-public-link", file_id=record.id, owner_id="alice", is_active=True)
+    db_session.add(link)
+    db_session.commit()
     with (
         patch("app.api.files.get_current_owner_id", return_value="alice"),
         patch("app.utils.user_scope.settings.multi_user_enabled", True),
@@ -33,12 +36,17 @@ def test_owner_can_set_and_clear_private_flag(client, db_session):
         assert response.status_code == 200
         assert response.json() == {"file_id": record.id, "is_private": True}
         db_session.refresh(record)
+        db_session.refresh(link)
         assert record.is_private is True
+        assert link.is_active is False
+        assert link.revoked_at is not None
 
         response = client.put(f"/api/files/{record.id}/privacy", json={"is_private": False})
         assert response.status_code == 200
         db_session.refresh(record)
+        db_session.refresh(link)
         assert record.is_private is False
+        assert link.is_active is False
 
 
 @pytest.mark.unit

--- a/tests/test_file_privacy.py
+++ b/tests/test_file_privacy.py
@@ -1,0 +1,54 @@
+"""Owner-controlled file privacy API tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.models import FileRecord
+
+
+def _file(db_session, owner_id="alice") -> FileRecord:
+    record = FileRecord(
+        owner_id=owner_id,
+        filehash="privacy-hash",
+        original_filename="privacy.pdf",
+        local_filename="/tmp/privacy.pdf",
+        file_size=123,
+        mime_type="application/pdf",
+    )
+    db_session.add(record)
+    db_session.commit()
+    db_session.refresh(record)
+    return record
+
+
+@pytest.mark.unit
+def test_owner_can_set_and_clear_private_flag(client, db_session):
+    record = _file(db_session)
+    with (
+        patch("app.api.files.get_current_owner_id", return_value="alice"),
+        patch("app.utils.user_scope.settings.multi_user_enabled", True),
+    ):
+        response = client.put(f"/api/files/{record.id}/privacy", json={"is_private": True})
+        assert response.status_code == 200
+        assert response.json() == {"file_id": record.id, "is_private": True}
+        db_session.refresh(record)
+        assert record.is_private is True
+
+        response = client.put(f"/api/files/{record.id}/privacy", json={"is_private": False})
+        assert response.status_code == 200
+        db_session.refresh(record)
+        assert record.is_private is False
+
+
+@pytest.mark.unit
+def test_admin_cannot_change_another_owners_private_flag(client, db_session):
+    record = _file(db_session)
+    with (
+        patch("app.api.files.get_current_owner_id", return_value="admin"),
+        patch("app.utils.user_scope.settings.multi_user_enabled", True),
+    ):
+        response = client.put(f"/api/files/{record.id}/privacy", json={"is_private": True})
+    assert response.status_code == 403
+    db_session.refresh(record)
+    assert record.is_private is False

--- a/tests/test_multi_user.py
+++ b/tests/test_multi_user.py
@@ -47,7 +47,7 @@ def mu_session(mu_engine):
     session.close()
 
 
-def _create_file_record(session, owner_id=None, filename="test.pdf"):
+def _create_file_record(session, owner_id=None, filename="test.pdf", is_private=False):
     """Helper to insert a minimal FileRecord."""
     rec = FileRecord(
         filehash="abc123",
@@ -57,6 +57,7 @@ def _create_file_record(session, owner_id=None, filename="test.pdf"):
         mime_type="application/pdf",
         is_duplicate=False,
         owner_id=owner_id,
+        is_private=is_private,
     )
     session.add(rec)
     session.commit()
@@ -89,6 +90,11 @@ class TestFileRecordOwnerField:
         """FileRecord created without owner_id should have None."""
         rec = _create_file_record(mu_session)
         assert rec.owner_id is None
+
+    @pytest.mark.unit
+    def test_private_defaults_to_false(self, mu_session):
+        rec = _create_file_record(mu_session)
+        assert rec.is_private is False
 
     @pytest.mark.unit
     def test_owner_id_stores_value(self, mu_session):
@@ -341,11 +347,12 @@ class TestApplyOwnerFilter:
 
     @pytest.mark.unit
     def test_admin_sees_all_when_enabled(self, mu_session):
-        """Admin users bypass the owner filter in multi-user mode."""
+        """Admins see non-private files but cannot override owner privacy."""
         from app.utils.user_scope import apply_owner_filter
 
         _create_file_record(mu_session, owner_id="alice")
         _create_file_record(mu_session, owner_id="bob")
+        _create_file_record(mu_session, owner_id="bob", filename="private.pdf", is_private=True)
         _create_file_record(mu_session, owner_id=None)
 
         request = _mock_request(user={"preferred_username": "admin", "is_admin": True})
@@ -355,6 +362,19 @@ class TestApplyOwnerFilter:
             filtered = apply_owner_filter(query, request)
 
         assert filtered.count() == 3
+
+    @pytest.mark.unit
+    def test_private_file_is_hidden_from_named_share(self, mu_session):
+        from app.models import FileShare
+        from app.utils.user_scope import apply_owner_filter
+
+        private_file = _create_file_record(mu_session, owner_id="alice", is_private=True)
+        mu_session.add(FileShare(file_id=private_file.id, owner_id="alice", shared_with_user_id="bob", role="viewer"))
+        mu_session.commit()
+
+        request = _mock_request(user={"preferred_username": "bob"})
+        with _patch_multi_user(True), patch.object(settings, "unowned_docs_visible_to_all", False):
+            assert apply_owner_filter(mu_session.query(FileRecord), request).all() == []
 
     @pytest.mark.unit
     def test_unauthenticated_sees_nothing_when_enabled(self, mu_session):

--- a/tests/test_shared_links.py
+++ b/tests/test_shared_links.py
@@ -46,7 +46,13 @@ def sl_session(sl_engine):
     session.close()
 
 
-def _make_file(session, owner_id: str = _OWNER, filename: str = "test.pdf") -> FileRecord:
+def _make_file(
+    session,
+    owner_id: str = _OWNER,
+    filename: str = "test.pdf",
+    *,
+    is_private: bool = False,
+) -> FileRecord:
     """Insert a minimal FileRecord and return it."""
     record = FileRecord(
         owner_id=owner_id,
@@ -55,6 +61,7 @@ def _make_file(session, owner_id: str = _OWNER, filename: str = "test.pdf") -> F
         local_filename="/tmp/test.pdf",
         file_size=1024,
         mime_type="application/pdf",
+        is_private=is_private,
     )
     session.add(record)
     session.commit()
@@ -116,6 +123,20 @@ class TestCreateSharedLink:
             assert data["is_active"] is True
             assert data["has_password"] is False
             assert data["expires_at"] is None
+        finally:
+            _cleanup(app)
+
+    @pytest.mark.unit
+    def test_owner_can_explicitly_create_link_after_file_is_private(self, sl_engine, sl_session):
+        """A new link on a private file is a separate explicit owner action."""
+        from app.main import app
+
+        file_record = _make_file(sl_session, is_private=True)
+        client = _make_client(sl_engine)
+        try:
+            resp = client.post("/api/shared-links/", json={"file_id": file_record.id})
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["is_active"] is True
         finally:
             _cleanup(app)
 

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -96,6 +96,18 @@ class TestGetFileRole:
         db_session.commit()
         assert get_file_role(f, "carol", db_session) == FILE_SHARE_ROLE_EDITOR
 
+    def test_private_file_ignores_named_share(self, db_session, monkeypatch):
+        from app.config import settings as real_settings
+        from app.utils.user_scope import get_file_role
+
+        monkeypatch.setattr(real_settings, "multi_user_enabled", True)
+        f = _create_file(db_session, owner_id="alice")
+        f.is_private = True
+        db_session.add(FileShare(file_id=f.id, owner_id="alice", shared_with_user_id="bob", role="viewer"))
+        db_session.commit()
+        assert get_file_role(f, "alice", db_session) == "owner"
+        assert get_file_role(f, "bob", db_session) is None
+
     def test_unowned_file_returns_viewer_when_setting_allows(self, db_session, monkeypatch):
         from app.utils import user_scope
 
@@ -252,6 +264,20 @@ class TestCreateShare:
         assert data["shared_with_user_id"] == "bob"
         assert data["role"] == "viewer"
         assert data["file_id"] == f.id
+
+    def test_private_file_cannot_create_named_share(self, client, db_session, monkeypatch):
+        from app.config import settings as real_settings
+
+        monkeypatch.setattr(real_settings, "multi_user_enabled", False)
+        f = _create_file(db_session, owner_id="alice")
+        f.is_private = True
+        db_session.commit()
+
+        response = client.post(
+            f"/api/files/{f.id}/shares",
+            json={"shared_with_user_id": "bob", "role": "viewer"},
+        )
+        assert response.status_code == 409
 
     def test_owner_can_share_with_editor(self, client, db_session, monkeypatch):
         import app.api.sharing as sharing_mod

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -226,6 +226,7 @@ def test_qdrant_collection_creation_and_dimension_guard():
             SimpleNamespace(status_code=201),
             SimpleNamespace(status_code=200),
             SimpleNamespace(status_code=200),
+            SimpleNamespace(status_code=200),
         ],
     ) as request:
         QdrantVectorIndex().ensure_collection(1536)
@@ -247,6 +248,12 @@ def test_qdrant_collection_creation_and_dimension_guard():
             "PUT",
             "/collections/docuelevate_documents/index?wait=true",
             {"field_name": "document_id", "field_schema": "integer"},
+            expected=(200, 201),
+        ),
+        call(
+            "PUT",
+            "/collections/docuelevate_documents/index?wait=true",
+            {"field_name": "is_private", "field_schema": "bool"},
             expected=(200, 201),
         ),
     ]
@@ -307,7 +314,12 @@ def test_qdrant_search_filters_owner_shares_and_unowned_before_ranking():
         "should": [
             {"key": "owner_id", "match": {"value": "alice@example.com"}},
             {"key": "document_id", "match": {"any": [8, 9]}},
-            {"is_null": {"key": "owner_id"}},
+            {
+                "must": [
+                    {"is_null": {"key": "owner_id"}},
+                    {"key": "is_private", "match": {"value": False}},
+                ]
+            },
         ]
     }
 

--- a/tests/test_views_filemanager.py
+++ b/tests/test_views_filemanager.py
@@ -576,7 +576,16 @@ class TestFilemanagerDownloadRoute:
             mime_type="text/plain",
             is_private=True,
         )
-        db_session.add(record)
+        accessible_alias = FileRecord(
+            owner_id="admin",
+            filehash="private-filemanager-download-alias",
+            original_filename="shared-alias.txt",
+            local_filename=str(test_file),
+            file_size=test_file.stat().st_size,
+            mime_type="text/plain",
+            is_private=False,
+        )
+        db_session.add_all([record, accessible_alias])
         db_session.commit()
         client.cookies.set("session", _make_admin_session_cookie())
         try:

--- a/tests/test_views_filemanager.py
+++ b/tests/test_views_filemanager.py
@@ -472,6 +472,27 @@ class TestFilemanagerRoute:
         response = client.get("/admin/files?view=database", follow_redirects=False)
         assert response.status_code == 200
 
+    def test_database_view_hides_another_owners_private_file(self, client, db_session):
+        """Admin file-manager listings must respect owner privacy."""
+        record = FileRecord(
+            owner_id="alice@example.com",
+            filehash="private-filemanager-listing",
+            original_filename="private-filemanager.pdf",
+            local_filename="/tmp/private-filemanager.pdf",
+            file_size=12,
+            mime_type="application/pdf",
+            is_private=True,
+        )
+        db_session.add(record)
+        db_session.commit()
+        client.cookies.set("session", _make_admin_session_cookie())
+
+        with patch("app.utils.user_scope.settings.multi_user_enabled", True):
+            response = client.get("/admin/files?view=database", follow_redirects=False)
+
+        assert response.status_code == 200
+        assert b"private-filemanager.pdf" not in response.content
+
     def test_reconcile_view_with_admin_session(self, client):
         """Test reconcile view with admin session."""
         client.cookies.set("session", _make_admin_session_cookie())
@@ -538,6 +559,33 @@ class TestFilemanagerDownloadRoute:
         try:
             response = client.get("/admin/files/download?path=test_download_xyz.txt", follow_redirects=False)
             assert response.status_code == 200
+        finally:
+            test_file.unlink(missing_ok=True)
+
+    def test_download_hides_another_owners_private_file(self, client, db_session):
+        """The raw workdir download route cannot bypass a private file flag."""
+        workdir = Path(os.environ.get("WORKDIR", "/tmp"))
+        test_file = workdir / "private-filemanager-download.txt"
+        test_file.write_text("private content")
+        record = FileRecord(
+            owner_id="alice@example.com",
+            filehash="private-filemanager-download",
+            original_filename=test_file.name,
+            local_filename=str(test_file),
+            file_size=test_file.stat().st_size,
+            mime_type="text/plain",
+            is_private=True,
+        )
+        db_session.add(record)
+        db_session.commit()
+        client.cookies.set("session", _make_admin_session_cookie())
+        try:
+            with patch("app.utils.user_scope.settings.multi_user_enabled", True):
+                response = client.get(
+                    f"/admin/files/download?path={test_file.name}",
+                    follow_redirects=False,
+                )
+            assert response.status_code == 404
         finally:
             test_file.unlink(missing_ok=True)
 
@@ -749,7 +797,9 @@ class TestFilemanagerDownloadUnit:
             mock_settings.workdir = str(tmp_path)
             mock_request = MagicMock()
             mock_request.query_params.get = MagicMock(return_value="download_me.pdf")
+            mock_db = MagicMock()
+            mock_db.query.return_value.all.return_value = []
 
-            result = await filemanager_download(mock_request)
+            result = await filemanager_download(mock_request, mock_db)
             assert isinstance(result, FileResponse)
             assert result.filename == "download_me.pdf"

--- a/tests/test_views_files_comprehensive.py
+++ b/tests/test_views_files_comprehensive.py
@@ -5,6 +5,7 @@ Tests all view endpoints with success and error cases, proper mocking, and edge 
 Target: Bring coverage from 8.77% to 70%+
 """
 
+import base64
 import json
 import uuid
 from datetime import datetime, timedelta
@@ -12,8 +13,19 @@ from unittest.mock import Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from itsdangerous import TimestampSigner
 
 from app.models import FileProcessingStep, FileRecord, ProcessingLog
+
+TEST_SESSION_SECRET = "test_secret_key_for_testing_must_be_at_least_32_characters_long"
+
+
+def _make_user_session_cookie(user_id: str) -> str:
+    """Create a signed browser session for an ordinary document owner."""
+    session_data = {"user": {"id": user_id, "is_admin": False}}
+    signer = TimestampSigner(TEST_SESSION_SECRET)
+    data = base64.b64encode(json.dumps(session_data).encode()).decode("utf-8")
+    return signer.sign(data).decode("utf-8")
 
 
 @pytest.mark.unit
@@ -2092,11 +2104,16 @@ class TestOwnerDisplayAndClaim:
         db_session.refresh(file_rec)
         return file_rec
 
+    @staticmethod
+    def _authenticate(client: TestClient, user_id: str) -> None:
+        client.cookies.set("session", _make_user_session_cookie(user_id))
+
     # ── /files/{id} (file_summary.html) ──────────────────────────────────
 
     def test_summary_shows_owner_when_multi_user_enabled(self, client, db_session):
         """Owner ID is rendered in file summary when multi-user mode is on."""
         file_rec = self._make_file(db_session, owner_id="alice@example.com")
+        self._authenticate(client, "alice@example.com")
         with patch("app.config.settings.multi_user_enabled", True):
             response = client.get(f"/files/{file_rec.id}")
         assert response.status_code == 200
@@ -2105,6 +2122,7 @@ class TestOwnerDisplayAndClaim:
     def test_summary_shows_unowned_label_for_unowned_file(self, client, db_session):
         """'Unowned' label is rendered in file summary for files without an owner."""
         file_rec = self._make_file(db_session, owner_id=None)
+        self._authenticate(client, "viewer@example.com")
         with patch("app.config.settings.multi_user_enabled", True):
             response = client.get(f"/files/{file_rec.id}")
         assert response.status_code == 200
@@ -2113,6 +2131,7 @@ class TestOwnerDisplayAndClaim:
     def test_summary_shows_claim_button_for_unowned_file(self, client, db_session):
         """Claim Ownership button appears on file summary for an unowned file."""
         file_rec = self._make_file(db_session, owner_id=None)
+        self._authenticate(client, "viewer@example.com")
         with patch("app.config.settings.multi_user_enabled", True):
             response = client.get(f"/files/{file_rec.id}")
         assert response.status_code == 200
@@ -2121,6 +2140,7 @@ class TestOwnerDisplayAndClaim:
     def test_summary_no_claim_button_when_owned(self, client, db_session):
         """No Claim Ownership button when the file already has an owner."""
         file_rec = self._make_file(db_session, owner_id="bob@example.com")
+        self._authenticate(client, "bob@example.com")
         with patch("app.config.settings.multi_user_enabled", True):
             response = client.get(f"/files/{file_rec.id}")
         assert response.status_code == 200
@@ -2140,6 +2160,7 @@ class TestOwnerDisplayAndClaim:
     def test_detail_shows_owner_when_multi_user_enabled(self, client, db_session):
         """Owner ID is rendered in file detail view when multi-user mode is on."""
         file_rec = self._make_file(db_session, owner_id="charlie@example.com")
+        self._authenticate(client, "charlie@example.com")
         with patch("app.config.settings.multi_user_enabled", True):
             response = client.get(f"/files/{file_rec.id}/detail")
         assert response.status_code == 200
@@ -2148,6 +2169,7 @@ class TestOwnerDisplayAndClaim:
     def test_detail_shows_claim_button_for_unowned_file(self, client, db_session):
         """Claim Ownership button appears in file detail view for an unowned file."""
         file_rec = self._make_file(db_session, owner_id=None)
+        self._authenticate(client, "viewer@example.com")
         with patch("app.config.settings.multi_user_enabled", True):
             response = client.get(f"/files/{file_rec.id}/detail")
         assert response.status_code == 200
@@ -2158,6 +2180,7 @@ class TestOwnerDisplayAndClaim:
     def test_annotations_shows_owner_info(self, client, db_session):
         """Owner info is rendered on the annotations page in multi-user mode."""
         file_rec = self._make_file(db_session, owner_id="dave@example.com")
+        self._authenticate(client, "dave@example.com")
         with patch("app.config.settings.multi_user_enabled", True):
             response = client.get(f"/files/{file_rec.id}/annotations")
         assert response.status_code == 200
@@ -2166,6 +2189,7 @@ class TestOwnerDisplayAndClaim:
     def test_annotations_shows_claim_button_for_unowned_file(self, client, db_session):
         """Claim Ownership button appears on annotations page for unowned file."""
         file_rec = self._make_file(db_session, owner_id=None)
+        self._authenticate(client, "viewer@example.com")
         with patch("app.config.settings.multi_user_enabled", True):
             response = client.get(f"/files/{file_rec.id}/annotations")
         assert response.status_code == 200
@@ -2174,6 +2198,7 @@ class TestOwnerDisplayAndClaim:
     def test_annotations_no_claim_button_when_owned(self, client, db_session):
         """No Claim Ownership button on annotations page when file has an owner."""
         file_rec = self._make_file(db_session, owner_id="eve@example.com")
+        self._authenticate(client, "eve@example.com")
         with patch("app.config.settings.multi_user_enabled", True):
             response = client.get(f"/files/{file_rec.id}/annotations")
         assert response.status_code == 200
@@ -2187,6 +2212,8 @@ class TestOwnerDisplayAndClaim:
         profile = UserProfile(user_id="frank@example.com", display_name="Frank Lastname")
         db_session.add(profile)
         db_session.commit()
+
+        self._authenticate(client, "frank@example.com")
 
         with patch("app.config.settings.multi_user_enabled", True):
             response = client.get(f"/files/{file_rec.id}")


### PR DESCRIPTION
## What changed

- add a canonical `files.is_private` flag and Alembic migration
- let only the document owner change privacy from the file UI or API
- make private documents owner-only across file views, API, comments, annotations, sharing, GraphQL, duplicate/similarity views, webhooks, Meilisearch and Qdrant retrieval
- suspend named-user shares while a file is private
- revoke all active public links when a document transitions to private; the owner may create a new link afterward as a separate explicit action
- add fail-closed Qdrant filtering and a payload index for the privacy flag\n- enforce the same owner privacy boundary in the admin database, reconciliation and raw-workdir download surfaces

## Why

Personal documents should be visible within the future tribe by default, while the file owner needs an enforceable privacy boundary that tribe or operational admins cannot override through ordinary product interfaces. Previously, several server-rendered and specialist endpoints did not consistently apply the central owner filter.

This provides the privacy-flag foundation for #1147. Classification rules and tribe management remain separate follow-up work.

## Validation

- Ruff check and format check passed
- Alembic reports `058_add_file_private_flag` as the single head
- 738 relevant API, database, migration, sharing, retrieval, webhook and UI tests passed; 2 skipped
- 149 directly affected privacy, sharing and vector-retrieval tests passed after the Qdrant filter update
- 147 privacy, sharing and public-link tests passed after automatic link revocation was added
- 38 focused privacy/public-link tests passed after the final explicit-link scenario was added

## Deployment

No environment has been deployed or changed by this PR. Production remains untouched.