### PR TITLE
Expose document privacy in single-user mode

### DIFF
--- a/frontend/templates/file_view.html
+++ b/frontend/templates/file_view.html
@@ -320,13 +320,13 @@
           <span class="info-key">{{ _("file.owner_label") }}</span>
           <span class="info-val">{{ owner_display or _("file.owner_unowned") }}</span>
         </div>
+        {% endif %}
         <div class="info-row">
           <span class="info-key">Sichtbarkeit</span>
           <span class="info-val" id="privacy-state">
             {% if file.is_private %}<i class="fas fa-lock" aria-hidden="true"></i> Privat{% else %}<i class="fas fa-users" aria-hidden="true"></i> Im Tribe sichtbar{% endif %}
           </span>
         </div>
-        {% endif %}
       </div>
 
       <!-- Actions -->
@@ -357,7 +357,7 @@
             <i class="fas fa-share-alt" aria-hidden="true"></i> Share
           </a>
           {% endif %}
-          {% if multi_user_enabled and current_user_role == "owner" %}
+          {% if current_user_role == "owner" %}
           <button type="button" class="action-btn btn-secondary" id="privacy-toggle" onclick="setFilePrivacy({{ file.id }}, {{ 'false' if file.is_private else 'true' }})">
             <i class="fas fa-{{ 'users' if file.is_private else 'lock' }}" aria-hidden="true"></i>
             {{ 'Im Tribe sichtbar machen' if file.is_private else 'Als privat markieren' }}

--- a/tests/test_views_files_comprehensive.py
+++ b/tests/test_views_files_comprehensive.py
@@ -2175,6 +2175,16 @@ class TestOwnerDisplayAndClaim:
         assert response.status_code == 200
         assert b"Claim Ownership" in response.content
 
+    def test_detail_shows_privacy_control_in_single_user_mode(self, client, db_session):
+        """The canonical privacy flag remains editable before multi-user activation."""
+        file_rec = self._make_file(db_session, owner_id=None)
+        with patch("app.config.settings.multi_user_enabled", False):
+            response = client.get(f"/files/{file_rec.id}/detail")
+        assert response.status_code == 200
+        assert b'id="privacy-state"' in response.content
+        assert b'id="privacy-toggle"' in response.content
+        assert b"Als privat markieren" in response.content
+
     # ── /files/{id}/annotations (file_annotations.html) ──────────────────
 
     def test_annotations_shows_owner_info(self, client, db_session):


### PR DESCRIPTION
## What
- keep the canonical file visibility state visible in every deployment mode
- allow the effective file owner to toggle `is_private` before multi-user/Tribe mode is enabled
- keep owner identity and claim controls gated to multi-user mode
- add a regression test for the single-user detail page

## Why
Chrome acceptance on preprod found that the new privacy flag was correctly deployed but its UI was hidden because preprod currently runs in single-user mode. The flag must remain an editable file property so existing installations can classify documents before enabling Tribe isolation.

## Validation
- `git diff --check` passed locally
- full pytest, Ruff, template accessibility, type and migration validation run in CI

Follow-up to #1147 and #1148.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Privacy controls are now visible to owners even when multi-user mode is disabled.
  * Owners can access the privacy toggle and related sharing controls in single-user mode.

* **Tests**
  * Added coverage to verify that privacy controls render correctly in single-user mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->