### PR TITLE
fix: isolate Celery database pools after prefork

### DIFF
--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -4,7 +4,13 @@ import logging
 import os
 
 from celery import Celery
-from celery.signals import after_setup_logger, after_setup_task_logger, task_failure, worker_ready
+from celery.signals import (
+    after_setup_logger,
+    after_setup_task_logger,
+    task_failure,
+    worker_process_init,
+    worker_ready,
+)
 
 from app.config import settings
 from app.utils.log_safety import restrict_sensitive_provider_logging
@@ -42,6 +48,24 @@ celery.conf.task_routes = {
     "app.tasks.batch_tasks.sync_search_index": {"queue": "search_index"},
     "app.tasks.*": {"queue": "document_processor"},
 }
+
+
+@worker_process_init.connect
+def reset_database_pool_after_fork(**kwargs):
+    """Discard database connections inherited by a prefork worker child.
+
+    ``celery_worker`` reads database-backed schedules while the worker parent is
+    starting.  A prefork child must never reuse a DBAPI connection opened by
+    that parent (or by a sibling), because concurrent use corrupts the wire
+    protocol and can make an otherwise empty fresh installation hang.
+
+    ``close=False`` replaces the child's pool without closing descriptors that
+    still belong to the parent process.
+    """
+    from app.database import engine
+
+    engine.dispose(close=False)
+
 
 # Mapping of document pipeline task names to the positional index of ``file_id``
 # in their ``args`` tuple.  These indices correspond to the task signatures:

--- a/tests/test_celery_app.py
+++ b/tests/test_celery_app.py
@@ -62,6 +62,15 @@ class TestCeleryAppConfig:
             "priority_steps": list(range(10)),
         }
 
+    @patch("app.database.engine.dispose")
+    def test_prefork_child_replaces_inherited_database_pool(self, mock_dispose):
+        """A child process must not reuse a DB connection opened by its parent."""
+        from app.celery_app import reset_database_pool_after_fork
+
+        reset_database_pool_after_fork()
+
+        mock_dispose.assert_called_once_with(close=False)
+
 
 @pytest.mark.unit
 class TestTaskFailureHandler:


### PR DESCRIPTION
## What changed

- dispose the inherited SQLAlchemy pool in every Celery prefork child
- preserve the parent-owned descriptors with `close=False`
- add a focused regression test for the child-process signal handler

## Why

A truly empty Docker canary exposed a one-minute `monitor_stalled_steps` hang and psycopg protocol corruption (`unexpected result EMPTY_QUERY` / SQLAlchemy `NotImplementedError`). The worker parent loads database-backed schedules before forking, so children inherited a connection that could be reused concurrently by sibling processes.

## Validation

- `29 passed`: `tests/test_celery_app.py` and `tests/test_monitor_stalled_steps.py`
- Ruff lint and format pass
- fresh-canary reproduction captured before the fix; post-fix Docker acceptance will run after CI

This is intentionally separate from #1141 so the keyless setup feature remains reviewable.
