### PR TITLE
Fix exhaustive research for inflected German superlatives

### DIFF
--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -31,7 +31,7 @@ DbSession = Annotated[Session, Depends(get_db)]
 
 _SEARCH_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
 _RESEARCH_QUESTION_RE = re.compile(
-    r"\b(wie oft|wie viele|teuerst|höchst|über die jahre|im verlauf|trend|how many|how often|"
+    r"\b(wie oft|wie viele|teuerst\w*|höchst\w*|größt\w*|über die jahre|im verlauf|trend|how many|how often|"
     r"most expensive|highest|largest|biggest|over (?:the )?(?:years|time))\b",
     re.IGNORECASE,
 )

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -547,6 +547,20 @@ def test_research_keyword_query_keeps_domain_terms(question, expected):
     assert _research_keyword_query(question) == expected
 
 
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Was war der teuerste Amazon-Kauf bis jetzt?",
+        "Was war die höchste belegte Rechnung?",
+        "Welches war der größte Einkauf?",
+    ],
+)
+def test_research_classifier_accepts_inflected_german_superlatives(question):
+    from app.api.knowledge import _is_research_question
+
+    assert _is_research_question(question)
+
+
 def test_search_returns_cited_authoritative_document(client, db_session):
     record = FileRecord(
         id=3,


### PR DESCRIPTION
## User-visible bug
DearConcierge correctly classified “Was war der teuerste Amazon-Kauf?” as exhaustive, but DocuElevate treated it as focused RAG because the classifier matched only the uninflected token `teuerst`. The response had no research job ID, so the cross-product journey failed safely instead of returning an exhaustive answer.

## Fix
- classify inflected German superlatives (`teuerste`, `höchste`, `größte`, etc.)
- add deterministic regression coverage for the real DearConcierge query

## Verification
- `tests/test_vector_knowledge.py`: 40 passed
- `tests/test_knowledge_research.py`: 39 passed

Related: christianlouis/dearconcierge#544