### PR TITLE
feat: add tenant and tribe isolation foundation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,6 +119,8 @@ Conductor, and Signal are currently planning-track names because their former
 - Full-text search and document discovery
 - Multi-destination distribution (cloud providers, DMS, protocols, email)
 - Admin UI for configuration (database-backed settings, encryption, setup wizard)
+- [x] Tenant/Tribe document boundary foundation with canonical per-file `is_private` enforcement
+- [ ] Tribe membership, invitations, delegated routing administration, and explicit shared-intake UI (#1146)
 - Production hardening building blocks (CI/CD, security docs, deployment guides)
 
 ## Feature Landscape (Themes)

--- a/app/api/comments.py
+++ b/app/api/comments.py
@@ -280,6 +280,13 @@ def create_comment(
                         )
                         .first()
                     )
+                    from app.utils.tribe_scope import ensure_personal_scope
+
+                    ensure_personal_scope(
+                        db,
+                        tenant_id=file_record.tenant_id,
+                        user_id=mentioned_user,
+                    )
                     if not existing_share:
                         auto_share = FileShare(
                             file_id=file_id,

--- a/app/api/files.py
+++ b/app/api/files.py
@@ -2029,7 +2029,12 @@ def claim_file(request: Request, file_id: int, db: DbSession):
             return {"status": "already_owned", "message": "You already own this document", "file_id": file_id}
         raise HTTPException(status_code=403, detail="This document is already owned by another user")
 
+    from app.utils.tribe_scope import ensure_personal_scope
+
+    tenant_id, tribe_id = ensure_personal_scope(db, owner_id, file_record.tenant_id)
     file_record.owner_id = owner_id
+    file_record.tenant_id = tenant_id
+    file_record.tribe_id = tribe_id
     try:
         db.commit()
     except Exception as e:
@@ -2063,9 +2068,14 @@ def bulk_claim_files(request: Request, file_ids: list[int], db: DbSession):
 
     claimed = []
     skipped = []
+    from app.utils.tribe_scope import ensure_personal_scope
+
     for rec in file_records:
         if rec.owner_id is None:
+            tenant_id, tribe_id = ensure_personal_scope(db, owner_id, rec.tenant_id)
             rec.owner_id = owner_id
+            rec.tenant_id = tenant_id
+            rec.tribe_id = tribe_id
             claimed.append(rec.id)
         else:
             skipped.append({"file_id": rec.id, "reason": "already owned"})

--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -300,17 +300,18 @@ def _qdrant_authorization_scope(db: Session, request: Request) -> dict[str, Any]
     """Build a pre-ranking Qdrant scope matching relational access rules."""
     if not settings.multi_user_enabled:
         return {}
-    user = get_current_user(request)
-    if isinstance(user, dict) and user.get("is_admin"):
-        return {
-            "document_ids": [
-                row[0]
-                for row in apply_owner_filter(db.query(FileRecord.id), request).order_by(FileRecord.id.asc()).all()
-            ]
-        }
     owner_id = get_current_owner_id(request)
     if owner_id is None:
         return {"document_ids": []}
+    from app.models import TribeMembership
+
+    tribe_scopes = [
+        (row[0], row[1])
+        for row in db.query(TribeMembership.tenant_id, TribeMembership.tribe_id)
+        .filter(TribeMembership.user_id == owner_id)
+        .order_by(TribeMembership.tenant_id.asc(), TribeMembership.tribe_id.asc())
+        .all()
+    ]
     shared_document_ids = [
         row[0]
         for row in db.query(FileShare.file_id)
@@ -323,6 +324,7 @@ def _qdrant_authorization_scope(db: Session, request: Request) -> dict[str, Any]
         "owner_id": owner_id,
         "shared_document_ids": shared_document_ids,
         "include_unowned": settings.unowned_docs_visible_to_all,
+        "tribe_scopes": tribe_scopes,
     }
 
 

--- a/app/api/knowledge.py
+++ b/app/api/knowledge.py
@@ -312,11 +312,16 @@ def _qdrant_authorization_scope(db: Session, request: Request) -> dict[str, Any]
         .order_by(TribeMembership.tenant_id.asc(), TribeMembership.tribe_id.asc())
         .all()
     ]
+    tenant_ids = sorted({tenant_id for tenant_id, _tribe_id in tribe_scopes})
     shared_document_ids = [
         row[0]
         for row in db.query(FileShare.file_id)
         .join(FileRecord, FileRecord.id == FileShare.file_id)
-        .filter(FileShare.shared_with_user_id == owner_id, FileRecord.is_private.is_(False))
+        .filter(
+            FileShare.shared_with_user_id == owner_id,
+            FileRecord.tenant_id.in_(tenant_ids),
+            FileRecord.is_private.is_(False),
+        )
         .order_by(FileShare.file_id.asc())
         .all()
     ]

--- a/app/api/sharing.py
+++ b/app/api/sharing.py
@@ -152,6 +152,15 @@ def create_share(
         )
 
     try:
+        from app.utils.tribe_scope import ensure_personal_scope
+
+        # Keep a direct share file-specific: prove tenant membership through
+        # the recipient's personal Tribe without exposing this whole Tribe.
+        ensure_personal_scope(
+            db,
+            tenant_id=file_record.tenant_id,
+            user_id=shared_with_user_id,
+        )
         existing = (
             db.query(FileShare)
             .filter(FileShare.file_id == file_id, FileShare.shared_with_user_id == shared_with_user_id)

--- a/app/api/sharing.py
+++ b/app/api/sharing.py
@@ -69,9 +69,6 @@ def list_shares(request: Request, file_id: int, db: DbSession):
         A list of share objects.
     """
     user_id = get_current_owner_id(request)
-    user = request.session.get("user")
-    is_admin = isinstance(user, dict) and bool(user.get("is_admin"))
-
     file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
@@ -80,7 +77,7 @@ def list_shares(request: Request, file_id: int, db: DbSession):
     if role is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
-    if role != "owner" and not is_admin:
+    if role != "owner":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only the file owner can view shares",
@@ -334,15 +331,12 @@ def list_shared_with(request: Request, file_id: int, db: DbSession):
         A list of ``{share_id, user_id, display_name, role}`` objects.
     """
     user_id = get_current_owner_id(request)
-    user = request.session.get("user")
-    is_admin = isinstance(user, dict) and bool(user.get("is_admin"))
-
     file_record = db.query(FileRecord).filter(FileRecord.id == file_id).first()
     if not file_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     role = get_file_role(file_record, user_id, db)
-    if role is None and not (is_admin and not file_record.is_private):
+    if role is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     shares = db.query(FileShare).filter(FileShare.file_id == file_id).all()

--- a/app/models.py
+++ b/app/models.py
@@ -25,6 +25,47 @@ _FILES_ID_FK = "files.id"
 _PIPELINES_ID_FK = "pipelines.id"
 _ROUTING_RULES_TABLE = "pipeline_routing_rules"
 
+DEFAULT_TENANT_ID = "default"
+QUARANTINE_TRIBE_ID = "default-quarantine"
+
+
+class Tenant(Base):
+    """Hard security boundary for independent DocuElevate customers."""
+
+    __tablename__ = "tenants"
+
+    id = Column(String(64), primary_key=True)
+    name = Column(String(255), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class Tribe(Base):
+    """Collaboration boundary inside exactly one tenant."""
+
+    __tablename__ = "tribes"
+
+    id = Column(String(64), primary_key=True)
+    tenant_id = Column(String(64), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String(255), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    __table_args__ = (UniqueConstraint("tenant_id", "name", name="uq_tribes_tenant_name"),)
+
+
+class TribeMembership(Base):
+    """User membership and delegated role within a Tribe."""
+
+    __tablename__ = "tribe_memberships"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(String(64), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+    tribe_id = Column(String(64), ForeignKey("tribes.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id = Column(String, nullable=False, index=True)
+    role = Column(String(32), nullable=False, default="member", server_default="member")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    __table_args__ = (UniqueConstraint("tribe_id", "user_id", name="uq_tribe_memberships_tribe_user"),)
+
 
 class DocumentMetadata(Base):
     __tablename__ = "documents"
@@ -46,6 +87,27 @@ class FileRecord(Base):
     # Stores the user's unique identifier (e.g. email or OAuth sub claim).
     # NULL means the file belongs to the shared/global space (single-user mode).
     owner_id = Column(String, nullable=True, index=True)
+
+    # Every document is bound to one Tribe inside one tenant before it can be
+    # exposed.  Server defaults keep direct/offline record creation safe by
+    # placing it in the non-member quarantine; normal ingestion assigns the
+    # owner's personal/shared Tribe explicitly.
+    tenant_id = Column(
+        String(64),
+        ForeignKey("tenants.id"),
+        nullable=False,
+        default=DEFAULT_TENANT_ID,
+        server_default=DEFAULT_TENANT_ID,
+        index=True,
+    )
+    tribe_id = Column(
+        String(64),
+        ForeignKey("tribes.id"),
+        nullable=False,
+        default=QUARANTINE_TRIBE_ID,
+        server_default=QUARANTINE_TRIBE_ID,
+        index=True,
+    )
 
     # Hash of the file content (e.g. SHA-256)
     # Note: duplicates are allowed so filehash is not unique

--- a/app/tasks/process_document.py
+++ b/app/tasks/process_document.py
@@ -426,6 +426,9 @@ def process_document(
             # (not its own hash when reprocessing)
             if existing and existing.id != file_id and settings.enable_deduplication:
                 logger.info(f"[{task_id}] Duplicate file detected (hash={filehash[:10]}...) Skipping processing.")
+                from app.utils.tribe_scope import ensure_document_scope
+
+                tenant_id, tribe_id = ensure_document_scope(db, owner_id)
                 duplicate_record = FileRecord(
                     filehash=filehash,
                     original_filename=original_filename,
@@ -435,6 +438,8 @@ def process_document(
                     is_duplicate=True,
                     duplicate_of_id=existing.id,
                     owner_id=owner_id,
+                    tenant_id=tenant_id,
+                    tribe_id=tribe_id,
                 )
                 db.add(duplicate_record)
                 db.commit()
@@ -483,6 +488,9 @@ def process_document(
             # Not a duplicate (or deduplication disabled) -> insert a new record
             logger.info(f"[{task_id}] Creating new file record in database")
             log_task_progress(task_id, "create_file_record", "in_progress", "Creating file record")
+            from app.utils.tribe_scope import ensure_document_scope
+
+            tenant_id, tribe_id = ensure_document_scope(db, owner_id)
             new_record = FileRecord(
                 filehash=filehash,
                 original_filename=original_filename,
@@ -491,6 +499,8 @@ def process_document(
                 mime_type=mime_type,
                 is_duplicate=False,
                 owner_id=owner_id,
+                tenant_id=tenant_id,
+                tribe_id=tribe_id,
             )
             db.add(new_record)
             db.commit()

--- a/app/utils/db_migrate.py
+++ b/app/utils/db_migrate.py
@@ -27,6 +27,9 @@ _SKIP_TABLES = {"alembic_version"}
 
 # Ordered list — parent tables first to respect foreign-key constraints.
 _TABLE_ORDER = [
+    "tenants",
+    "tribes",
+    "tribe_memberships",
     "documents",
     "files",
     "file_processing_steps",

--- a/app/utils/tribe_scope.py
+++ b/app/utils/tribe_scope.py
@@ -15,9 +15,35 @@ from app.models import (
 )
 
 
-def personal_tribe_id(owner_id: str) -> str:
+def personal_tribe_id(owner_id: str, tenant_id: str = DEFAULT_TENANT_ID) -> str:
     """Return a stable opaque ID without exposing the login in file payloads."""
-    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"docuelevate:tribe:{DEFAULT_TENANT_ID}:{owner_id}"))
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"docuelevate:tribe:{tenant_id}:{owner_id}"))
+
+
+def ensure_personal_scope(
+    db: Session,
+    user_id: str,
+    tenant_id: str = DEFAULT_TENANT_ID,
+) -> tuple[str, str]:
+    """Ensure a user has a personal Tribe proving membership in one tenant."""
+    tenant = db.get(Tenant, tenant_id)
+    if tenant is None:
+        db.add(Tenant(id=tenant_id, name="Default tenant" if tenant_id == DEFAULT_TENANT_ID else tenant_id))
+        db.flush()
+
+    tribe_id = personal_tribe_id(user_id, tenant_id)
+    tribe = db.get(Tribe, tribe_id)
+    if tribe is None:
+        db.add(Tribe(id=tribe_id, tenant_id=tenant_id, name=f"Personal space for {user_id}"))
+        db.flush()
+    ensure_tribe_membership(
+        db,
+        tenant_id=tenant_id,
+        tribe_id=tribe_id,
+        user_id=user_id,
+        role="admin",
+    )
+    return tenant_id, tribe_id
 
 
 def ensure_document_scope(db: Session, owner_id: str | None) -> tuple[str, str]:
@@ -27,12 +53,11 @@ def ensure_document_scope(db: Session, owner_id: str | None) -> tuple[str, str]:
     later routing decision may move the document to an explicitly selected
     shared Tribe before indexing or delivery.
     """
-    tenant = db.get(Tenant, DEFAULT_TENANT_ID)
-    if tenant is None:
-        db.add(Tenant(id=DEFAULT_TENANT_ID, name="Default tenant"))
-        db.flush()
-
     if owner_id is None:
+        tenant = db.get(Tenant, DEFAULT_TENANT_ID)
+        if tenant is None:
+            db.add(Tenant(id=DEFAULT_TENANT_ID, name="Default tenant"))
+            db.flush()
         tribe_id = QUARANTINE_TRIBE_ID
         tribe = db.get(Tribe, tribe_id)
         if tribe is None:
@@ -40,24 +65,30 @@ def ensure_document_scope(db: Session, owner_id: str | None) -> tuple[str, str]:
             db.flush()
         return DEFAULT_TENANT_ID, tribe_id
 
-    tribe_id = personal_tribe_id(owner_id)
-    tribe = db.get(Tribe, tribe_id)
-    if tribe is None:
-        db.add(Tribe(id=tribe_id, tenant_id=DEFAULT_TENANT_ID, name=f"Personal space for {owner_id}"))
-        db.flush()
+    return ensure_personal_scope(db, owner_id)
+
+
+def ensure_tribe_membership(
+    db: Session,
+    *,
+    tenant_id: str,
+    tribe_id: str,
+    user_id: str,
+    role: str = "member",
+) -> TribeMembership:
+    """Return the user's membership, creating it when collaboration grants access."""
     membership = (
         db.query(TribeMembership)
-        .filter(TribeMembership.tribe_id == tribe_id, TribeMembership.user_id == owner_id)
+        .filter(TribeMembership.tribe_id == tribe_id, TribeMembership.user_id == user_id)
         .first()
     )
     if membership is None:
-        db.add(
-            TribeMembership(
-                tenant_id=DEFAULT_TENANT_ID,
-                tribe_id=tribe_id,
-                user_id=owner_id,
-                role="admin",
-            )
+        membership = TribeMembership(
+            tenant_id=tenant_id,
+            tribe_id=tribe_id,
+            user_id=user_id,
+            role=role,
         )
+        db.add(membership)
         db.flush()
-    return DEFAULT_TENANT_ID, tribe_id
+    return membership

--- a/app/utils/tribe_scope.py
+++ b/app/utils/tribe_scope.py
@@ -1,0 +1,63 @@
+"""Tenant/Tribe assignment helpers used before document processing starts."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from app.models import (
+    DEFAULT_TENANT_ID,
+    QUARANTINE_TRIBE_ID,
+    Tenant,
+    Tribe,
+    TribeMembership,
+)
+
+
+def personal_tribe_id(owner_id: str) -> str:
+    """Return a stable opaque ID without exposing the login in file payloads."""
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"docuelevate:tribe:{DEFAULT_TENANT_ID}:{owner_id}"))
+
+
+def ensure_document_scope(db: Session, owner_id: str | None) -> tuple[str, str]:
+    """Return a valid tenant/Tribe pair and create missing foundation rows.
+
+    Unowned intake is quarantined.  An owner starts in a personal Tribe; a
+    later routing decision may move the document to an explicitly selected
+    shared Tribe before indexing or delivery.
+    """
+    tenant = db.get(Tenant, DEFAULT_TENANT_ID)
+    if tenant is None:
+        db.add(Tenant(id=DEFAULT_TENANT_ID, name="Default tenant"))
+        db.flush()
+
+    if owner_id is None:
+        tribe_id = QUARANTINE_TRIBE_ID
+        tribe = db.get(Tribe, tribe_id)
+        if tribe is None:
+            db.add(Tribe(id=tribe_id, tenant_id=DEFAULT_TENANT_ID, name="Unassigned intake quarantine"))
+            db.flush()
+        return DEFAULT_TENANT_ID, tribe_id
+
+    tribe_id = personal_tribe_id(owner_id)
+    tribe = db.get(Tribe, tribe_id)
+    if tribe is None:
+        db.add(Tribe(id=tribe_id, tenant_id=DEFAULT_TENANT_ID, name=f"Personal space for {owner_id}"))
+        db.flush()
+    membership = (
+        db.query(TribeMembership)
+        .filter(TribeMembership.tribe_id == tribe_id, TribeMembership.user_id == owner_id)
+        .first()
+    )
+    if membership is None:
+        db.add(
+            TribeMembership(
+                tenant_id=DEFAULT_TENANT_ID,
+                tribe_id=tribe_id,
+                user_id=owner_id,
+                role="admin",
+            )
+        )
+        db.flush()
+    return DEFAULT_TENANT_ID, tribe_id

--- a/app/utils/user_scope.py
+++ b/app/utils/user_scope.py
@@ -10,12 +10,12 @@ documents are visible to all users (single-user / shared mode).
 import logging
 
 from fastapi import Request
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, or_, select, tuple_
 from sqlalchemy.orm import Query, Session
 from sqlalchemy.sql import false
 
 from app.config import settings
-from app.models import FILE_SHARE_ROLE_EDITOR, FILE_SHARE_ROLE_VIEWER, FileRecord, FileShare
+from app.models import FILE_SHARE_ROLE_EDITOR, FILE_SHARE_ROLE_VIEWER, FileRecord, FileShare, TribeMembership
 
 logger = logging.getLogger(__name__)
 
@@ -121,26 +121,32 @@ def apply_owner_filter(query: Query, request: Request) -> Query:
     if not settings.multi_user_enabled:
         return query
 
-    user = request.session.get("user")
     owner_id = get_current_owner_id(request)
     if owner_id is None:
         # No authenticated user — return empty result set
         return query.filter(false())
 
-    # A private document is owner-only.  This condition intentionally also
-    # applies to administrators: an operational role must not silently
-    # override a user's privacy choice.
-    if isinstance(user, dict) and user.get("is_admin"):
-        return query.filter(or_(FileRecord.owner_id == owner_id, FileRecord.is_private.is_(False)))
+    # Tenant/Tribe membership is evaluated before visibility.  Platform or
+    # Tribe administration never widens this boundary and never overrides an
+    # owner's private flag.
+    member_scopes = select(TribeMembership.tenant_id, TribeMembership.tribe_id).where(
+        TribeMembership.user_id == owner_id
+    )
+    in_member_tribe = tuple_(FileRecord.tenant_id, FileRecord.tribe_id).in_(member_scopes)
 
-    # Build filter: user's own documents + non-private documents shared with them
-    conditions = [FileRecord.owner_id == owner_id]
+    # The owner can read their document only inside a current membership; any
+    # member of the same Tribe can read a non-private document.
+    conditions = [
+        and_(in_member_tribe, FileRecord.owner_id == owner_id),
+        and_(in_member_tribe, FileRecord.is_private.is_(False)),
+    ]
 
     # Include files explicitly shared with this user
     from sqlalchemy import select as sa_select
 
     conditions.append(
         and_(
+            in_member_tribe,
             FileRecord.is_private.is_(False),
             FileRecord.id.in_(sa_select(FileShare.file_id).where(FileShare.shared_with_user_id == owner_id)),
         )
@@ -148,7 +154,7 @@ def apply_owner_filter(query: Query, request: Request) -> Query:
 
     # Optionally include unclaimed (owner_id IS NULL) documents
     if settings.unowned_docs_visible_to_all:
-        conditions.append(and_(FileRecord.is_private.is_(False), FileRecord.owner_id.is_(None)))
+        conditions.append(and_(in_member_tribe, FileRecord.is_private.is_(False), FileRecord.owner_id.is_(None)))
 
     return query.filter(or_(*conditions))
 
@@ -182,7 +188,19 @@ def get_file_role(file_record: FileRecord, user_id: str | None, db: Session) -> 
     if user_id is None:
         return None
 
-    # Owner always has full access
+    membership = (
+        db.query(TribeMembership.id)
+        .filter(
+            TribeMembership.user_id == user_id,
+            TribeMembership.tenant_id == file_record.tenant_id,
+            TribeMembership.tribe_id == file_record.tribe_id,
+        )
+        .first()
+    )
+
+    if membership is None:
+        return None
+
     if file_record.owner_id == user_id:
         return "owner"
 
@@ -190,10 +208,6 @@ def get_file_role(file_record: FileRecord, user_id: str | None, db: Session) -> 
     # unclaimed-document discovery.
     if file_record.is_private:
         return None
-
-    # Unclaimed document — limited access when setting allows it
-    if file_record.owner_id is None and settings.unowned_docs_visible_to_all:
-        return FILE_SHARE_ROLE_VIEWER
 
     # Check for an explicit share
     share = (
@@ -203,6 +217,14 @@ def get_file_role(file_record: FileRecord, user_id: str | None, db: Session) -> 
     )
     if share:
         return share.role
+
+    # Every non-private document is visible to authorised Tribe members.
+    if not file_record.is_private:
+        return FILE_SHARE_ROLE_VIEWER
+
+    # Unclaimed document — limited access when setting allows it
+    if file_record.owner_id is None and settings.unowned_docs_visible_to_all:
+        return FILE_SHARE_ROLE_VIEWER
 
     return None
 

--- a/app/utils/user_scope.py
+++ b/app/utils/user_scope.py
@@ -156,7 +156,7 @@ def apply_owner_filter(query: Query, request: Request) -> Query:
 
     # Optionally include unclaimed (owner_id IS NULL) documents
     if settings.unowned_docs_visible_to_all:
-        conditions.append(and_(in_member_tribe, FileRecord.is_private.is_(False), FileRecord.owner_id.is_(None)))
+        conditions.append(and_(in_member_tenant, FileRecord.is_private.is_(False), FileRecord.owner_id.is_(None)))
 
     return query.filter(or_(*conditions))
 

--- a/app/utils/user_scope.py
+++ b/app/utils/user_scope.py
@@ -132,7 +132,9 @@ def apply_owner_filter(query: Query, request: Request) -> Query:
     member_scopes = select(TribeMembership.tenant_id, TribeMembership.tribe_id).where(
         TribeMembership.user_id == owner_id
     )
+    member_tenants = select(TribeMembership.tenant_id).where(TribeMembership.user_id == owner_id)
     in_member_tribe = tuple_(FileRecord.tenant_id, FileRecord.tribe_id).in_(member_scopes)
+    in_member_tenant = FileRecord.tenant_id.in_(member_tenants)
 
     # The owner can read their document only inside a current membership; any
     # member of the same Tribe can read a non-private document.
@@ -146,7 +148,7 @@ def apply_owner_filter(query: Query, request: Request) -> Query:
 
     conditions.append(
         and_(
-            in_member_tribe,
+            in_member_tenant,
             FileRecord.is_private.is_(False),
             FileRecord.id.in_(sa_select(FileShare.file_id).where(FileShare.shared_with_user_id == owner_id)),
         )
@@ -188,7 +190,18 @@ def get_file_role(file_record: FileRecord, user_id: str | None, db: Session) -> 
     if user_id is None:
         return None
 
-    membership = (
+    tenant_membership = (
+        db.query(TribeMembership.id)
+        .filter(
+            TribeMembership.user_id == user_id,
+            TribeMembership.tenant_id == file_record.tenant_id,
+        )
+        .first()
+    )
+    if tenant_membership is None:
+        return None
+
+    tribe_membership = (
         db.query(TribeMembership.id)
         .filter(
             TribeMembership.user_id == user_id,
@@ -198,10 +211,7 @@ def get_file_role(file_record: FileRecord, user_id: str | None, db: Session) -> 
         .first()
     )
 
-    if membership is None:
-        return None
-
-    if file_record.owner_id == user_id:
+    if tribe_membership is not None and file_record.owner_id == user_id:
         return "owner"
 
     # Privacy is an owner-only boundary and wins over named shares and
@@ -219,7 +229,7 @@ def get_file_role(file_record: FileRecord, user_id: str | None, db: Session) -> 
         return share.role
 
     # Every non-private document is visible to authorised Tribe members.
-    if not file_record.is_private:
+    if tribe_membership is not None and not file_record.is_private:
         return FILE_SHARE_ROLE_VIEWER
 
     # Unclaimed document — limited access when setting allows it

--- a/app/utils/user_scope.py
+++ b/app/utils/user_scope.py
@@ -154,9 +154,11 @@ def apply_owner_filter(query: Query, request: Request) -> Query:
         )
     )
 
-    # Optionally include unclaimed (owner_id IS NULL) documents
+    # Optionally include unclaimed (owner_id IS NULL) documents, but only for
+    # members of the document's quarantine Tribe. Tenant membership alone must
+    # not make shared intake visible across otherwise isolated Tribes.
     if settings.unowned_docs_visible_to_all:
-        conditions.append(and_(in_member_tenant, FileRecord.is_private.is_(False), FileRecord.owner_id.is_(None)))
+        conditions.append(and_(in_member_tribe, FileRecord.is_private.is_(False), FileRecord.owner_id.is_(None)))
 
     return query.filter(or_(*conditions))
 

--- a/app/utils/vector_index.py
+++ b/app/utils/vector_index.py
@@ -186,6 +186,8 @@ class QdrantVectorIndex:
         # Qdrant needs payload indexes to evaluate tenant and document filters
         # before vector ranking without scanning the whole shared collection.
         for field_name, field_schema in (
+            ("tenant_id", "keyword"),
+            ("tribe_id", "keyword"),
             ("owner_id", "keyword"),
             ("document_id", "integer"),
             ("is_private", "bool"),
@@ -210,21 +212,65 @@ class QdrantVectorIndex:
         owner_id: str | None,
         shared_document_ids: list[int] | None,
         include_unowned: bool,
+        tribe_scopes: list[tuple[str, str]] | None = None,
     ) -> dict[str, Any] | None:
+        scope_filter: dict[str, Any] | None = None
+        if tribe_scopes is not None:
+            scope_filter = (
+                {
+                    "should": [
+                        {
+                            "must": [
+                                {"key": "tenant_id", "match": {"value": tenant_id}},
+                                {"key": "tribe_id", "match": {"value": tribe_id}},
+                            ]
+                        }
+                        for tenant_id, tribe_id in tribe_scopes
+                    ]
+                }
+                if tribe_scopes
+                else {"key": "tribe_id", "match": {"value": "__no_authorized_tribe__"}}
+            )
+
         conditions: list[dict[str, Any]] = []
         if owner_id is not None:
-            conditions.append(cls._owner_condition(owner_id))
-        if shared_document_ids:
-            conditions.append({"key": "document_id", "match": {"any": shared_document_ids}})
-        if include_unowned:
+            owner_condition: dict[str, Any] = cls._owner_condition(owner_id)
+            conditions.append(
+                {"must": [scope_filter, owner_condition]} if scope_filter is not None else owner_condition
+            )
+        if scope_filter is not None:
             conditions.append(
                 {
                     "must": [
-                        cls._owner_condition(None),
+                        scope_filter,
                         {"key": "is_private", "match": {"value": False}},
                     ]
                 }
             )
+        if shared_document_ids:
+            shared_condition: dict[str, Any] = {
+                "key": "document_id",
+                "match": {"any": shared_document_ids},
+            }
+            conditions.append(
+                {
+                    "must": [
+                        scope_filter,
+                        shared_condition,
+                        {"key": "is_private", "match": {"value": False}},
+                    ]
+                }
+                if scope_filter is not None
+                else shared_condition
+            )
+        if include_unowned:
+            unowned_conditions = [
+                cls._owner_condition(None),
+                {"key": "is_private", "match": {"value": False}},
+            ]
+            if scope_filter is not None:
+                unowned_conditions.insert(0, scope_filter)
+            conditions.append({"must": unowned_conditions})
         return {"should": conditions} if conditions else None
 
     def index_document(self, file_record: Any) -> int:
@@ -273,6 +319,8 @@ class QdrantVectorIndex:
                     "vector": vector,
                     "payload": {
                         "document_id": file_record.id,
+                        "tenant_id": getattr(file_record, "tenant_id", "default"),
+                        "tribe_id": getattr(file_record, "tribe_id", "default-quarantine"),
                         "owner_id": file_record.owner_id,
                         "is_private": bool(getattr(file_record, "is_private", False)),
                         "file_hash": file_record.filehash,
@@ -368,6 +416,7 @@ class QdrantVectorIndex:
         owner_id: str | None = None,
         shared_document_ids: list[int] | None = None,
         include_unowned: bool = False,
+        tribe_scopes: list[tuple[str, str]] | None = None,
     ) -> list[dict[str, Any]]:
         vector = generate_embeddings([query])[0]
         body: dict[str, Any] = {
@@ -382,6 +431,7 @@ class QdrantVectorIndex:
             owner_id=owner_id,
             shared_document_ids=shared_document_ids,
             include_unowned=include_unowned,
+            tribe_scopes=tribe_scopes,
         )
         if document_ids is not None:
             if not document_ids:

--- a/app/utils/vector_index.py
+++ b/app/utils/vector_index.py
@@ -238,6 +238,20 @@ class QdrantVectorIndex:
             conditions.append(
                 {"must": [scope_filter, owner_condition]} if scope_filter is not None else owner_condition
             )
+            if scope_filter is not None and tribe_scopes:
+                # Points written before Tribe payloads existed remain usable
+                # for their owner during the rolling reindex. Requiring both
+                # fields to be absent prevents this compatibility path from
+                # weakening newly scoped points.
+                conditions.append(
+                    {
+                        "must": [
+                            {"is_null": {"key": "tenant_id"}},
+                            {"is_null": {"key": "tribe_id"}},
+                            owner_condition,
+                        ]
+                    }
+                )
         if scope_filter is not None:
             conditions.append(
                 {
@@ -255,7 +269,6 @@ class QdrantVectorIndex:
             conditions.append(
                 {
                     "must": [
-                        scope_filter,
                         shared_condition,
                         {"key": "is_private", "match": {"value": False}},
                     ]
@@ -263,6 +276,17 @@ class QdrantVectorIndex:
                 if scope_filter is not None
                 else shared_condition
             )
+            if scope_filter is not None and tribe_scopes:
+                conditions.append(
+                    {
+                        "must": [
+                            {"is_null": {"key": "tenant_id"}},
+                            {"is_null": {"key": "tribe_id"}},
+                            shared_condition,
+                            {"key": "is_private", "match": {"value": False}},
+                        ]
+                    }
+                )
         if include_unowned:
             unowned_conditions = [
                 cls._owner_condition(None),

--- a/app/utils/vector_index.py
+++ b/app/utils/vector_index.py
@@ -215,7 +215,9 @@ class QdrantVectorIndex:
         tribe_scopes: list[tuple[str, str]] | None = None,
     ) -> dict[str, Any] | None:
         scope_filter: dict[str, Any] | None = None
+        tenant_filter: dict[str, Any] | None = None
         if tribe_scopes is not None:
+            tenant_ids = sorted({tenant_id for tenant_id, _tribe_id in tribe_scopes})
             scope_filter = (
                 {
                     "should": [
@@ -230,6 +232,11 @@ class QdrantVectorIndex:
                 }
                 if tribe_scopes
                 else {"key": "tribe_id", "match": {"value": "__no_authorized_tribe__"}}
+            )
+            tenant_filter = (
+                {"key": "tenant_id", "match": {"any": tenant_ids}}
+                if tenant_ids
+                else {"key": "tenant_id", "match": {"value": "__no_authorized_tenant__"}}
             )
 
         conditions: list[dict[str, Any]] = []
@@ -292,9 +299,20 @@ class QdrantVectorIndex:
                 cls._owner_condition(None),
                 {"key": "is_private", "match": {"value": False}},
             ]
-            if scope_filter is not None:
-                unowned_conditions.insert(0, scope_filter)
+            if tenant_filter is not None:
+                unowned_conditions.insert(0, tenant_filter)
             conditions.append({"must": unowned_conditions})
+            if tribe_scopes:
+                conditions.append(
+                    {
+                        "must": [
+                            {"is_null": {"key": "tenant_id"}},
+                            {"is_null": {"key": "tribe_id"}},
+                            cls._owner_condition(None),
+                            {"key": "is_private", "match": {"value": False}},
+                        ]
+                    }
+                )
         return {"should": conditions} if conditions else None
 
     def index_document(self, file_record: Any) -> int:

--- a/docs/API.md
+++ b/docs/API.md
@@ -159,6 +159,13 @@ wins until the owner returns the file to automatic handling.
 | `POST` | `/api/privacy-rules/{rule_id}/preview` | Preview owner-file matches without mutation |
 | `POST` | `/api/privacy-rules/{rule_id}/apply` | Mark matching owner files private, skipping manual overrides |
 
+The access decision is evaluated in this order: authenticated tenant and Tribe
+membership first, then the file's canonical `is_private` flag. A non-private
+file is visible only to authorised members of its one Tribe; it is never global
+or internet-public. A private file remains owner-only in authenticated document
+access. Administrator status does not bypass either boundary. Explicit share
+links remain a separate, owner-controlled access path.
+
 Privacy is committed before Meilisearch or Qdrant indexing. Derived index payloads
 are reconciled asynchronously, while the relational database remains authoritative.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -159,12 +159,14 @@ wins until the owner returns the file to automatic handling.
 | `POST` | `/api/privacy-rules/{rule_id}/preview` | Preview owner-file matches without mutation |
 | `POST` | `/api/privacy-rules/{rule_id}/apply` | Mark matching owner files private, skipping manual overrides |
 
-The access decision is evaluated in this order: authenticated tenant and Tribe
-membership first, then the file's canonical `is_private` flag. A non-private
-file is visible only to authorised members of its one Tribe; it is never global
-or internet-public. A private file remains owner-only in authenticated document
-access. Administrator status does not bypass either boundary. Explicit share
-links remain a separate, owner-controlled access path.
+The access decision is evaluated in this order: authenticated tenant membership,
+then Tribe membership or a file-specific share, and finally the file's canonical
+`is_private` flag. A non-private file is normally visible only to authorised
+members of its one Tribe; it is never global or internet-public. A direct share
+can grant access to one file inside the same tenant without adding the recipient
+to that Tribe. A private file remains owner-only in authenticated document access.
+Administrator status does not bypass either boundary. Explicit share links remain
+a separate, owner-controlled access path.
 
 Privacy is committed before Meilisearch or Qdrant indexing. Derived index payloads
 are reconciled asynchronously, while the relational database remains authoritative.

--- a/migrations/versions/060_add_tenant_tribe_foundation.py
+++ b/migrations/versions/060_add_tenant_tribe_foundation.py
@@ -83,9 +83,24 @@ def upgrade() -> None:
     )
 
     bind = op.get_bind()
-    owners = [row[0] for row in bind.execute(sa.text("SELECT DISTINCT owner_id FROM files WHERE owner_id IS NOT NULL"))]
-    profile_owners = [row[0] for row in bind.execute(sa.text("SELECT user_id FROM user_profiles"))]
-    share_recipients = [row[0] for row in bind.execute(sa.text("SELECT DISTINCT shared_with_user_id FROM file_shares"))]
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+    file_columns = {column["name"] for column in inspector.get_columns("files")}
+    owners = (
+        [row[0] for row in bind.execute(sa.text("SELECT DISTINCT owner_id FROM files WHERE owner_id IS NOT NULL"))]
+        if "owner_id" in file_columns
+        else []
+    )
+    profile_owners = (
+        [row[0] for row in bind.execute(sa.text("SELECT user_id FROM user_profiles"))]
+        if "user_profiles" in tables
+        else []
+    )
+    share_recipients = (
+        [row[0] for row in bind.execute(sa.text("SELECT DISTINCT shared_with_user_id FROM file_shares"))]
+        if "file_shares" in tables
+        else []
+    )
     for owner_id in sorted(set(owners + profile_owners + share_recipients)):
         tribe_id = _personal_tribe_id(owner_id)
         bind.execute(
@@ -99,10 +114,11 @@ def upgrade() -> None:
             ),
             {"tenant": DEFAULT_TENANT_ID, "tribe": tribe_id, "user": owner_id},
         )
-        bind.execute(
-            sa.text("UPDATE files SET tribe_id=:tribe WHERE owner_id=:owner"),
-            {"tribe": tribe_id, "owner": owner_id},
-        )
+        if "owner_id" in file_columns:
+            bind.execute(
+                sa.text("UPDATE files SET tribe_id=:tribe WHERE owner_id=:owner"),
+                {"tribe": tribe_id, "owner": owner_id},
+            )
 
     op.create_index("ix_files_tenant_id", "files", ["tenant_id"])
     op.create_index("ix_files_tribe_id", "files", ["tribe_id"])

--- a/migrations/versions/060_add_tenant_tribe_foundation.py
+++ b/migrations/versions/060_add_tenant_tribe_foundation.py
@@ -1,0 +1,123 @@
+"""Add the hard tenant and mandatory Tribe document boundary.
+
+Revision ID: 060_add_tenant_tribe_foundation
+Revises: 059_owner_privacy_rules
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "060_add_tenant_tribe_foundation"
+down_revision: Union[str, None] = "059_owner_privacy_rules"
+branch_labels = None
+depends_on = None
+
+DEFAULT_TENANT_ID = "default"
+QUARANTINE_TRIBE_ID = "default-quarantine"
+
+
+def _personal_tribe_id(owner_id: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"docuelevate:tribe:{DEFAULT_TENANT_ID}:{owner_id}"))
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tenants",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "tribes",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("tenant_id", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("tenant_id", "name", name="uq_tribes_tenant_name"),
+    )
+    op.create_index("ix_tribes_tenant_id", "tribes", ["tenant_id"])
+    op.create_table(
+        "tribe_memberships",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sa.String(length=64), nullable=False),
+        sa.Column("tribe_id", sa.String(length=64), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("role", sa.String(length=32), server_default="member", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tribe_id"], ["tribes.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("tribe_id", "user_id", name="uq_tribe_memberships_tribe_user"),
+    )
+    op.create_index("ix_tribe_memberships_id", "tribe_memberships", ["id"])
+    op.create_index("ix_tribe_memberships_tenant_id", "tribe_memberships", ["tenant_id"])
+    op.create_index("ix_tribe_memberships_tribe_id", "tribe_memberships", ["tribe_id"])
+    op.create_index("ix_tribe_memberships_user_id", "tribe_memberships", ["user_id"])
+
+    op.execute(
+        sa.text("INSERT INTO tenants (id, name) VALUES (:id, :name)").bindparams(
+            id=DEFAULT_TENANT_ID, name="Default tenant"
+        )
+    )
+    op.execute(
+        sa.text("INSERT INTO tribes (id, tenant_id, name) VALUES (:id, :tenant, :name)").bindparams(
+            id=QUARANTINE_TRIBE_ID, tenant=DEFAULT_TENANT_ID, name="Unassigned intake quarantine"
+        )
+    )
+
+    op.add_column(
+        "files",
+        sa.Column("tenant_id", sa.String(length=64), server_default=DEFAULT_TENANT_ID, nullable=False),
+    )
+    op.add_column(
+        "files",
+        sa.Column("tribe_id", sa.String(length=64), server_default=QUARANTINE_TRIBE_ID, nullable=False),
+    )
+
+    bind = op.get_bind()
+    owners = [row[0] for row in bind.execute(sa.text("SELECT DISTINCT owner_id FROM files WHERE owner_id IS NOT NULL"))]
+    profile_owners = [row[0] for row in bind.execute(sa.text("SELECT user_id FROM user_profiles"))]
+    for owner_id in sorted(set(owners + profile_owners)):
+        tribe_id = _personal_tribe_id(owner_id)
+        bind.execute(
+            sa.text("INSERT INTO tribes (id, tenant_id, name) VALUES (:id, :tenant, :name)"),
+            {"id": tribe_id, "tenant": DEFAULT_TENANT_ID, "name": f"Personal space for {owner_id}"},
+        )
+        bind.execute(
+            sa.text(
+                "INSERT INTO tribe_memberships (tenant_id, tribe_id, user_id, role) "
+                "VALUES (:tenant, :tribe, :user, 'admin')"
+            ),
+            {"tenant": DEFAULT_TENANT_ID, "tribe": tribe_id, "user": owner_id},
+        )
+        bind.execute(
+            sa.text("UPDATE files SET tribe_id=:tribe WHERE owner_id=:owner"),
+            {"tribe": tribe_id, "owner": owner_id},
+        )
+
+    op.create_index("ix_files_tenant_id", "files", ["tenant_id"])
+    op.create_index("ix_files_tribe_id", "files", ["tribe_id"])
+    with op.batch_alter_table("files") as batch_op:
+        batch_op.create_foreign_key("fk_files_tenant_id", "tenants", ["tenant_id"], ["id"])
+        batch_op.create_foreign_key("fk_files_tribe_id", "tribes", ["tribe_id"], ["id"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("files") as batch_op:
+        batch_op.drop_constraint("fk_files_tribe_id", type_="foreignkey")
+        batch_op.drop_constraint("fk_files_tenant_id", type_="foreignkey")
+    op.drop_index("ix_files_tribe_id", table_name="files")
+    op.drop_index("ix_files_tenant_id", table_name="files")
+    op.drop_column("files", "tribe_id")
+    op.drop_column("files", "tenant_id")
+    op.drop_table("tribe_memberships")
+    op.drop_table("tribes")
+    op.drop_table("tenants")

--- a/migrations/versions/060_add_tenant_tribe_foundation.py
+++ b/migrations/versions/060_add_tenant_tribe_foundation.py
@@ -85,7 +85,8 @@ def upgrade() -> None:
     bind = op.get_bind()
     owners = [row[0] for row in bind.execute(sa.text("SELECT DISTINCT owner_id FROM files WHERE owner_id IS NOT NULL"))]
     profile_owners = [row[0] for row in bind.execute(sa.text("SELECT user_id FROM user_profiles"))]
-    for owner_id in sorted(set(owners + profile_owners)):
+    share_recipients = [row[0] for row in bind.execute(sa.text("SELECT DISTINCT shared_with_user_id FROM file_shares"))]
+    for owner_id in sorted(set(owners + profile_owners + share_recipients)):
         tribe_id = _personal_tribe_id(owner_id)
         bind.execute(
             sa.text("INSERT INTO tribes (id, tenant_id, name) VALUES (:id, :tenant, :name)"),

--- a/tests/test_db_migrate.py
+++ b/tests/test_db_migrate.py
@@ -63,6 +63,21 @@ class TestOrderedTables:
         # custom_table is not in _TABLE_ORDER so comes after known tables
         assert "custom_table" in result
 
+    def test_tenant_parents_are_copied_before_files(self):
+        mock_inspector = MagicMock()
+        mock_inspector.get_table_names.return_value = [
+            "files",
+            "tribe_memberships",
+            "tribes",
+            "tenants",
+        ]
+
+        result = _ordered_tables(mock_inspector)
+
+        assert result.index("tenants") < result.index("tribes")
+        assert result.index("tribes") < result.index("tribe_memberships")
+        assert result.index("tribe_memberships") < result.index("files")
+
     def test_skips_alembic_version(self):
         """Test that alembic_version table is always skipped."""
         mock_inspector = MagicMock()

--- a/tests/test_file_privacy.py
+++ b/tests/test_file_privacy.py
@@ -5,9 +5,11 @@ from unittest.mock import patch
 import pytest
 
 from app.models import FileRecord, SharedLink
+from app.utils.tribe_scope import ensure_document_scope
 
 
 def _file(db_session, owner_id="alice") -> FileRecord:
+    tenant_id, tribe_id = ensure_document_scope(db_session, owner_id)
     record = FileRecord(
         owner_id=owner_id,
         filehash="privacy-hash",
@@ -15,6 +17,8 @@ def _file(db_session, owner_id="alice") -> FileRecord:
         local_filename="/tmp/privacy.pdf",
         file_size=123,
         mime_type="application/pdf",
+        tenant_id=tenant_id,
+        tribe_id=tribe_id,
     )
     db_session.add(record)
     db_session.commit()

--- a/tests/test_multi_user.py
+++ b/tests/test_multi_user.py
@@ -18,7 +18,7 @@ from sqlalchemy.pool import StaticPool
 
 from app.config import settings
 from app.database import Base
-from app.models import ApiToken, FileRecord
+from app.models import ApiToken, FileRecord, Tenant, Tribe, TribeMembership
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -47,8 +47,25 @@ def mu_session(mu_engine):
     session.close()
 
 
-def _create_file_record(session, owner_id=None, filename="test.pdf", is_private=False):
+def _create_file_record(
+    session,
+    owner_id=None,
+    filename="test.pdf",
+    is_private=False,
+    tenant_id="test-tenant",
+    tribe_id=None,
+):
     """Helper to insert a minimal FileRecord."""
+    tribe_id = tribe_id or (f"personal-{owner_id}" if owner_id else "quarantine")
+    if session.get(Tenant, tenant_id) is None:
+        session.add(Tenant(id=tenant_id, name=tenant_id))
+        session.flush()
+    if session.get(Tribe, tribe_id) is None:
+        session.add(Tribe(id=tribe_id, tenant_id=tenant_id, name=tribe_id))
+        session.flush()
+    if owner_id and not session.query(TribeMembership).filter_by(tribe_id=tribe_id, user_id=owner_id).first():
+        session.add(TribeMembership(tenant_id=tenant_id, tribe_id=tribe_id, user_id=owner_id, role="admin"))
+        session.flush()
     rec = FileRecord(
         filehash="abc123",
         original_filename=filename,
@@ -58,6 +75,8 @@ def _create_file_record(session, owner_id=None, filename="test.pdf", is_private=
         is_duplicate=False,
         owner_id=owner_id,
         is_private=is_private,
+        tenant_id=tenant_id,
+        tribe_id=tribe_id,
     )
     session.add(rec)
     session.commit()
@@ -321,10 +340,10 @@ class TestApplyOwnerFilter:
             filtered = apply_owner_filter(query, request)
 
         results = filtered.all()
-        # Alice sees her own file + the unowned file (not Bob's)
-        assert len(results) == 2
+        # Unowned intake is quarantined rather than exposed to unrelated Tribes.
+        assert len(results) == 1
         owner_ids = {r.owner_id for r in results}
-        assert owner_ids == {"alice", None}
+        assert owner_ids == {"alice"}
 
     @pytest.mark.unit
     def test_filters_strictly_when_unowned_not_visible(self, mu_session):
@@ -346,8 +365,8 @@ class TestApplyOwnerFilter:
         assert results[0].owner_id == "alice"
 
     @pytest.mark.unit
-    def test_admin_sees_all_when_enabled(self, mu_session):
-        """Admins see non-private files but cannot override owner privacy."""
+    def test_admin_is_limited_to_their_tribes(self, mu_session):
+        """Platform administration never widens the Tribe boundary."""
         from app.utils.user_scope import apply_owner_filter
 
         _create_file_record(mu_session, owner_id="alice")
@@ -361,7 +380,29 @@ class TestApplyOwnerFilter:
         with _patch_multi_user(True):
             filtered = apply_owner_filter(query, request)
 
-        assert filtered.count() == 3
+        assert filtered.count() == 0
+
+    @pytest.mark.unit
+    def test_non_private_is_visible_inside_tribe_but_private_is_owner_only(self, mu_session):
+        from app.utils.user_scope import apply_owner_filter
+
+        public = _create_file_record(mu_session, owner_id="alice", tribe_id="family")
+        private = _create_file_record(
+            mu_session,
+            owner_id="alice",
+            filename="private.pdf",
+            is_private=True,
+            tribe_id="family",
+        )
+        mu_session.add(TribeMembership(tenant_id="test-tenant", tribe_id="family", user_id="bob", role="member"))
+        mu_session.commit()
+
+        request = _mock_request(user={"preferred_username": "bob"})
+        with _patch_multi_user(True):
+            results = apply_owner_filter(mu_session.query(FileRecord), request).all()
+
+        assert [record.id for record in results] == [public.id]
+        assert private.id not in {record.id for record in results}
 
     @pytest.mark.unit
     def test_private_file_is_hidden_from_named_share(self, mu_session):
@@ -942,7 +983,7 @@ class TestApplyOwnerFilterEdgeCases:
 
         result_ids = {r.id for r in results}
         assert own.id in result_ids
-        assert orphan.id in result_ids
+        assert orphan.id not in result_ids
         assert other.id not in result_ids
 
     @pytest.mark.unit
@@ -964,8 +1005,8 @@ class TestApplyOwnerFilterEdgeCases:
         assert orphan.id not in result_ids
 
     @pytest.mark.unit
-    def test_admin_always_sees_all(self, mu_session):
-        """Admin user always sees all files, regardless of unowned_docs_visible_to_all."""
+    def test_admin_does_not_cross_tribes(self, mu_session):
+        """Admin status does not grant access outside a membership."""
         from app.utils.user_scope import apply_owner_filter
 
         _create_file_record(mu_session, owner_id="alice")
@@ -977,7 +1018,7 @@ class TestApplyOwnerFilterEdgeCases:
         with _patch_multi_user(True), patch.object(settings, "unowned_docs_visible_to_all", False):
             results = apply_owner_filter(query, request).all()
 
-        assert len(results) == 2
+        assert results == []
 
     @pytest.mark.unit
     def test_no_files_returns_empty(self, mu_session):

--- a/tests/test_privacy_rules.py
+++ b/tests/test_privacy_rules.py
@@ -13,9 +13,11 @@ from app.utils.privacy_rules import (
     RULE_TYPE_METADATA,
     match_privacy_rule,
 )
+from app.utils.tribe_scope import ensure_document_scope
 
 
 def _file(db, *, owner: str, name: str, text: str = "", metadata: str | None = None) -> FileRecord:
+    tenant_id, tribe_id = ensure_document_scope(db, owner)
     record = FileRecord(
         owner_id=owner,
         filehash=f"hash-{owner}-{name}",
@@ -28,6 +30,8 @@ def _file(db, *, owner: str, name: str, text: str = "", metadata: str | None = N
         ocr_text=text,
         ai_metadata=metadata,
         pipeline_id=None,
+        tenant_id=tenant_id,
+        tribe_id=tribe_id,
     )
     db.add(record)
     db.commit()

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -10,7 +10,7 @@ from app.models import (
     TribeMembership,
     UserProfile,
 )
-from app.utils.tribe_scope import ensure_document_scope
+from app.utils.tribe_scope import ensure_document_scope, ensure_personal_scope
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -110,6 +110,21 @@ class TestGetFileRole:
         share = FileShare(file_id=f.id, owner_id="alice", shared_with_user_id="bob", role=FILE_SHARE_ROLE_VIEWER)
         db_session.add(share)
         db_session.commit()
+        assert get_file_role(f, "bob", db_session) == FILE_SHARE_ROLE_VIEWER
+
+    def test_file_share_does_not_require_or_grant_file_tribe_membership(self, db_session, monkeypatch):
+        from app.config import settings as real_settings
+        from app.utils.user_scope import get_file_role
+
+        monkeypatch.setattr(real_settings, "multi_user_enabled", True)
+        f = _create_file(db_session, owner_id="alice")
+        _tenant_id, bob_tribe_id = ensure_personal_scope(db_session, "bob", f.tenant_id)
+        db_session.add(
+            FileShare(file_id=f.id, owner_id="alice", shared_with_user_id="bob", role=FILE_SHARE_ROLE_VIEWER)
+        )
+        db_session.commit()
+
+        assert bob_tribe_id != f.tribe_id
         assert get_file_role(f, "bob", db_session) == FILE_SHARE_ROLE_VIEWER
 
     def test_shared_editor_returns_editor(self, db_session, monkeypatch):
@@ -323,6 +338,9 @@ class TestCreateShare:
         )
         assert resp.status_code == 201
         assert resp.json()["role"] == "editor"
+        carol_membership = db_session.query(TribeMembership).filter_by(user_id="carol").one()
+        assert carol_membership.tenant_id == f.tenant_id
+        assert carol_membership.tribe_id != f.tribe_id
 
     def test_non_owner_cannot_share(self, client, db_session, monkeypatch):
         import app.api.sharing as sharing_mod
@@ -634,6 +652,9 @@ class TestAutoShareOnMention:
         )
         assert share is not None
         assert share.role == FILE_SHARE_ROLE_VIEWER
+        bob_membership = db_session.query(TribeMembership).filter_by(user_id="bob").one()
+        assert bob_membership.tenant_id == f.tenant_id
+        assert bob_membership.tribe_id != f.tribe_id
 
     def test_mention_does_not_duplicate_share(self, client, db_session, monkeypatch):
         """Mentioning a user that already has a share does not create a duplicate."""

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -2,7 +2,15 @@
 
 import pytest
 
-from app.models import FILE_SHARE_ROLE_EDITOR, FILE_SHARE_ROLE_VIEWER, FileRecord, FileShare, UserProfile
+from app.models import (
+    FILE_SHARE_ROLE_EDITOR,
+    FILE_SHARE_ROLE_VIEWER,
+    FileRecord,
+    FileShare,
+    TribeMembership,
+    UserProfile,
+)
+from app.utils.tribe_scope import ensure_document_scope
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -11,6 +19,7 @@ from app.models import FILE_SHARE_ROLE_EDITOR, FILE_SHARE_ROLE_VIEWER, FileRecor
 
 def _create_file(db_session, owner_id="owner1") -> FileRecord:
     """Create a minimal owned FileRecord."""
+    tenant_id, tribe_id = ensure_document_scope(db_session, owner_id)
     f = FileRecord(
         owner_id=owner_id,
         filehash="sharehash",
@@ -18,6 +27,8 @@ def _create_file(db_session, owner_id="owner1") -> FileRecord:
         local_filename="shared.pdf",
         file_size=1024,
         mime_type="application/pdf",
+        tenant_id=tenant_id,
+        tribe_id=tribe_id,
     )
     db_session.add(f)
     db_session.commit()
@@ -27,6 +38,7 @@ def _create_file(db_session, owner_id="owner1") -> FileRecord:
 
 def _create_unowned_file(db_session) -> FileRecord:
     """Create a FileRecord with no owner."""
+    tenant_id, tribe_id = ensure_document_scope(db_session, None)
     f = FileRecord(
         owner_id=None,
         filehash="unownedhash",
@@ -34,6 +46,8 @@ def _create_unowned_file(db_session) -> FileRecord:
         local_filename="unowned.pdf",
         file_size=512,
         mime_type="application/pdf",
+        tenant_id=tenant_id,
+        tribe_id=tribe_id,
     )
     db_session.add(f)
     db_session.commit()
@@ -47,6 +61,18 @@ def _create_profile(db_session, user_id: str, display_name: str | None = None) -
     db_session.commit()
     db_session.refresh(p)
     return p
+
+
+def _add_tribe_member(db_session, file_record: FileRecord, user_id: str) -> None:
+    db_session.add(
+        TribeMembership(
+            tenant_id=file_record.tenant_id,
+            tribe_id=file_record.tribe_id,
+            user_id=user_id,
+            role="member",
+        )
+    )
+    db_session.flush()
 
 
 # ---------------------------------------------------------------------------
@@ -80,6 +106,7 @@ class TestGetFileRole:
 
         monkeypatch.setattr(real_settings, "multi_user_enabled", True)
         f = _create_file(db_session, owner_id="alice")
+        _add_tribe_member(db_session, f, "bob")
         share = FileShare(file_id=f.id, owner_id="alice", shared_with_user_id="bob", role=FILE_SHARE_ROLE_VIEWER)
         db_session.add(share)
         db_session.commit()
@@ -91,6 +118,7 @@ class TestGetFileRole:
 
         monkeypatch.setattr(real_settings, "multi_user_enabled", True)
         f = _create_file(db_session, owner_id="alice")
+        _add_tribe_member(db_session, f, "carol")
         share = FileShare(file_id=f.id, owner_id="alice", shared_with_user_id="carol", role=FILE_SHARE_ROLE_EDITOR)
         db_session.add(share)
         db_session.commit()
@@ -115,7 +143,7 @@ class TestGetFileRole:
         monkeypatch.setattr(user_scope.settings, "unowned_docs_visible_to_all", True)
         f = _create_unowned_file(db_session)
         role = user_scope.get_file_role(f, "anyone", db_session)
-        assert role == FILE_SHARE_ROLE_VIEWER
+        assert role is None
 
     def test_none_user_returns_none(self, db_session, monkeypatch):
         from app.config import settings as real_settings
@@ -165,6 +193,7 @@ class TestHasFileRole:
 
         monkeypatch.setattr(real_settings, "multi_user_enabled", True)
         f = _create_file(db_session, owner_id="alice")
+        _add_tribe_member(db_session, f, "bob")
         share = FileShare(file_id=f.id, owner_id="alice", shared_with_user_id="bob", role=FILE_SHARE_ROLE_VIEWER)
         db_session.add(share)
         db_session.commit()
@@ -176,6 +205,7 @@ class TestHasFileRole:
 
         monkeypatch.setattr(real_settings, "multi_user_enabled", True)
         f = _create_file(db_session, owner_id="alice")
+        _add_tribe_member(db_session, f, "carol")
         share = FileShare(file_id=f.id, owner_id="alice", shared_with_user_id="carol", role=FILE_SHARE_ROLE_EDITOR)
         db_session.add(share)
         db_session.commit()
@@ -550,6 +580,7 @@ class TestListSharedWith:
         monkeypatch.setattr(sharing_mod, "get_current_owner_id", lambda req: "bob")
 
         f = _create_file(db_session, owner_id="alice")
+        _add_tribe_member(db_session, f, "bob")
         share = FileShare(file_id=f.id, owner_id="alice", shared_with_user_id="bob", role="viewer")
         db_session.add(share)
         db_session.commit()
@@ -691,6 +722,7 @@ class TestDeleteFileOwnerOnly:
         monkeypatch.setattr(user_scope_mod, "get_current_owner_id", lambda req: "bob")
 
         f = _create_file(db_session, owner_id="alice")
+        _add_tribe_member(db_session, f, "bob")
         share = FileShare(file_id=f.id, owner_id="alice", shared_with_user_id="bob", role="viewer")
         db_session.add(share)
         db_session.commit()
@@ -709,6 +741,7 @@ class TestDeleteFileOwnerOnly:
         monkeypatch.setattr(user_scope_mod, "get_current_owner_id", lambda req: "carol")
 
         f = _create_file(db_session, owner_id="alice")
+        _add_tribe_member(db_session, f, "carol")
         share = FileShare(file_id=f.id, owner_id="alice", shared_with_user_id="carol", role="editor")
         db_session.add(share)
         db_session.commit()

--- a/tests/test_tribe_scope.py
+++ b/tests/test_tribe_scope.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.config import settings
+from app.models import FileRecord, TribeMembership
+from app.utils.tribe_scope import ensure_document_scope
+from app.utils.user_scope import apply_owner_filter
+
+
+@pytest.mark.unit
+def test_personal_scope_is_stable_and_creates_membership(db_session):
+    first = ensure_document_scope(db_session, "alice")
+    second = ensure_document_scope(db_session, "alice")
+
+    assert first == second
+    assert db_session.query(TribeMembership).filter_by(user_id="alice", tribe_id=first[1]).count() == 1
+
+
+@pytest.mark.unit
+def test_private_flag_is_canonical_inside_shared_tribe(db_session):
+    tenant_id, tribe_id = ensure_document_scope(db_session, "alice")
+    db_session.add(TribeMembership(tenant_id=tenant_id, tribe_id=tribe_id, user_id="bob", role="member"))
+    public = FileRecord(
+        filehash="public",
+        local_filename="/tmp/public.pdf",
+        file_size=1,
+        owner_id="alice",
+        tenant_id=tenant_id,
+        tribe_id=tribe_id,
+        is_private=False,
+    )
+    private = FileRecord(
+        filehash="private",
+        local_filename="/tmp/private.pdf",
+        file_size=1,
+        owner_id="alice",
+        tenant_id=tenant_id,
+        tribe_id=tribe_id,
+        is_private=True,
+    )
+    db_session.add_all([public, private])
+    db_session.commit()
+
+    request = MagicMock()
+    request.session = {"user": {"preferred_username": "bob"}}
+    with patch.object(settings, "multi_user_enabled", True):
+        visible = apply_owner_filter(db_session.query(FileRecord), request).all()
+
+    assert [record.filehash for record in visible] == ["public"]

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -368,9 +368,7 @@ def test_qdrant_search_denies_all_when_user_has_no_tribe_membership():
 
     no_scope = {"key": "tribe_id", "match": {"value": "__no_authorized_tribe__"}}
     conditions = request.call_args.args[2]["filter"]["should"]
-    assert conditions[0] == {
-        "must": [no_scope, {"key": "owner_id", "match": {"value": "alice@example.com"}}]
-    }
+    assert conditions[0] == {"must": [no_scope, {"key": "owner_id", "match": {"value": "alice@example.com"}}]}
     assert all(no_scope in condition["must"] for condition in conditions)
 
 

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -361,7 +361,7 @@ def test_qdrant_search_denies_all_when_user_has_no_tribe_membership():
             "query",
             limit=5,
             owner_id="alice@example.com",
-            shared_document_ids=[8],
+            shared_document_ids=[],
             include_unowned=True,
             tribe_scopes=[],
         )
@@ -370,6 +370,31 @@ def test_qdrant_search_denies_all_when_user_has_no_tribe_membership():
     conditions = request.call_args.args[2]["filter"]["should"]
     assert conditions[0] == {"must": [no_scope, {"key": "owner_id", "match": {"value": "alice@example.com"}}]}
     assert all(no_scope in condition["must"] for condition in conditions)
+
+
+def test_qdrant_search_keeps_legacy_owner_points_during_scope_transition():
+    from app.utils.vector_index import QdrantVectorIndex
+
+    response = SimpleNamespace(status_code=200, json=lambda: {"result": {"points": []}})
+    with (
+        patch("app.utils.vector_index.generate_embeddings", return_value=[[0.1, 0.2]]),
+        patch.object(QdrantVectorIndex, "_request", return_value=response) as request,
+    ):
+        QdrantVectorIndex().search(
+            "query",
+            limit=5,
+            owner_id="alice@example.com",
+            tribe_scopes=[("tenant-a", "tribe-a")],
+        )
+
+    conditions = request.call_args.args[2]["filter"]["should"]
+    assert {
+        "must": [
+            {"is_null": {"key": "tenant_id"}},
+            {"is_null": {"key": "tribe_id"}},
+            {"key": "owner_id", "match": {"value": "alice@example.com"}},
+        ]
+    } in conditions
 
 
 def test_qdrant_document_cleanup_is_owner_scoped():
@@ -477,8 +502,8 @@ def test_knowledge_search_passes_authorized_scope_to_qdrant(db_session):
         mime_type="application/pdf",
         ocr_text="denied evidence",
     )
-    _assign_personal_scope(db_session, "alice@example.com", own, shared)
-    _assign_personal_scope(db_session, "bob@example.com", denied)
+    _assign_personal_scope(db_session, "alice@example.com", own)
+    _assign_personal_scope(db_session, "bob@example.com", shared, denied)
     db_session.add_all([own, shared, denied])
     db_session.add(
         FileShare(

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -9,12 +9,23 @@ import requests
 from starlette.requests import Request
 
 from app.models import FileRecord, FileShare, KnowledgeResearchJob
+from app.utils.tribe_scope import ensure_document_scope
+
+
+def _assign_personal_scope(db_session, owner_id: str, *records: FileRecord) -> tuple[str, str]:
+    tenant_id, tribe_id = ensure_document_scope(db_session, owner_id)
+    for record in records:
+        record.tenant_id = tenant_id
+        record.tribe_id = tribe_id
+    return tenant_id, tribe_id
 
 
 def _file(file_id: int = 7, owner_id: str | None = None) -> SimpleNamespace:
     return SimpleNamespace(
         id=file_id,
         owner_id=owner_id,
+        tenant_id="default",
+        tribe_id="default-quarantine",
         filehash="file-hash",
         original_filename="project-plan.pdf",
         document_title="Project plan",
@@ -227,6 +238,8 @@ def test_qdrant_collection_creation_and_dimension_guard():
             SimpleNamespace(status_code=200),
             SimpleNamespace(status_code=200),
             SimpleNamespace(status_code=200),
+            SimpleNamespace(status_code=200),
+            SimpleNamespace(status_code=200),
         ],
     ) as request:
         QdrantVectorIndex().ensure_collection(1536)
@@ -236,6 +249,18 @@ def test_qdrant_collection_creation_and_dimension_guard():
             "PUT",
             "/collections/docuelevate_documents",
             {"vectors": {"size": 1536, "distance": "Cosine"}},
+            expected=(200, 201),
+        ),
+        call(
+            "PUT",
+            "/collections/docuelevate_documents/index?wait=true",
+            {"field_name": "tenant_id", "field_schema": "keyword"},
+            expected=(200, 201),
+        ),
+        call(
+            "PUT",
+            "/collections/docuelevate_documents/index?wait=true",
+            {"field_name": "tribe_id", "field_schema": "keyword"},
             expected=(200, 201),
         ),
         call(
@@ -324,6 +349,31 @@ def test_qdrant_search_filters_owner_shares_and_unowned_before_ranking():
     }
 
 
+def test_qdrant_search_denies_all_when_user_has_no_tribe_membership():
+    from app.utils.vector_index import QdrantVectorIndex
+
+    response = SimpleNamespace(status_code=200, json=lambda: {"result": {"points": []}})
+    with (
+        patch("app.utils.vector_index.generate_embeddings", return_value=[[0.1, 0.2]]),
+        patch.object(QdrantVectorIndex, "_request", return_value=response) as request,
+    ):
+        QdrantVectorIndex().search(
+            "query",
+            limit=5,
+            owner_id="alice@example.com",
+            shared_document_ids=[8],
+            include_unowned=True,
+            tribe_scopes=[],
+        )
+
+    no_scope = {"key": "tribe_id", "match": {"value": "__no_authorized_tribe__"}}
+    conditions = request.call_args.args[2]["filter"]["should"]
+    assert conditions[0] == {
+        "must": [no_scope, {"key": "owner_id", "match": {"value": "alice@example.com"}}]
+    }
+    assert all(no_scope in condition["must"] for condition in conditions)
+
+
 def test_qdrant_document_cleanup_is_owner_scoped():
     from app.utils.vector_index import QdrantVectorIndex
 
@@ -383,6 +433,8 @@ def test_owner_filter_removes_unauthorized_vector_hits(db_session):
         file_size=1,
         mime_type="application/pdf",
     )
+    _assign_personal_scope(db_session, "alice@example.com", own)
+    _assign_personal_scope(db_session, "bob@example.com", other)
     db_session.add_all([own, other])
     db_session.commit()
     request = Request({"type": "http", "headers": []})
@@ -427,6 +479,8 @@ def test_knowledge_search_passes_authorized_scope_to_qdrant(db_session):
         mime_type="application/pdf",
         ocr_text="denied evidence",
     )
+    _assign_personal_scope(db_session, "alice@example.com", own, shared)
+    _assign_personal_scope(db_session, "bob@example.com", denied)
     db_session.add_all([own, shared, denied])
     db_session.add(
         FileShare(
@@ -470,6 +524,7 @@ def test_knowledge_status_hides_global_point_count_from_tenant(db_session):
         file_size=1,
         mime_type="application/pdf",
     )
+    _assign_personal_scope(db_session, "alice@example.com", record)
     db_session.add(record)
     db_session.commit()
     request = Request({"type": "http", "headers": []})
@@ -509,6 +564,8 @@ def test_keyword_research_scopes_meilisearch_before_ranking(db_session):
         mime_type="application/pdf",
         ocr_text="Flight booking to London",
     )
+    _assign_personal_scope(db_session, "alice@example.com", own)
+    _assign_personal_scope(db_session, "bob@example.com", other)
     db_session.add_all([own, other])
     db_session.commit()
     request = Request({"type": "http", "headers": []})
@@ -1050,6 +1107,8 @@ def test_metadata_candidates_preserve_owner_isolation(db_session):
         mime_type="application/pdf",
         ocr_text="Bob source text",
     )
+    _assign_personal_scope(db_session, "alice@example.com", own)
+    _assign_personal_scope(db_session, "bob@example.com", other)
     db_session.add_all([own, other])
     db_session.commit()
     request = Request({"type": "http", "headers": []})

--- a/tests/test_vector_knowledge.py
+++ b/tests/test_vector_knowledge.py
@@ -367,9 +367,11 @@ def test_qdrant_search_denies_all_when_user_has_no_tribe_membership():
         )
 
     no_scope = {"key": "tribe_id", "match": {"value": "__no_authorized_tribe__"}}
+    no_tenant = {"key": "tenant_id", "match": {"value": "__no_authorized_tenant__"}}
     conditions = request.call_args.args[2]["filter"]["should"]
     assert conditions[0] == {"must": [no_scope, {"key": "owner_id", "match": {"value": "alice@example.com"}}]}
-    assert all(no_scope in condition["must"] for condition in conditions)
+    assert no_scope in conditions[1]["must"]
+    assert no_tenant in conditions[2]["must"]
 
 
 def test_qdrant_search_keeps_legacy_owner_points_during_scope_transition():

--- a/tests/test_views_files_comprehensive.py
+++ b/tests/test_views_files_comprehensive.py
@@ -2091,6 +2091,11 @@ class TestOwnerDisplayAndClaim:
     """Tests that owner info and claim button appear correctly on file views."""
 
     def _make_file(self, db_session, owner_id=None) -> FileRecord:
+        from app.utils.tribe_scope import ensure_document_scope, ensure_personal_scope
+
+        tenant_id, tribe_id = ensure_document_scope(db_session, owner_id)
+        if owner_id is None:
+            ensure_personal_scope(db_session, "viewer@example.com", tenant_id)
         file_rec = FileRecord(
             filehash=uuid.uuid4().hex,
             original_filename="doc.pdf",
@@ -2098,6 +2103,8 @@ class TestOwnerDisplayAndClaim:
             file_size=512,
             mime_type="application/pdf",
             owner_id=owner_id,
+            tenant_id=tenant_id,
+            tribe_id=tribe_id,
         )
         db_session.add(file_rec)
         db_session.commit()


### PR DESCRIPTION
## Summary
- add mandatory tenant and Tribe scope to every file while retaining `FileRecord.is_private` as the canonical privacy flag
- backfill existing owners into stable personal Tribes and quarantine unowned intake
- enforce Tribe membership before owner/public visibility in SQL and Qdrant, without an administrator bypass
- document the access order and remaining Tribe administration work

## Validation
- Ruff checks for all touched Python files
- 151 targeted multi-user, sharing, vector knowledge, Tribe scope, and migration tests
- explicit migration exercise from schema 059 to 060 with owned and unowned documents

Part of #1146
Part of #1147