### PR TITLE
test: model quarantine membership for claim views

### DIFF
--- a/tests/test_views_files_comprehensive.py
+++ b/tests/test_views_files_comprehensive.py
@@ -2091,11 +2091,19 @@ class TestOwnerDisplayAndClaim:
     """Tests that owner info and claim button appear correctly on file views."""
 
     def _make_file(self, db_session, owner_id=None) -> FileRecord:
-        from app.utils.tribe_scope import ensure_document_scope, ensure_personal_scope
+        from app.utils.tribe_scope import ensure_document_scope, ensure_tribe_membership
 
         tenant_id, tribe_id = ensure_document_scope(db_session, owner_id)
         if owner_id is None:
-            ensure_personal_scope(db_session, "viewer@example.com", tenant_id)
+            # Claim actions are available only to users admitted to the shared
+            # intake quarantine. Tenant membership by itself must not expose
+            # unowned documents from another Tribe.
+            ensure_tribe_membership(
+                db_session,
+                tenant_id=tenant_id,
+                tribe_id=tribe_id,
+                user_id="viewer@example.com",
+            )
         file_rec = FileRecord(
             filehash=uuid.uuid4().hex,
             original_filename="doc.pdf",


### PR DESCRIPTION
Follow-up to #1155.

The full suite correctly rejected the old claim-view fixture: tenant membership alone no longer grants access to unowned quarantine intake. The fixture now explicitly admits the test viewer to the quarantine Tribe, matching the production access model.

No runtime behavior changes.

Validation: 24 related tests, Ruff, and diff check pass locally.