### PR TITLE
Add secure agentic and Terraform setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,15 @@ MANIFEST
 *.key
 *.p12
 *.pfx
+
+# Terraform working directories and local state (provider lock files are kept)
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+
+# Helm dependencies are restored from Chart.lock
+helm/*/charts/*.tgz
 id_rsa*
 ssh_host_*
 

--- a/app/agentic_setup.py
+++ b/app/agentic_setup.py
@@ -1,0 +1,42 @@
+"""Local entry point for planning and applying declarative setup manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from app.database import SessionLocal, init_db
+from app.utils.setup_manifest import (
+    SetupManifestError,
+    apply_setup_manifest,
+    load_setup_manifest,
+    plan_setup_manifest,
+    resolve_setup_manifest,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plan or apply an idempotent DocuElevate setup manifest")
+    parser.add_argument("mode", choices=("plan", "apply"))
+    parser.add_argument("manifest", help="Path to a DocuElevateSetup JSON manifest")
+    args = parser.parse_args()
+
+    try:
+        init_db()
+        resolved = resolve_setup_manifest(load_setup_manifest(args.manifest))
+        db = SessionLocal()
+        try:
+            result = plan_setup_manifest(db, resolved) if args.mode == "plan" else apply_setup_manifest(db, resolved)
+        finally:
+            db.close()
+        print(json.dumps(result, indent=2, sort_keys=True))
+        if not result.get("success"):
+            raise SystemExit(2)
+    except SetupManifestError as exc:
+        print(json.dumps({"success": False, "error": str(exc)}, indent=2), file=sys.stderr)
+        raise SystemExit(2) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -3695,14 +3695,21 @@ def save_setting_to_db(db: Session, key: str, value: Optional[str], changed_by: 
         metadata = get_setting_metadata(key)
         storage_value = value
 
-        if metadata.get("sensitive", False) and value:
-            from app.utils.encryption import encrypt_value, is_encryption_available
+        is_sensitive = bool(metadata.get("sensitive", False))
+        if is_sensitive and value:
+            from app.utils.encryption import encrypt_value, is_encrypted, is_encryption_available
 
             if is_encryption_available():
                 storage_value = encrypt_value(value)
+                if not is_encrypted(storage_value):
+                    logger.error("Refusing to store sensitive setting %s because encryption failed", key)
+                    db.rollback()
+                    return False
                 logger.debug(f"Encrypted sensitive setting: {key}")
             else:
-                logger.warning(f"Storing sensitive setting {key} in plaintext (encryption unavailable)")
+                logger.error("Refusing to store sensitive setting %s because encryption is unavailable", key)
+                db.rollback()
+                return False
 
         setting = db.query(ApplicationSettings).filter(ApplicationSettings.key == key).first()
         old_storage_value = setting.value if setting else None
@@ -3713,24 +3720,13 @@ def save_setting_to_db(db: Session, key: str, value: Optional[str], changed_by: 
             setting = ApplicationSettings(key=key, value=storage_value)
             db.add(setting)
 
-        # Determine human-readable old value for audit log (decrypt if needed)
-        old_display_value = None
-        if old_storage_value is not None:
-            if metadata.get("sensitive", False):
-                try:
-                    from app.utils.encryption import decrypt_value
-
-                    old_display_value = decrypt_value(old_storage_value)
-                except Exception:
-                    old_display_value = old_storage_value
-            else:
-                old_display_value = old_storage_value
-
         # Write audit log entry
         audit_entry = SettingsAuditLog(
             key=key,
-            old_value=old_display_value,
-            new_value=value,
+            # Sensitive history stays encrypted at rest. API responses redact
+            # it, while rollback decrypts only the selected value in memory.
+            old_value=old_storage_value,
+            new_value=storage_value,
             changed_by=changed_by,
             action="update",
         )
@@ -3794,25 +3790,11 @@ def delete_setting_from_db(db: Session, key: str, changed_by: str = "system") ->
     try:
         setting = db.query(ApplicationSettings).filter(ApplicationSettings.key == key).first()
         if setting:
-            # Capture old value for audit log (decrypt if sensitive)
-            metadata = get_setting_metadata(key)
-            old_display_value = None
-            if setting.value is not None:
-                if metadata.get("sensitive", False):
-                    try:
-                        from app.utils.encryption import decrypt_value
-
-                        old_display_value = decrypt_value(setting.value)
-                    except Exception:
-                        old_display_value = setting.value
-                else:
-                    old_display_value = setting.value
-
             db.delete(setting)
 
             audit_entry = SettingsAuditLog(
                 key=key,
-                old_value=old_display_value,
+                old_value=setting.value,
                 new_value=None,
                 changed_by=changed_by,
                 action="delete",
@@ -4056,6 +4038,16 @@ def rollback_setting(db: Session, key: str, history_id: int, changed_by: str = "
             # The old value was empty – remove the current db value to revert to ENV/default
             return delete_setting_from_db(db, key, changed_by=changed_by)
         else:
+            if get_setting_metadata(key).get("sensitive", False):
+                from app.utils.encryption import decrypt_value, is_encrypted
+
+                if not is_encrypted(target_value):
+                    logger.error("Rollback refused for legacy plaintext sensitive history: %s", key)
+                    return False
+                target_value = decrypt_value(target_value)
+                if target_value in {"[ENCRYPTED - Cannot decrypt]", "[DECRYPTION FAILED]"}:
+                    logger.error("Rollback could not decrypt sensitive history: %s", key)
+                    return False
             return save_setting_to_db(db, key, target_value, changed_by=changed_by)
     except SQLAlchemyError as e:
         logger.error(f"Error rolling back setting {key} to history entry {history_id}: {e}")

--- a/app/utils/setup_manifest.py
+++ b/app/utils/setup_manifest.py
@@ -1,0 +1,420 @@
+"""Declarative, idempotent setup manifests for humans and automation agents."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import Any, Mapping
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models import LocalUser, Tenant, Tribe, TribeMembership, UserProfile
+from app.utils.local_auth import hash_password, verify_password
+from app.utils.settings_service import (
+    SETTING_METADATA,
+    get_setting_from_db,
+    get_setting_metadata,
+    save_setting_to_db,
+    validate_setting_value,
+)
+from app.utils.settings_sync import notify_settings_updated
+from app.utils.setup_wizard import get_missing_required_settings
+from app.utils.tribe_scope import DEFAULT_TENANT_ID, ensure_personal_scope, personal_tribe_id
+
+MANIFEST_API_VERSION = "docuelevate.org/v1alpha1"
+MANIFEST_KIND = "DocuElevateSetup"
+BOOTSTRAP_SETTING_KEYS = {"database_url", "session_secret"}
+_ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+_USERNAME_RE = re.compile(r"^[A-Za-z0-9_.-]{2,64}$")
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_MAX_MANIFEST_BYTES = 1024 * 1024
+
+
+class SetupManifestError(ValueError):
+    """Raised when a setup manifest is unsafe or structurally invalid."""
+
+
+def load_setup_manifest(path: str | Path) -> dict[str, Any]:
+    """Read a bounded JSON setup manifest from disk."""
+    manifest_path = Path(path)
+    if manifest_path.suffix.lower() != ".json":
+        raise SetupManifestError("Setup manifests must use the .json extension")
+    if manifest_path.stat().st_size > _MAX_MANIFEST_BYTES:
+        raise SetupManifestError("Setup manifest exceeds the 1 MiB limit")
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SetupManifestError(f"Could not read setup manifest: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SetupManifestError("Setup manifest root must be an object")
+    return payload
+
+
+def _scalar_string(value: Any, *, path: str) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (str, int, float)) and not isinstance(value, complex):
+        return str(value)
+    raise SetupManifestError(f"{path} must be a string, number, boolean, or fromEnv reference")
+
+
+def _resolve_value(value: Any, *, path: str, environ: Mapping[str, str]) -> tuple[str, str | None]:
+    if not isinstance(value, dict):
+        return _scalar_string(value, path=path), None
+    if set(value) != {"fromEnv"}:
+        raise SetupManifestError(f"{path} supports only {{\"fromEnv\": \"NAME\"}} references")
+    env_name = value["fromEnv"]
+    if not isinstance(env_name, str) or not _ENV_NAME_RE.fullmatch(env_name):
+        raise SetupManifestError(f"{path}.fromEnv must be a valid environment variable name")
+    resolved = environ.get(env_name)
+    if not resolved:
+        raise SetupManifestError(f"Required environment variable {env_name} is not set")
+    return resolved, env_name
+
+
+def _validate_root(manifest: dict[str, Any]) -> dict[str, Any]:
+    allowed_root = {"apiVersion", "kind", "metadata", "spec"}
+    unknown = sorted(set(manifest) - allowed_root)
+    if unknown:
+        raise SetupManifestError(f"Unknown manifest fields: {', '.join(unknown)}")
+    if manifest.get("apiVersion") != MANIFEST_API_VERSION:
+        raise SetupManifestError(f"apiVersion must be {MANIFEST_API_VERSION}")
+    if manifest.get("kind") != MANIFEST_KIND:
+        raise SetupManifestError(f"kind must be {MANIFEST_KIND}")
+    metadata = manifest.get("metadata")
+    if not isinstance(metadata, dict) or not str(metadata.get("name") or "").strip():
+        raise SetupManifestError("metadata.name is required")
+    unknown_metadata = sorted(set(metadata) - {"name"})
+    if unknown_metadata:
+        raise SetupManifestError(f"Unknown metadata fields: {', '.join(unknown_metadata)}")
+    spec = manifest.get("spec")
+    if not isinstance(spec, dict):
+        raise SetupManifestError("spec must be an object")
+    unknown_spec = sorted(set(spec) - {"completeSetup", "settings", "users", "tribes"})
+    if unknown_spec:
+        raise SetupManifestError(f"Unsupported spec fields: {', '.join(unknown_spec)}")
+    if "completeSetup" in spec and not isinstance(spec["completeSetup"], bool):
+        raise SetupManifestError("spec.completeSetup must be a boolean")
+    return spec
+
+
+def resolve_setup_manifest(
+    manifest: dict[str, Any],
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Validate and resolve secret references without writing anything."""
+    env = environ if environ is not None else os.environ
+    spec = _validate_root(manifest)
+    resolved_settings: list[dict[str, Any]] = []
+    raw_settings = spec.get("settings", {})
+    if not isinstance(raw_settings, dict):
+        raise SetupManifestError("spec.settings must be an object")
+    for key, raw_value in raw_settings.items():
+        if key not in SETTING_METADATA:
+            raise SetupManifestError(f"Unknown setting: {key}")
+        if key in BOOTSTRAP_SETTING_KEYS:
+            raise SetupManifestError(f"{key} is deployment bootstrap state and cannot be stored by a manifest")
+        value, env_name = _resolve_value(raw_value, path=f"spec.settings.{key}", environ=env)
+        metadata = get_setting_metadata(key)
+        if metadata.get("sensitive") and env_name is None:
+            raise SetupManifestError(f"Sensitive setting {key} must use a fromEnv reference")
+        valid, error = validate_setting_value(key, value)
+        if not valid:
+            raise SetupManifestError(error or f"Invalid setting: {key}")
+        resolved_settings.append({"key": key, "value": value, "from_env": env_name})
+
+    resolved_users: list[dict[str, Any]] = []
+    raw_users = spec.get("users", [])
+    if not isinstance(raw_users, list):
+        raise SetupManifestError("spec.users must be an array")
+    seen_emails: set[str] = set()
+    seen_usernames: set[str] = set()
+    for index, raw_user in enumerate(raw_users):
+        path = f"spec.users[{index}]"
+        if not isinstance(raw_user, dict):
+            raise SetupManifestError(f"{path} must be an object")
+        unknown_user = sorted(set(raw_user) - {"email", "username", "displayName", "password", "isAdmin"})
+        if unknown_user:
+            raise SetupManifestError(f"Unknown fields in {path}: {', '.join(unknown_user)}")
+        email = str(raw_user.get("email") or "").strip().lower()
+        username = str(raw_user.get("username") or "").strip()
+        if not _EMAIL_RE.fullmatch(email):
+            raise SetupManifestError(f"{path}.email is invalid")
+        if not _USERNAME_RE.fullmatch(username):
+            raise SetupManifestError(f"{path}.username is invalid")
+        if email in seen_emails:
+            raise SetupManifestError(f"Duplicate user email: {email}")
+        if username in seen_usernames:
+            raise SetupManifestError(f"Duplicate username: {username}")
+        seen_emails.add(email)
+        seen_usernames.add(username)
+        if "isAdmin" in raw_user and not isinstance(raw_user["isAdmin"], bool):
+            raise SetupManifestError(f"{path}.isAdmin must be a boolean")
+        password, password_env = _resolve_value(raw_user.get("password"), path=f"{path}.password", environ=env)
+        if password_env is None:
+            raise SetupManifestError(f"{path}.password must use a fromEnv reference")
+        if len(password) < 12:
+            raise SetupManifestError(f"{path}.password must contain at least 12 characters")
+        resolved_users.append(
+            {
+                "email": email,
+                "username": username,
+                "display_name": str(raw_user.get("displayName") or username).strip(),
+                "password": password,
+                "password_from_env": password_env,
+                "is_admin": bool(raw_user.get("isAdmin", False)),
+            }
+        )
+
+    resolved_tribes: list[dict[str, Any]] = []
+    raw_tribes = spec.get("tribes", [])
+    if not isinstance(raw_tribes, list):
+        raise SetupManifestError("spec.tribes must be an array")
+    seen_tribe_names: set[str] = set()
+    for index, raw_tribe in enumerate(raw_tribes):
+        path = f"spec.tribes[{index}]"
+        if not isinstance(raw_tribe, dict) or set(raw_tribe) - {"name", "members"}:
+            raise SetupManifestError(f"{path} supports only name and members")
+        name = str(raw_tribe.get("name") or "").strip()
+        members = raw_tribe.get("members", [])
+        if not name or not isinstance(members, list) or not members:
+            raise SetupManifestError(f"{path} requires a name and at least one member")
+        if name in seen_tribe_names:
+            raise SetupManifestError(f"Duplicate Tribe name: {name}")
+        seen_tribe_names.add(name)
+        resolved_members = []
+        seen_member_emails: set[str] = set()
+        for member_index, member in enumerate(members):
+            if not isinstance(member, dict) or set(member) - {"email", "role"}:
+                raise SetupManifestError(f"{path}.members[{member_index}] supports only email and role")
+            email = str(member.get("email") or "").strip().lower()
+            role = str(member.get("role") or "member").strip().lower()
+            if not _EMAIL_RE.fullmatch(email) or role not in {"admin", "member"}:
+                raise SetupManifestError(f"Invalid member in {path}.members[{member_index}]")
+            if email in seen_member_emails:
+                raise SetupManifestError(f"Duplicate member in {path}: {email}")
+            seen_member_emails.add(email)
+            resolved_members.append({"email": email, "role": role})
+        if not any(member["role"] == "admin" for member in resolved_members):
+            raise SetupManifestError(f"{path} requires at least one admin member")
+        resolved_tribes.append({"name": name, "members": resolved_members})
+
+    return {
+        "name": str(manifest["metadata"]["name"]).strip(),
+        "complete_setup": bool(spec.get("completeSetup", False)),
+        "settings": resolved_settings,
+        "users": resolved_users,
+        "tribes": resolved_tribes,
+    }
+
+
+def _redacted_setting(setting: dict[str, Any]) -> str:
+    return "<resolved-secret>" if setting["from_env"] else setting["value"]
+
+
+def _effective_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def plan_setup_manifest(db: Session, resolved: dict[str, Any]) -> dict[str, Any]:
+    """Return a secret-safe desired-state diff."""
+    changes: list[dict[str, Any]] = []
+    desired_user_emails = {user["email"] for user in resolved["users"]}
+    for tribe in resolved["tribes"]:
+        for member in tribe["members"]:
+            if member["email"] in desired_user_emails:
+                continue
+            if db.query(UserProfile).filter(UserProfile.user_id == member["email"]).first() is None:
+                raise SetupManifestError(f"Tribe member does not exist: {member['email']}")
+    for setting in resolved["settings"]:
+        key = setting["key"]
+        current = get_setting_from_db(db, key)
+        if current is None:
+            current = getattr(settings, key, None)
+        status = (
+            "unchanged"
+            if _effective_string(current) == setting["value"]
+            else ("create" if current is None else "update")
+        )
+        changes.append({"resource": "setting", "key": key, "status": status, "desired": _redacted_setting(setting)})
+
+    for user in resolved["users"]:
+        existing = db.query(LocalUser).filter(LocalUser.email == user["email"]).first()
+        username_owner = db.query(LocalUser).filter(LocalUser.username == user["username"]).first()
+        if username_owner is not None and (existing is None or username_owner.id != existing.id):
+            raise SetupManifestError(f"Username already belongs to another user: {user['username']}")
+        status = "create"
+        if existing is not None:
+            has_personal_scope = (
+                db.query(TribeMembership)
+                .filter(
+                    TribeMembership.tribe_id == personal_tribe_id(user["email"], DEFAULT_TENANT_ID),
+                    TribeMembership.user_id == user["email"],
+                    TribeMembership.role == "admin",
+                )
+                .first()
+                is not None
+            )
+            unchanged = (
+                existing.username == user["username"]
+                and (existing.display_name or existing.username) == user["display_name"]
+                and bool(existing.is_admin) == user["is_admin"]
+                and bool(existing.is_active)
+                and verify_password(user["password"], existing.hashed_password)
+                and has_personal_scope
+            )
+            status = "unchanged" if unchanged else "update"
+        changes.append({"resource": "user", "key": user["email"], "status": status, "desired": "configured"})
+
+    for tribe in resolved["tribes"]:
+        existing = db.query(Tribe).filter(Tribe.tenant_id == DEFAULT_TENANT_ID, Tribe.name == tribe["name"]).first()
+        status = "create"
+        if existing is not None:
+            current_members = {
+                membership.user_id: membership.role
+                for membership in db.query(TribeMembership).filter(TribeMembership.tribe_id == existing.id).all()
+            }
+            desired_members = {member["email"]: member["role"] for member in tribe["members"]}
+            status = "unchanged" if current_members == desired_members else "update"
+        changes.append(
+            {
+                "resource": "tribe",
+                "key": tribe["name"],
+                "status": status,
+                "desired": {"members": len(tribe["members"])},
+            }
+        )
+
+    return {
+        "success": True,
+        "mode": "plan",
+        "manifest": resolved["name"],
+        "changes": changes,
+        "summary": {
+            "create": sum(change["status"] == "create" for change in changes),
+            "update": sum(change["status"] == "update" for change in changes),
+            "unchanged": sum(change["status"] == "unchanged" for change in changes),
+        },
+    }
+
+
+def apply_setup_manifest(db: Session, resolved: dict[str, Any]) -> dict[str, Any]:
+    """Apply an already validated manifest and return a secret-safe report."""
+    plan = plan_setup_manifest(db, resolved)
+    applied: list[dict[str, str]] = []
+    restart_required: list[str] = []
+
+    for setting in resolved["settings"]:
+        planned = next(change for change in plan["changes"] if change["resource"] == "setting" and change["key"] == setting["key"])
+        if planned["status"] == "unchanged":
+            continue
+        if not save_setting_to_db(db, setting["key"], setting["value"], changed_by="agentic_setup"):
+            raise SetupManifestError(f"Failed to persist setting {setting['key']}")
+        applied.append({"resource": "setting", "key": setting["key"]})
+        if get_setting_metadata(setting["key"]).get("restart_required"):
+            restart_required.append(setting["key"])
+
+    for user in resolved["users"]:
+        planned = next(
+            change for change in plan["changes"] if change["resource"] == "user" and change["key"] == user["email"]
+        )
+        if planned["status"] == "unchanged":
+            continue
+        existing = db.query(LocalUser).filter(LocalUser.email == user["email"]).first()
+        if existing is None:
+            existing = LocalUser(email=user["email"], username=user["username"])
+            db.add(existing)
+        elif existing.username != user["username"]:
+            duplicate = db.query(LocalUser).filter(LocalUser.username == user["username"], LocalUser.id != existing.id).first()
+            if duplicate:
+                raise SetupManifestError(f"Username already belongs to another user: {user['username']}")
+        existing.username = user["username"]
+        existing.display_name = user["display_name"]
+        existing.hashed_password = hash_password(user["password"])
+        existing.is_active = True
+        existing.is_admin = user["is_admin"]
+        profile = db.query(UserProfile).filter(UserProfile.user_id == user["email"]).first()
+        if profile is None:
+            profile = UserProfile(user_id=user["email"])
+            db.add(profile)
+        profile.display_name = user["display_name"]
+        ensure_personal_scope(db, user["email"], DEFAULT_TENANT_ID)
+        applied.append({"resource": "user", "key": user["email"]})
+    db.commit()
+
+    tenant = db.query(Tenant).filter(Tenant.id == DEFAULT_TENANT_ID).first()
+    if tenant is None:
+        tenant = Tenant(id=DEFAULT_TENANT_ID, name="Default tenant")
+        db.add(tenant)
+        db.commit()
+    for tribe_spec in resolved["tribes"]:
+        planned = next(
+            change
+            for change in plan["changes"]
+            if change["resource"] == "tribe" and change["key"] == tribe_spec["name"]
+        )
+        if planned["status"] == "unchanged":
+            continue
+        tribe = db.query(Tribe).filter(Tribe.tenant_id == DEFAULT_TENANT_ID, Tribe.name == tribe_spec["name"]).first()
+        if tribe is None:
+            tribe = Tribe(
+                id=str(uuid.uuid5(uuid.NAMESPACE_URL, f"docuelevate:tribe:{DEFAULT_TENANT_ID}:{tribe_spec['name']}")),
+                tenant_id=DEFAULT_TENANT_ID,
+                name=tribe_spec["name"],
+            )
+            db.add(tribe)
+            db.flush()
+        desired_emails = {member["email"] for member in tribe_spec["members"]}
+        existing_members = db.query(TribeMembership).filter(TribeMembership.tribe_id == tribe.id).all()
+        for membership in existing_members:
+            if membership.user_id not in desired_emails:
+                db.delete(membership)
+        for member in tribe_spec["members"]:
+            if db.query(UserProfile).filter(UserProfile.user_id == member["email"]).first() is None:
+                raise SetupManifestError(f"Tribe member does not exist: {member['email']}")
+            membership = (
+                db.query(TribeMembership)
+                .filter(TribeMembership.tribe_id == tribe.id, TribeMembership.user_id == member["email"])
+                .first()
+            )
+            if membership is None:
+                membership = TribeMembership(
+                    tenant_id=DEFAULT_TENANT_ID,
+                    tribe_id=tribe.id,
+                    user_id=member["email"],
+                )
+                db.add(membership)
+            membership.role = member["role"]
+        applied.append({"resource": "tribe", "key": tribe_spec["name"]})
+    db.commit()
+
+    notify_settings_updated()
+    missing = get_missing_required_settings()
+    setup_completed = False
+    if resolved["complete_setup"] and not missing:
+        if not save_setting_to_db(db, "_setup_wizard_completed", "true", changed_by="agentic_setup"):
+            raise SetupManifestError("Failed to record setup completion")
+        setup_completed = True
+        notify_settings_updated()
+
+    return {
+        "success": not (resolved["complete_setup"] and missing),
+        "mode": "apply",
+        "manifest": resolved["name"],
+        "applied": applied,
+        "setup_completed": setup_completed,
+        "missing_required_settings": missing,
+        "restart_required": sorted(set(restart_required)),
+        "next_actions": [
+            "Complete interactive OAuth grants in the browser for integrations that require user consent."
+        ],
+    }

--- a/app/utils/setup_manifest.py
+++ b/app/utils/setup_manifest.py
@@ -66,7 +66,7 @@ def _resolve_value(value: Any, *, path: str, environ: Mapping[str, str]) -> tupl
     if not isinstance(value, dict):
         return _scalar_string(value, path=path), None
     if set(value) != {"fromEnv"}:
-        raise SetupManifestError(f"{path} supports only {{\"fromEnv\": \"NAME\"}} references")
+        raise SetupManifestError(f'{path} supports only {{"fromEnv": "NAME"}} references')
     env_name = value["fromEnv"]
     if not isinstance(env_name, str) or not _ENV_NAME_RE.fullmatch(env_name):
         raise SetupManifestError(f"{path}.fromEnv must be a valid environment variable name")
@@ -314,7 +314,9 @@ def apply_setup_manifest(db: Session, resolved: dict[str, Any]) -> dict[str, Any
     restart_required: list[str] = []
 
     for setting in resolved["settings"]:
-        planned = next(change for change in plan["changes"] if change["resource"] == "setting" and change["key"] == setting["key"])
+        planned = next(
+            change for change in plan["changes"] if change["resource"] == "setting" and change["key"] == setting["key"]
+        )
         if planned["status"] == "unchanged":
             continue
         if not save_setting_to_db(db, setting["key"], setting["value"], changed_by="agentic_setup"):
@@ -334,7 +336,9 @@ def apply_setup_manifest(db: Session, resolved: dict[str, Any]) -> dict[str, Any
             existing = LocalUser(email=user["email"], username=user["username"])
             db.add(existing)
         elif existing.username != user["username"]:
-            duplicate = db.query(LocalUser).filter(LocalUser.username == user["username"], LocalUser.id != existing.id).first()
+            duplicate = (
+                db.query(LocalUser).filter(LocalUser.username == user["username"], LocalUser.id != existing.id).first()
+            )
             if duplicate:
                 raise SetupManifestError(f"Username already belongs to another user: {user['username']}")
         existing.username = user["username"]

--- a/app/utils/setup_wizard.py
+++ b/app/utils/setup_wizard.py
@@ -159,8 +159,9 @@ def is_setup_required() -> bool:
 
     except Exception as e:
         logger.error(f"Error checking if setup required: {e}")
-        # If we can't check, assume setup is not required (fail open)
-        return False
+        # Never expose an installation whose security state could not be
+        # determined. The setup boundary must fail closed.
+        return True
 
 
 def get_missing_required_settings() -> List[str]:

--- a/app/views/general.py
+++ b/app/views/general.py
@@ -33,10 +33,9 @@ async def serve_index(request: Request, db: Session = Depends(get_db)):
     # Check if setup was explicitly skipped
     setup_skipped = get_setting_from_db(db, "_setup_wizard_skipped")
 
-    # Check setup completion query param
-    setup_complete = request.query_params.get("setup") == "complete"
-
-    if not setup_skipped and not setup_complete and is_setup_required():
+    # Setup state is server-owned. A query parameter must never be able to
+    # bypass an incomplete first-run configuration.
+    if not setup_skipped and is_setup_required():
         logger.info("System requires initial setup, redirecting to wizard")
         return RedirectResponse(url="/setup?step=1", status_code=303)
 

--- a/app/views/wizard.py
+++ b/app/views/wizard.py
@@ -3,18 +3,45 @@ Setup wizard views for initial system configuration.
 """
 
 import logging
+from urllib.parse import quote
 
 from fastapi import Depends, Form, Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
-from app.utils.settings_service import save_setting_to_db
+from app.config import settings as app_settings
+from app.utils.settings_service import get_setting_from_db, save_setting_to_db
 from app.utils.settings_sync import notify_settings_updated
-from app.utils.setup_wizard import get_wizard_steps
+from app.utils.setup_wizard import get_missing_required_settings, get_wizard_steps, is_setup_required
 from app.views.base import APIRouter, get_db, templates
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+_BOOTSTRAP_SESSION_KEY = "_setup_wizard_bootstrap"
+_COMPLETED_SETTING_KEY = "_setup_wizard_completed"
+
+
+def _is_admin(request: Request) -> bool:
+    user = request.session.get("user")
+    return isinstance(user, dict) and bool(user.get("is_admin"))
+
+
+def _setup_access_allowed(request: Request, db: Session, *, begin_bootstrap: bool = False) -> bool:
+    """Allow a genuine first-run browser or an authenticated administrator."""
+    if not app_settings.auth_enabled or _is_admin(request):
+        return True
+    if request.session.get(_BOOTSTRAP_SESSION_KEY) is True:
+        return True
+    if begin_bootstrap and not get_setting_from_db(db, _COMPLETED_SETTING_KEY) and is_setup_required():
+        request.session[_BOOTSTRAP_SESSION_KEY] = True
+        return True
+    return False
+
+
+def _login_redirect(request: Request) -> RedirectResponse:
+    target = quote(str(request.url.path), safe="/")
+    return RedirectResponse(url=f"/login?next={target}", status_code=303)
 
 
 @router.get("/setup")
@@ -25,6 +52,9 @@ async def setup_wizard(request: Request, step: int = 1, db: Session = Depends(ge
     This wizard guides users through configuring essential settings
     needed for the system to operate properly.
     """
+    if not _setup_access_allowed(request, db, begin_bootstrap=step == 1):
+        return _login_redirect(request)
+
     # Get wizard steps
     wizard_steps = get_wizard_steps()
     max_step = max(wizard_steps.keys())
@@ -88,6 +118,9 @@ async def setup_wizard_save(request: Request, step: int = Form(...), db: Session
     """
     Save settings from the current wizard step.
     """
+    if not _setup_access_allowed(request, db):
+        return _login_redirect(request)
+
     try:
         # Get form data
         form_data = await request.form()
@@ -95,6 +128,17 @@ async def setup_wizard_save(request: Request, step: int = Form(...), db: Session
         # Get settings for current step
         wizard_steps = get_wizard_steps()
         current_settings = wizard_steps.get(step, [])
+
+        # Fresh installs must not advance past an empty required value. During
+        # an admin re-run an existing DB or environment value may be retained.
+        for setting in current_settings:
+            if not setting.get("required") or setting.get("bootstrap"):
+                continue
+            key = setting["key"]
+            submitted = str(form_data.get(key) or "").strip()
+            existing = get_setting_from_db(db, key) or getattr(app_settings, key, None)
+            if not submitted and not existing:
+                return RedirectResponse(url=f"/setup?step={step}&error=required_missing", status_code=303)
 
         # Save each setting from the form
         saved_count = 0
@@ -126,8 +170,25 @@ async def setup_wizard_save(request: Request, step: int = Form(...), db: Session
         next_step = step + 1
 
         if next_step > max_step:
-            # Setup complete, redirect to home
-            return RedirectResponse(url="/?setup=complete", status_code=303)
+            missing = get_missing_required_settings()
+            if missing:
+                missing_steps = {
+                    setting["key"]: setting.get("wizard_step", 1)
+                    for settings_for_step in wizard_steps.values()
+                    for setting in settings_for_step
+                }
+                first_missing_step = min(missing_steps.get(key, 1) for key in missing)
+                return RedirectResponse(
+                    url=f"/setup?step={first_missing_step}&error=required_missing",
+                    status_code=303,
+                )
+
+            save_setting_to_db(db, _COMPLETED_SETTING_KEY, "true", changed_by="setup_wizard")
+            notify_settings_updated()
+            request.session.pop(_BOOTSTRAP_SESSION_KEY, None)
+            if app_settings.auth_enabled:
+                return RedirectResponse(url="/login?setup=complete", status_code=303)
+            return RedirectResponse(url="/", status_code=303)
         else:
             # Go to next step
             return RedirectResponse(url=f"/setup?step={next_step}", status_code=303)
@@ -137,28 +198,26 @@ async def setup_wizard_save(request: Request, step: int = Form(...), db: Session
         return RedirectResponse(url=f"/setup?step={step}&error=save_failed", status_code=303)
 
 
-@router.get("/setup/skip")
-async def setup_wizard_skip(request: Request):
+@router.post("/setup/skip")
+async def setup_wizard_skip(request: Request, db: Session = Depends(get_db)):
     """
     Skip the setup wizard (for advanced users).
 
     Creates a marker to indicate setup was skipped.
     """
+    if app_settings.auth_enabled and not _is_admin(request):
+        return _login_redirect(request)
     try:
-        db = next(get_db())
-        try:
-            # Save a marker to indicate setup was skipped
-            save_setting_to_db(db, "_setup_wizard_skipped", "true")
-            logger.info("Setup wizard skipped by user")
-            return RedirectResponse(url="/", status_code=303)
-        finally:
-            db.close()
+        save_setting_to_db(db, "_setup_wizard_skipped", "true", changed_by="setup_wizard_admin")
+        notify_settings_updated()
+        logger.info("Setup wizard skipped by administrator")
+        return RedirectResponse(url="/", status_code=303)
     except Exception as e:
         logger.error(f"Error skipping setup wizard: {e}")
         return RedirectResponse(url="/", status_code=303)
 
 
-@router.get("/setup/undo-skip")
+@router.post("/setup/undo-skip")
 async def setup_wizard_undo_skip(request: Request, db: Session = Depends(get_db)):
     """
     Undo a previously skipped setup wizard.
@@ -167,10 +226,13 @@ async def setup_wizard_undo_skip(request: Request, db: Session = Depends(get_db)
     presented again on next visit to the home page.  Redirects to
     step 1 of the wizard immediately.
     """
+    if app_settings.auth_enabled and not _is_admin(request):
+        return _login_redirect(request)
     try:
         from app.utils.settings_service import delete_setting_from_db
 
         delete_setting_from_db(db, "_setup_wizard_skipped", changed_by="wizard_undo_skip")
+        notify_settings_updated()
         logger.info("Setup wizard skip marker removed; redirecting to wizard")
         return RedirectResponse(url="/setup?step=1", status_code=303)
     except Exception as e:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 name: docuelevate
 
 x-docuelevate-service: &docuelevate-service
+  image: ${DOCUELEVATE_IMAGE:-docuelevate:local}
   build:
     context: .
     dockerfile: Dockerfile
@@ -25,10 +26,10 @@ x-docuelevate-service: &docuelevate-service
     MULTI_USER_ENABLED: "true"
     ALLOW_LOCAL_SIGNUP: "true"
     UNOWNED_DOCS_VISIBLE_TO_ALL: "false"
-    EXTERNAL_HOSTNAME: localhost:8000
-    PUBLIC_BASE_URL: http://localhost:8000
+    EXTERNAL_HOSTNAME: localhost:${DOCUELEVATE_PORT:-8000}
+    PUBLIC_BASE_URL: http://localhost:${DOCUELEVATE_PORT:-8000}
   volumes:
-    - ${DOCUELEVATE_WORKDIR:-/var/docparse/workdir}:/workdir
+    - ${DOCUELEVATE_WORKDIR:-workdir-data}:/workdir
     - bootstrap-secrets:/run/docuelevate-bootstrap:ro
 
 services:
@@ -102,7 +103,7 @@ services:
     <<: *docuelevate-service
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips=*"]
     ports:
-      - "8000:8000"
+      - "${DOCUELEVATE_PORT:-8000}:8000"
     depends_on:
       bootstrap:
         condition: service_completed_successfully
@@ -201,6 +202,7 @@ services:
 
 volumes:
   bootstrap-secrets:
+  workdir-data:
   postgres-data:
   meilisearch-data:
   qdrant-data:

--- a/docs/AgenticSetup.md
+++ b/docs/AgenticSetup.md
@@ -1,0 +1,121 @@
+# Agentic setup
+
+DocuElevate can be configured declaratively by an automation agent. The agent
+describes the desired instance in a versioned JSON manifest, previews the exact
+changes, applies them idempotently, and verifies the resulting state. This uses
+the same validation, encrypted database storage and live worker invalidation as
+the browser wizard.
+
+The intended prompt is therefore practical: “Install DocuElevate as a Preprod
+Canary, create Christian and Julia, place both in the family Tribe, configure
+the AI provider and leave only interactive OAuth approvals for me.”
+
+## Safety contract
+
+- Always run `plan` before `apply`.
+- `DATABASE_URL` and `SESSION_SECRET` remain deployment bootstrap values. A
+  manifest cannot move them into the database it is trying to open.
+- Sensitive values are rejected when written directly into JSON. Use a
+  `fromEnv` reference and let the authorised process receive the value from a
+  secret manager.
+- Plans and apply reports never print resolved secret values.
+- Settings and their audit history are encrypted at rest. If encryption is not
+  available, a sensitive setting is rejected instead of falling back to
+  plaintext.
+- Reapplying the same manifest is a no-op. User passwords are verified, not
+  needlessly re-hashed on every run.
+- A manifest may create local users, their isolated personal Tribes and shared
+  Tribes. Documents are still bound to one tenant and one Tribe; this command
+  does not weaken document access rules.
+- User-consent OAuth grants cannot be faked by an agent. They are returned as
+  explicit next actions and completed through the normal browser OAuth flow.
+
+## Manifest format
+
+Start from
+[`examples/agentic-setup.preprod.json`](https://github.com/christianlouis/DocuElevate/blob/main/examples/agentic-setup.preprod.json).
+The current schema is `docuelevate.org/v1alpha1` with kind
+`DocuElevateSetup`. Unknown fields and unsupported resources fail validation;
+they are never silently ignored.
+
+Automation can validate structure and generate forms from the published
+[`v1alpha1` JSON Schema](https://github.com/christianlouis/DocuElevate/blob/main/schemas/docuelevate-setup-v1alpha1.schema.json).
+The application additionally validates setting names, types, allowed values,
+secret handling, uniqueness and database conflicts at plan time.
+
+`spec.settings` accepts normal setting names. Non-sensitive scalars can be
+written directly. Sensitive values must use an environment reference:
+
+```json
+{
+  "openai_api_key": {
+    "fromEnv": "DOCUELEVATE_SETUP_OPENAI_API_KEY"
+  }
+}
+```
+
+`spec.users` creates or reconciles active local accounts. Passwords must use
+`fromEnv` and contain at least 12 characters. Every user receives a personal
+Tribe with an admin membership.
+
+`spec.tribes` reconciles shared Tribe membership by email. Removing a member
+from the manifest removes that membership from the named shared Tribe, but does
+not delete the user, personal Tribe or documents.
+
+## Agent workflow
+
+1. Clone DocuElevate and create a disposable, environment-qualified Compose
+   project as described in the deployment guide.
+2. Copy the example manifest outside the repository and change only the desired
+   non-secret parameters.
+3. Inject the referenced environment variables into the authorised process.
+   A secret manager may do this without revealing the values to the agent.
+4. Preview the exact desired-state change:
+
+   ```bash
+   docker-compose run --rm \
+     -v "$PWD/agentic-setup.preprod.json:/config/setup.json:ro" \
+     api python -m app.agentic_setup plan /config/setup.json
+   ```
+
+5. Review the JSON result. It reports `create`, `update` and `unchanged` items
+   and uses `<resolved-secret>` for credentials.
+6. Apply the same manifest:
+
+   ```bash
+   docker-compose run --rm \
+     -v "$PWD/agentic-setup.preprod.json:/config/setup.json:ro" \
+     api python -m app.agentic_setup apply /config/setup.json
+   ```
+
+7. Require `success: true` and `setup_completed: true`. Treat
+   `missing_required_settings`, `restart_required`, and `next_actions` as work
+   still to perform, not as a successful finished installation.
+8. Re-run `plan`. A converged instance reports only `unchanged` resources.
+9. Check `/api/diagnostic/healthz/ready`, log in as each configured user, upload
+   distinct documents, and prove that personal/private documents do not leak
+   across users or Tribes.
+
+## Terraform and Kubernetes
+
+The reference module in
+[`examples/terraform/kubernetes`](https://github.com/christianlouis/DocuElevate/tree/main/examples/terraform/kubernetes) deploys
+the Helm chart and can mount this same manifest into a post-install Job. Helm
+runs the DocuElevate `plan` first and only applies a valid plan. The Job is
+idempotent, so a later `terraform apply` converges instead of creating duplicate
+users or Tribes.
+
+Terraform receives only the names of two existing Kubernetes Secrets: a runtime
+bootstrap Secret and an optional short-lived setup Secret for the manifest's
+`fromEnv` values. This prevents database passwords, session keys, API keys and
+initial user passwords from being copied into Terraform state. See the
+[Terraform deployment guide](TerraformDeployment.md) for the complete contract.
+
+## What remains interactive
+
+OAuth application credentials can be supplied as settings or deployment
+secrets. A user's Dropbox, Google Drive or OneDrive consent still requires that
+user to authenticate with the provider. An agent should open or hand off those
+flows, then continue validation after the callback has stored the encrypted
+grant in the database. It must never invent, scrape or copy a user's OAuth
+grant from another installation.

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -7,6 +7,7 @@ This guide covers all supported deployment methods for DocuElevate.
 - [Prerequisites](#prerequisites)
 - [Docker Compose Deployment](#docker-compose-deployment) *(recommended for single-server)*
 - [Kubernetes / Helm Deployment](#kubernetes--helm-deployment) *(recommended for production scale-out)*
+- [Terraform Deployment](#terraform-deployment) *(declarative Kubernetes deployment)*
 - [Production Considerations](#production-considerations)
 - [Scaling](#scaling)
 - [Backup Procedures](#backup-procedures)
@@ -56,9 +57,10 @@ GOOGLE_CLIENT_ID=...
 GOOGLE_CLIENT_SECRET=...
 ```
 
-For upgrade compatibility, documents continue to live under the host path
-`/var/docparse/workdir`. A new installation can choose another persistent host
-path without changing the Compose file:
+Fresh installations store documents in the private `workdir-data` Docker named
+volume. This avoids host-specific paths and makes a disposable Canary safe to
+create and remove. Existing operators who intentionally want a host directory
+can opt in without changing the Compose file:
 
 ```dotenv
 DOCUELEVATE_WORKDIR=/srv/docuelevate/workdir
@@ -67,6 +69,24 @@ DOCUELEVATE_WORKDIR=/srv/docuelevate/workdir
 The containers themselves keep `/workdir` as their working directory, so a
 legacy relative SQLite `DATABASE_URL` also continues to resolve against the
 persisted document path during an upgrade.
+
+Run a parallel disposable Canary on another local port without changing the
+Compose file or colliding with an existing DocuElevate installation:
+
+```bash
+COMPOSE_PROJECT_NAME=docuelevate-canary-preprod \
+DOCUELEVATE_PORT=8180 \
+docker-compose up -d --build
+```
+
+The browser journey is then available at `http://localhost:8180`, and generated
+callback/base URLs use the same port automatically. Remove the complete Canary,
+including its generated bootstrap secret and all named data volumes, with:
+
+```bash
+COMPOSE_PROJECT_NAME=docuelevate-canary-preprod \
+docker-compose down --volumes --remove-orphans
+```
 
 See the [Configuration Guide](ConfigurationGuide.md) for all optional settings.
 
@@ -98,6 +118,10 @@ wizard. Then create normal user accounts and follow the per-user onboarding
 journey. Multi-user isolation is enabled by default and unowned documents are
 not visible to ordinary users.
 
+For automated or AI-operated installations, use the versioned
+[Agentic setup](AgenticSetup.md) manifest. Its `plan` and `apply` commands use
+the same database validation and encryption contract as the browser journey.
+
 The API readiness endpoint is
 `http://localhost:8000/api/diagnostic/healthz/ready`; optional API documentation
 is available at `http://localhost:8000/docs` when enabled.
@@ -114,6 +138,8 @@ The Helm chart at `helm/docuelevate/` packages all components into a single, con
 - Persistent volumes for workdir and Meilisearch data
 - Alembic database migration Job (pre-install/upgrade hook)
 - TLS Ingress via any controller (nginx, Traefik, etc.)
+- An optional, idempotent agentic setup Job after migrations
+- Existing Kubernetes Secrets managed by 1Password / External Secrets
 
 ### Prerequisites
 
@@ -298,6 +324,16 @@ Internet
 ```
 
 ---
+
+## Terraform Deployment
+
+The reference Terraform configuration deploys this Helm chart and optionally
+applies the same versioned setup manifest used by an automation agent. It does
+not accept raw secrets: runtime and initial-setup credentials are referenced by
+existing Kubernetes Secret names so they do not enter Terraform state.
+
+See the [Terraform deployment guide](TerraformDeployment.md) and the runnable
+[`examples/terraform/kubernetes`](https://github.com/christianlouis/DocuElevate/tree/main/examples/terraform/kubernetes) module.
 
 ## Production Considerations
 

--- a/docs/SetupWizard.md
+++ b/docs/SetupWizard.md
@@ -78,11 +78,10 @@ Configure the AI provider used for metadata extraction and document understandin
 
 ### Skipping
 
-If you are an advanced user who has already configured settings via environment variables, you can skip the wizard by clicking **Skip for now** or by visiting:
-
-```
-GET /setup/skip
-```
+An authenticated administrator who has already configured the installation by
+other means can skip the wizard using the **Skip setup** action. This is a
+state-changing POST action protected by the normal session and CSRF controls;
+an unauthenticated first-run visitor cannot bypass the required security step.
 
 This writes a `_setup_wizard_skipped` marker to the database so the wizard is not re-shown automatically.
 
@@ -91,7 +90,7 @@ This writes a `_setup_wizard_skipped` marker to the database so the wizard is no
 To re-run the wizard after skipping it:
 
 1. Navigate to **Settings → System** and click **Re-run Setup Wizard**, or
-2. Visit `/setup/undo-skip` directly.
+2. Use **Re-run setup** as an authenticated administrator.
 
 This removes the skip marker and redirects you to Step 1.
 
@@ -99,7 +98,10 @@ This removes the skip marker and redirects you to Step 1.
 
 ## After the Wizard
 
-Once all three steps are complete you are redirected to the home page with a `?setup=complete` confirmation banner.  At that point DocuElevate is operational with the core settings in place.
+Once all three steps are complete, DocuElevate records completion on the
+server, closes the one-time bootstrap session and sends you to the login page.
+The setup URL is administrator-only from then on. A URL query parameter cannot
+bypass an incomplete installation.
 
 **Recommended next steps:**
 

--- a/docs/TerraformDeployment.md
+++ b/docs/TerraformDeployment.md
@@ -1,0 +1,84 @@
+# Terraform deployment
+
+DocuElevate can be installed declaratively on Kubernetes with Terraform. The
+reference deployment composes two existing product interfaces:
+
+1. Terraform manages the namespace and DocuElevate Helm release.
+2. Helm runs migrations and, when enabled, a post-install setup Job.
+3. The Job plans and applies the versioned `DocuElevateSetup` JSON manifest.
+4. Settings are validated and stored through the same encrypted database path
+   used by the browser setup journey; workers receive live invalidation events.
+
+The runnable reference is in
+[`examples/terraform/kubernetes`](https://github.com/christianlouis/DocuElevate/tree/main/examples/terraform/kubernetes).
+
+## Prerequisites
+
+- Terraform 1.6 or newer
+- access to Kubernetes through the Helm and Kubernetes providers
+- a PostgreSQL database and a suitable persistent storage class
+- an existing namespace with two Kubernetes Secrets created by 1Password
+  Connect with External Secrets, or an equivalent secret operator
+- an immutable DocuElevate image tag
+
+The runtime bootstrap Secret contains at least `DATABASE_URL` and
+`SESSION_SECRET`. The optional setup Secret contains only environment keys
+referenced from the setup manifest, such as initial user passwords. It is
+mounted into the setup Job but never into the long-running API or workers.
+
+The module therefore defaults to `create_namespace = false`. Let the platform
+or GitOps layer create the namespace and reconcile its Secrets before applying
+the DocuElevate application module. Creating the namespace in this module is an
+explicit opt-in for environments where a separate controller can populate the
+Secrets before Helm's atomic timeout.
+
+Do not put secret values into Terraform variables, `tfvars`, Helm values or
+provider command lines. Marking a Terraform variable as `sensitive` hides it
+from normal output but does not keep it out of state.
+
+## Deploy
+
+Copy the example variables and manifest outside source control:
+
+```bash
+cd examples/terraform/kubernetes
+cp terraform.tfvars.example preprod.auto.tfvars
+cp ../../agentic-setup.preprod.json /secure/config/docuelevate-preprod.json
+```
+
+Use environment-qualified resource names containing `Preprod`, point at the
+existing Secret names, and pin `image_tag` to an immutable version. Then run:
+
+```bash
+terraform init
+terraform fmt -check
+terraform validate
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+The Helm release is atomic. A migration failure, invalid setup manifest, failed
+setup plan or failed setup apply causes the release to fail instead of leaving
+Terraform reporting a healthy deployment.
+
+## Acceptance contract for an AI operator
+
+An AI may report the installation ready only after all of these checks pass:
+
+- `terraform plan` was reviewed before the exact saved plan was applied;
+- the Helm release and agentic setup Job completed successfully;
+- `/api/diagnostic/healthz/ready` returns ready;
+- a second `terraform plan` reports no infrastructure changes;
+- a second manifest plan reports only unchanged application resources;
+- every configured user can log in;
+- documents uploaded for two different users remain separated by tenant and
+  Tribe rules;
+- OAuth integrations are either completed by the relevant user or explicitly
+  listed as pending interactive actions;
+- the deployed image tag and environment names match the intended target.
+
+The current `v1alpha1` manifest reconciles settings, local users and Tribes.
+Pipelines, integration instances, routing rules and user-consent OAuth grants
+are not silently approximated. Until those resource types are added to the
+schema, configure them through their supported product journeys and keep them
+as explicit acceptance actions.

--- a/examples/agentic-setup.preprod.json
+++ b/examples/agentic-setup.preprod.json
@@ -1,0 +1,55 @@
+{
+  "apiVersion": "docuelevate.org/v1alpha1",
+  "kind": "DocuElevateSetup",
+  "metadata": {
+    "name": "DocuElevate Preprod Canary"
+  },
+  "spec": {
+    "completeSetup": true,
+    "settings": {
+      "ai_provider": "openai",
+      "openai_model": "gpt-5-nano",
+      "openai_api_key": {
+        "fromEnv": "DOCUELEVATE_SETUP_OPENAI_API_KEY"
+      },
+      "admin_password": {
+        "fromEnv": "DOCUELEVATE_SETUP_ADMIN_PASSWORD"
+      }
+    },
+    "users": [
+      {
+        "email": "christian@example.test",
+        "username": "christian",
+        "displayName": "Christian",
+        "password": {
+          "fromEnv": "DOCUELEVATE_SETUP_CHRISTIAN_PASSWORD"
+        },
+        "isAdmin": true
+      },
+      {
+        "email": "julia@example.test",
+        "username": "julia",
+        "displayName": "Julia",
+        "password": {
+          "fromEnv": "DOCUELEVATE_SETUP_JULIA_PASSWORD"
+        },
+        "isAdmin": false
+      }
+    ],
+    "tribes": [
+      {
+        "name": "Krakau Family Preprod",
+        "members": [
+          {
+            "email": "christian@example.test",
+            "role": "admin"
+          },
+          {
+            "email": "julia@example.test",
+            "role": "member"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/terraform/kubernetes/.terraform.lock.hcl
+++ b/examples/terraform/kubernetes/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.13"
+  hashes = [
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.29"
+  hashes = [
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}

--- a/examples/terraform/kubernetes/README.md
+++ b/examples/terraform/kubernetes/README.md
@@ -1,0 +1,52 @@
+# Terraform deployment for DocuElevate
+
+This example deploys the DocuElevate Helm chart and optionally converges the
+application through the same `DocuElevateSetup` manifest used by the local
+agentic installer. It is deliberately suitable for an automation agent: inputs,
+secret boundaries, plan, apply and acceptance checks are explicit.
+
+## Secret contract
+
+Create the namespace and two Kubernetes Secrets before this application module
+runs:
+
+- the bootstrap Secret contains at least `DATABASE_URL` and `SESSION_SECRET`;
+- the setup Secret contains the environment names referenced by `fromEnv` in
+  the setup manifest, such as `DOCUELEVATE_SETUP_ADMIN_PASSWORD`.
+
+Use 1Password Connect plus External Secrets, or an equivalent secret operator.
+Terraform receives **only the Secret names**. Do not pass secret values through
+variables, `tfvars`, Helm values or command-line `-var` arguments: Terraform
+would retain them in state.
+
+The default `create_namespace = false` is intentional: a platform or GitOps
+layer normally creates the namespace and reconciles External Secrets first. Set
+it to `true` only when another process can populate the Secrets before Helm's
+atomic timeout; otherwise the migration and setup hooks correctly remain
+unready rather than starting without credentials.
+
+The setup Secret is injected only into the short-lived setup Job. It is not
+available to the API or workers. OAuth user consent remains an interactive
+post-install action.
+
+## AI-readable runbook
+
+1. Copy `terraform.tfvars.example` to a file outside source control and use an
+   immutable image tag plus environment-qualified names.
+2. Copy and edit `../agentic-setup.preprod.json`. Keep all sensitive values as
+   `fromEnv` references.
+3. Confirm that the namespace and both referenced Kubernetes Secrets exist in the target
+   namespace and expose the required key names. Do not read their values.
+4. Run `terraform init`, then save and review `terraform plan -out=tfplan`.
+5. Apply only that reviewed plan with `terraform apply tfplan`.
+6. The Helm hook first runs the manifest's safe `plan`, then its idempotent
+   `apply`. A validation or setup failure makes the atomic Helm release fail.
+7. Require a successful Helm release, a completed setup Job and a ready response
+   from `/api/diagnostic/healthz/ready`.
+8. Re-run `terraform plan`; a converged installation must show no changes.
+9. Log in as every seeded user and prove document and Tribe isolation before
+   treating the Canary as accepted.
+
+Provider authentication is intentionally not defined here. Supply Kubernetes
+and Helm provider credentials through your normal CI or workstation identity;
+do not commit a kubeconfig or cluster token.

--- a/examples/terraform/kubernetes/main.tf
+++ b/examples/terraform/kubernetes/main.tf
@@ -1,0 +1,67 @@
+locals {
+  agentic_setup_enabled = var.agentic_setup_manifest_path != null
+  agentic_manifest      = local.agentic_setup_enabled ? file(var.agentic_setup_manifest_path) : ""
+
+  docuelevate_values = {
+    image = {
+      repository = var.image_repository
+      tag        = var.image_tag
+    }
+    env = {
+      EXTERNAL_HOSTNAME = var.external_hostname
+    }
+    secrets = {
+      existingSecret = var.bootstrap_secret_name
+    }
+    agenticSetup = {
+      enabled        = local.agentic_setup_enabled
+      manifest       = local.agentic_manifest
+      existingSecret = var.setup_secret_name
+    }
+    ingress = {
+      enabled   = true
+      className = var.ingress_class_name
+      hosts = [{
+        host = var.external_hostname
+        paths = [{
+          path     = "/"
+          pathType = "Prefix"
+        }]
+      }]
+      tls = var.tls_secret_name == "" ? [] : [{
+        secretName = var.tls_secret_name
+        hosts      = [var.external_hostname]
+      }]
+    }
+  }
+}
+
+resource "kubernetes_namespace_v1" "docuelevate" {
+  count = var.create_namespace ? 1 : 0
+
+  metadata {
+    name = var.namespace
+    labels = {
+      "app.kubernetes.io/part-of"     = "docuelevate"
+      "app.kubernetes.io/environment" = var.environment
+    }
+  }
+}
+
+resource "helm_release" "docuelevate" {
+  name              = var.release_name
+  namespace         = var.namespace
+  chart             = var.chart_path
+  dependency_update = true
+
+  atomic  = true
+  wait    = true
+  timeout = 900
+
+  values = concat(
+    [yamlencode(local.docuelevate_values)],
+    var.additional_helm_values,
+  )
+
+  depends_on = [kubernetes_namespace_v1.docuelevate]
+}

--- a/examples/terraform/kubernetes/outputs.tf
+++ b/examples/terraform/kubernetes/outputs.tf
@@ -1,0 +1,15 @@
+output "namespace" {
+  value = var.namespace
+}
+
+output "release_name" {
+  value = helm_release.docuelevate.name
+}
+
+output "application_url" {
+  value = "https://${var.external_hostname}"
+}
+
+output "agentic_setup_enabled" {
+  value = local.agentic_setup_enabled
+}

--- a/examples/terraform/kubernetes/terraform.tfvars.example
+++ b/examples/terraform/kubernetes/terraform.tfvars.example
@@ -1,0 +1,15 @@
+release_name   = "docuelevate-preprod-canary"
+namespace      = "docuelevate-preprod-canary"
+create_namespace = false
+environment      = "preprod"
+image_tag      = "0.186.0"
+external_hostname = "canary-preprod.app.docuelevate.org"
+
+# These Secrets must already exist and should be reconciled by 1Password
+# Connect / External Secrets. Never put their values in this file.
+bootstrap_secret_name = "docuelevate-preprod-canary-bootstrap"
+setup_secret_name     = "docuelevate-preprod-canary-setup"
+
+agentic_setup_manifest_path = "../../agentic-setup.preprod.json"
+ingress_class_name           = "nginx"
+tls_secret_name              = "docuelevate-preprod-canary-tls"

--- a/examples/terraform/kubernetes/variables.tf
+++ b/examples/terraform/kubernetes/variables.tf
@@ -1,0 +1,81 @@
+variable "release_name" {
+  description = "Helm release name. Include the environment in the name."
+  type        = string
+  default     = "docuelevate-preprod"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace containing the externally managed Secrets."
+  type        = string
+  default     = "docuelevate-preprod"
+}
+
+variable "create_namespace" {
+  description = "Create the namespace. Keep false when a platform layer also reconciles Secrets into it."
+  type        = bool
+  default     = false
+}
+
+variable "environment" {
+  description = "Environment label applied when this module creates the namespace."
+  type        = string
+  default     = "preprod"
+}
+
+variable "chart_path" {
+  description = "Path to the checked-out DocuElevate Helm chart."
+  type        = string
+  default     = "../../../helm/docuelevate"
+}
+
+variable "image_repository" {
+  description = "DocuElevate container repository."
+  type        = string
+  default     = "ghcr.io/christianlouis/docuelevate"
+}
+
+variable "image_tag" {
+  description = "Immutable image tag to deploy. Never use latest."
+  type        = string
+}
+
+variable "external_hostname" {
+  description = "Public hostname used by DocuElevate and OAuth callbacks."
+  type        = string
+}
+
+variable "bootstrap_secret_name" {
+  description = "Existing Secret with DATABASE_URL, SESSION_SECRET and other process bootstrap values."
+  type        = string
+}
+
+variable "setup_secret_name" {
+  description = "Existing Secret with the manifest's fromEnv values. Not injected into long-running pods."
+  type        = string
+  default     = ""
+}
+
+variable "agentic_setup_manifest_path" {
+  description = "Path to a validated DocuElevateSetup JSON manifest, or null to use the browser wizard."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "ingress_class_name" {
+  description = "Ingress controller class."
+  type        = string
+  default     = "nginx"
+}
+
+variable "tls_secret_name" {
+  description = "Existing TLS Secret for external_hostname. Empty disables TLS configuration."
+  type        = string
+  default     = ""
+}
+
+variable "additional_helm_values" {
+  description = "Additional non-secret Helm YAML documents applied after the safe defaults."
+  type        = list(string)
+  default     = []
+}

--- a/examples/terraform/kubernetes/versions.tf
+++ b/examples/terraform/kubernetes/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.13"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.29"
+    }
+  }
+}

--- a/frontend/templates/setup_wizard.html
+++ b/frontend/templates/setup_wizard.html
@@ -86,6 +86,11 @@
           <p class="font-bold">⚠️ Error</p>
           <p>Failed to save settings. Please try again.</p>
         </div>
+        {% elif request.query_params.get('error') == 'required_missing' %}
+        <div class="mb-6 bg-red-100 border-l-4 border-red-500 text-red-700 p-4" role="alert">
+          <p class="font-bold">Required information is missing</p>
+          <p>Complete the required fields before continuing. Existing values can be left unchanged when you re-run setup later.</p>
+        </div>
         {% endif %}
 
         <div class="space-y-6">
@@ -207,10 +212,15 @@
               Setup was previously skipped.
             </span>
             {% elif current_step == 1 %}
-            <a href="/setup/skip" class="text-sm text-gray-600 hover:text-gray-900">
-              <i class="fas fa-forward"></i>
-              Skip setup (advanced users)
-            </a>
+            {% if is_logged_in %}
+            <form method="post" action="/setup/skip" class="inline">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token | default('', true) }}">
+              <button type="submit" class="text-sm text-gray-600 hover:text-gray-900">
+                <i class="fas fa-forward"></i>
+                Skip setup (administrators only)
+              </button>
+            </form>
+            {% endif %}
             {% endif %}
           </div>
 
@@ -248,10 +258,14 @@
         Fields marked with <span class="text-red-600">*</span> are required.
       </p>
       {% if setup_skipped %}
-      <p class="text-xs text-amber-600 mt-2">
+      <div class="text-xs text-amber-600 mt-2">
         <i class="fas fa-info-circle"></i>
-        You previously skipped the setup wizard. <a href="/setup/undo-skip" class="underline hover:text-amber-800">Click here to re-run it.</a>
-      </p>
+        You previously skipped the setup wizard.
+        <form method="post" action="/setup/undo-skip" class="inline">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token | default('', true) }}">
+          <button type="submit" class="underline hover:text-amber-800">Re-run it now.</button>
+        </form>
+      </div>
       {% endif %}
     </div>
 

--- a/helm/docuelevate/Chart.lock
+++ b/helm/docuelevate/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 20.13.4
+digest: sha256:7057fcbbe1c53c3ce689c21a9bd39da646fe8b463bba060eb986040d34bd79ef
+generated: "2026-07-17T00:14:50.875007+02:00"

--- a/helm/docuelevate/Chart.yaml
+++ b/helm/docuelevate/Chart.yaml
@@ -7,10 +7,10 @@ description: >
 type: application
 
 # Chart version — bump on every chart change (independent of appVersion).
-version: 0.1.0
+version: 0.2.0
 
 # Application version — kept in sync with the VERSION file.
-appVersion: "0.54.0"
+appVersion: "0.186.0"
 
 keywords:
   - document-management

--- a/helm/docuelevate/templates/_helpers.tpl
+++ b/helm/docuelevate/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Name of the Secret injected into every DocuElevate process.
+*/}}
+{{- define "docuelevate.secretName" -}}
+{{- default (printf "%s-secret" (include "docuelevate.fullname" .)) .Values.secrets.existingSecret }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this.
 If release name contains chart name it will be used as a full name.

--- a/helm/docuelevate/templates/agentic-setup.yaml
+++ b/helm/docuelevate/templates/agentic-setup.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.agenticSetup.enabled }}
+{{- if not .Values.agenticSetup.manifest }}
+{{- fail "agenticSetup.manifest is required when agenticSetup.enabled=true" }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "docuelevate.fullname" . }}-agentic-setup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "docuelevate.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agentic-setup
+data:
+  setup.json: |-
+    {{- .Values.agenticSetup.manifest | nindent 4 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "docuelevate.fullname" . }}-agentic-setup-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "docuelevate.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agentic-setup
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  ttlSecondsAfterFinished: {{ .Values.agenticSetup.ttlSecondsAfterFinished }}
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        {{- include "docuelevate.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: agentic-setup
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "docuelevate.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: setup
+          image: {{ include "docuelevate.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+            - >-
+              python -m app.agentic_setup plan /config/setup.json &&
+              python -m app.agentic_setup apply /config/setup.json
+          envFrom:
+            - configMapRef:
+                name: {{ include "docuelevate.fullname" . }}-config
+            - secretRef:
+                name: {{ include "docuelevate.secretName" . }}
+            {{- if .Values.agenticSetup.existingSecret }}
+            - secretRef:
+                name: {{ .Values.agenticSetup.existingSecret }}
+            {{- end }}
+          volumeMounts:
+            - name: setup-manifest
+              mountPath: /config
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: setup-manifest
+          configMap:
+            name: {{ include "docuelevate.fullname" . }}-agentic-setup
+{{- end }}

--- a/helm/docuelevate/templates/api-deployment.yaml
+++ b/helm/docuelevate/templates/api-deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - configMapRef:
                 name: {{ include "docuelevate.fullname" . }}-config
             - secretRef:
-                name: {{ include "docuelevate.fullname" . }}-secret
+                name: {{ include "docuelevate.secretName" . }}
           {{- with .Values.api.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/helm/docuelevate/templates/knowledge-research-worker-deployment.yaml
+++ b/helm/docuelevate/templates/knowledge-research-worker-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - configMapRef:
                 name: {{ include "docuelevate.fullname" . }}-config
             - secretRef:
-                name: {{ include "docuelevate.fullname" . }}-secret
+                name: {{ include "docuelevate.secretName" . }}
           {{- with .Values.knowledgeResearchWorker.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm/docuelevate/templates/meilisearch.yaml
+++ b/helm/docuelevate/templates/meilisearch.yaml
@@ -39,7 +39,7 @@ spec:
             - name: MEILI_MASTER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "docuelevate.fullname" . }}-secret
+                  name: {{ include "docuelevate.secretName" . }}
                   key: MEILISEARCH_API_KEY
             {{- end }}
           resources:

--- a/helm/docuelevate/templates/migration-job.yaml
+++ b/helm/docuelevate/templates/migration-job.yaml
@@ -15,10 +15,6 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
-    {{- if .Values.migrations.ttlSecondsAfterFinished }}
-spec:
-  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished }}
-    {{- end }}
 spec:
   {{- if .Values.migrations.ttlSecondsAfterFinished }}
   ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished }}
@@ -32,7 +28,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ include "docuelevate.serviceAccountName" . }}
-      {{- with .Values.image.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -45,7 +41,7 @@ spec:
             - configMapRef:
                 name: {{ include "docuelevate.fullname" . }}-config
             - secretRef:
-                name: {{ include "docuelevate.fullname" . }}-secret
+                name: {{ include "docuelevate.secretName" . }}
           {{- with .Values.workdir.persistence }}
           volumeMounts:
             - name: workdir

--- a/helm/docuelevate/templates/runtime-config.yaml
+++ b/helm/docuelevate/templates/runtime-config.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "docuelevate.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "docuelevate.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secrets }}
+  {{- if ne $key "existingSecret" }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/docuelevate/templates/search-index-worker-deployment.yaml
+++ b/helm/docuelevate/templates/search-index-worker-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - configMapRef:
                 name: {{ include "docuelevate.fullname" . }}-config
             - secretRef:
-                name: {{ include "docuelevate.fullname" . }}-secret
+                name: {{ include "docuelevate.secretName" . }}
           {{- with .Values.searchIndexWorker.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm/docuelevate/templates/worker-deployment.yaml
+++ b/helm/docuelevate/templates/worker-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - configMapRef:
                 name: {{ include "docuelevate.fullname" . }}-config
             - secretRef:
-                name: {{ include "docuelevate.fullname" . }}-secret
+                name: {{ include "docuelevate.secretName" . }}
           {{- with .Values.worker.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm/docuelevate/values.yaml
+++ b/helm/docuelevate/values.yaml
@@ -64,6 +64,9 @@ env:
 # and leave these blank, then mount the Secret yourself.
 # ---------------------------------------------------------------------------
 secrets:
+  # Prefer a Secret created by External Secrets, 1Password Connect or your
+  # platform. When set, the chart does not create or own a Secret.
+  existingSecret: ""
   DATABASE_URL: ""         # e.g. postgresql://user:pass@postgres:5432/docuelevate
   REDIS_URL: ""            # leave blank to use bundled Redis
   SESSION_SECRET: ""       # min 32-char random string — generate with: openssl rand -hex 32
@@ -354,3 +357,18 @@ migrations:
   enabled: true
   # Automatically deleted after successful completion
   ttlSecondsAfterFinished: 120
+
+# ---------------------------------------------------------------------------
+# Declarative post-install setup
+# Runs the same validated, idempotent manifest used by the local agentic CLI.
+# Secret values referenced with fromEnv must exist in secrets.existingSecret
+# (or in the chart-managed Secret for disposable development installs).
+# ---------------------------------------------------------------------------
+agenticSetup:
+  enabled: false
+  manifest: ""
+  # Optional second Secret containing only fromEnv values used by the setup
+  # manifest (for example initial user passwords). It is not injected into the
+  # long-running API or worker pods.
+  existingSecret: ""
+  ttlSecondsAfterFinished: 300

--- a/migrations/versions/061_encrypt_sensitive_settings_audit.py
+++ b/migrations/versions/061_encrypt_sensitive_settings_audit.py
@@ -1,0 +1,91 @@
+"""Remove legacy plaintext secrets from settings audit history.
+
+Revision ID: 061_encrypt_sensitive_settings_audit
+Revises: 060_add_tenant_tribe_foundation
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "061_encrypt_sensitive_settings_audit"
+down_revision: Union[str, None] = "060_add_tenant_tribe_foundation"
+branch_labels = None
+depends_on = None
+
+SENSITIVE_SETTING_KEYS = (
+    "admin_password",
+    "anthropic_api_key",
+    "audit_siem_http_token",
+    "authentik_client_secret",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "azure_ai_key",
+    "database_url",
+    "dest_email_password",
+    "document_bridge_bearer_token",
+    "document_bridge_shared_secret",
+    "document_intake_shared_secret",
+    "dropbox_app_secret",
+    "dropbox_refresh_token",
+    "email_password",
+    "evernote_auth_token",
+    "ftp_password",
+    "gemini_api_key",
+    "google_docai_credentials_json",
+    "google_drive_client_secret",
+    "google_drive_credentials_json",
+    "google_drive_refresh_token",
+    "icloud_password",
+    "imap1_password",
+    "imap2_password",
+    "meilisearch_api_key",
+    "mistral_api_key",
+    "nextcloud_password",
+    "notification_urls",
+    "onedrive_client_secret",
+    "onedrive_refresh_token",
+    "openai_api_key",
+    "openrouter_api_key",
+    "paperless_ngx_api_token",
+    "portkey_api_key",
+    "portkey_virtual_key",
+    "sentry_dsn",
+    "session_secret",
+    "sftp_password",
+    "sftp_private_key",
+    "sftp_private_key_passphrase",
+    "sharepoint_client_secret",
+    "sharepoint_refresh_token",
+    "social_auth_apple_private_key",
+    "social_auth_dropbox_client_secret",
+    "social_auth_generic_oauth2_client_secret",
+    "social_auth_github_client_secret",
+    "social_auth_google_client_secret",
+    "social_auth_keycloak_client_secret",
+    "social_auth_microsoft_client_secret",
+    "social_auth_saml2_certificate",
+    "stripe_secret_key",
+    "stripe_webhook_secret",
+    "telegram_bot_token",
+    "vector_index_api_key",
+    "webdav_password",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if "settings_audit_log" not in sa.inspect(bind).get_table_names():
+        return
+    statement = sa.text(
+        "UPDATE settings_audit_log SET old_value = NULL, new_value = NULL WHERE key IN :keys"
+    ).bindparams(sa.bindparam("keys", expanding=True))
+    bind.execute(statement, {"keys": SENSITIVE_SETTING_KEYS})
+
+
+def downgrade() -> None:
+    # Redacted plaintext secrets cannot and must not be reconstructed.
+    pass

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,9 +30,10 @@ theme:
         name: Switch to light mode
 nav:
   - Getting Started:
-      - Setup Wizard: SetupWizard
-      - User Guide: UserGuide
-      - Browser Extension: BrowserExtension
+      - Setup Wizard: SetupWizard.md
+      - Agentic Setup: AgenticSetup.md
+      - User Guide: UserGuide.md
+      - Browser Extension: BrowserExtension.md
   - How-To Guides:
       - Overview: HowToGuides.md
       - HP Enterprise Printer: howto/HPPrinterSetup.md
@@ -40,29 +41,30 @@ nav:
       - Watched Folder: howto/WatchedFolderSetup.md
       - Email Ingestion: howto/EmailIngestion.md
       - Mobile Scanning: howto/MobileScanning.md
-  - API: API
-  - CLI: CLIGuide
+  - API: API.md
+  - CLI: CLIGuide.md
   - Deployment:
-      - Overview: DeploymentGuide
-      - Kubernetes / Helm: KubernetesDeployment
-      - Production Readiness: ProductionReadiness
+      - Overview: DeploymentGuide.md
+      - Kubernetes / Helm: KubernetesDeployment.md
+      - Terraform: TerraformDeployment.md
+      - Production Readiness: ProductionReadiness.md
   - Configuration:
-      - Overview: ConfigurationMaster
-      - Configuration Guide: ConfigurationGuide
-      - Settings Management: SettingsManagement
-      - Database: DatabaseConfiguration
-      - Dropbox: DropboxSetup
-      - Google Drive: GoogleDriveSetup
-      - OneDrive: OneDriveSetup
-      - Amazon S3: AmazonS3Setup
-      - Evernote: EvernoteSetup
-      - Authentication: AuthenticationSetup
-      - Notifications: NotificationsSetup
+      - Overview: ConfigurationMaster.md
+      - Configuration Guide: ConfigurationGuide.md
+      - Settings Management: SettingsManagement.md
+      - Database: DatabaseConfiguration.md
+      - Dropbox: DropboxSetup.md
+      - Google Drive: GoogleDriveSetup.md
+      - OneDrive: OneDriveSetup.md
+      - Amazon S3: AmazonS3Setup.md
+      - Evernote: EvernoteSetup.md
+      - Authentication: AuthenticationSetup.md
+      - Notifications: NotificationsSetup.md
   - Security:
-      - Credential Rotation: CredentialRotationGuide
+      - Credential Rotation: CredentialRotationGuide.md
   - Troubleshooting:
-      - General: Troubleshooting
-      - Configuration: ConfigurationTroubleshooting
+      - General: Troubleshooting.md
+      - Configuration: ConfigurationTroubleshooting.md
   - Compliance:
-      - Licensing: LicensingCompliance
-      - Privacy & GDPR: PrivacyCompliance
+      - Licensing: LicensingCompliance.md
+      - Privacy & GDPR: PrivacyCompliance.md

--- a/schemas/docuelevate-setup-v1alpha1.schema.json
+++ b/schemas/docuelevate-setup-v1alpha1.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docuelevate.org/schemas/docuelevate-setup-v1alpha1.schema.json",
+  "title": "DocuElevate declarative setup",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {"const": "docuelevate.org/v1alpha1"},
+    "kind": {"const": "DocuElevateSetup"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1}
+      }
+    },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "completeSetup": {"type": "boolean", "default": false},
+        "settings": {
+          "type": "object",
+          "additionalProperties": {"$ref": "#/$defs/settingValue"},
+          "default": {}
+        },
+        "users": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/user"},
+          "default": []
+        },
+        "tribes": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/tribe"},
+          "default": []
+        }
+      }
+    }
+  },
+  "$defs": {
+    "fromEnv": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fromEnv"],
+      "properties": {
+        "fromEnv": {"type": "string", "pattern": "^[A-Z_][A-Z0-9_]*$"}
+      }
+    },
+    "settingValue": {
+      "oneOf": [
+        {"type": "string"},
+        {"type": "number"},
+        {"type": "boolean"},
+        {"$ref": "#/$defs/fromEnv"}
+      ]
+    },
+    "user": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["email", "username", "password"],
+      "properties": {
+        "email": {"type": "string", "format": "email"},
+        "username": {"type": "string", "pattern": "^[A-Za-z0-9_.-]{2,64}$"},
+        "displayName": {"type": "string"},
+        "password": {"$ref": "#/$defs/fromEnv"},
+        "isAdmin": {"type": "boolean", "default": false}
+      }
+    },
+    "member": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["email", "role"],
+      "properties": {
+        "email": {"type": "string", "format": "email"},
+        "role": {"enum": ["admin", "member"]}
+      }
+    },
+    "tribe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "members"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "members": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/member"}
+        }
+      }
+    }
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,13 @@ os.environ["AZURE_ENDPOINT"] = "https://test.cognitiveservices.azure.com/"
 os.environ["GOTENBERG_URL"] = "http://localhost:3000"
 os.environ["WORKDIR"] = "/tmp"
 os.environ["AUTH_ENABLED"] = "False"
+os.environ["ADMIN_PASSWORD"] = "test_admin_password_for_completed_setup"
 os.environ["SESSION_SECRET"] = "test_secret_key_for_testing_must_be_at_least_32_characters_long"
+os.environ["LOG_FORMAT"] = "text"
+
+# Keep pytest-created files inside WORKDIR on macOS, where the system TMPDIR
+# otherwise resolves to /private/var while /tmp resolves to /private/tmp.
+tempfile.tempdir = "/tmp"
 
 from app.database import Base  # noqa: E402
 from app.main import app as fastapi_app  # noqa: E402

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,8 @@
 Integration tests for API endpoints.
 """
 
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -16,10 +18,9 @@ class TestHealthEndpoints:
         # Accept 200 (OK), 303 (setup wizard redirect), 307/308 (other redirects)
         assert response.status_code in [200, 303, 307, 308]
 
-    def test_root_redirects_to_setup_wizard_when_setup_required(self, client: TestClient):
+    @patch("app.utils.setup_wizard.is_setup_required", return_value=True)
+    def test_root_redirects_to_setup_wizard_when_setup_required(self, _setup_required, client: TestClient):
         """Test that GET / redirects to setup wizard when setup is required."""
-        # With test env vars (OPENAI_API_KEY=test-key, AZURE_AI_KEY=test-key),
-        # is_setup_required() returns True, so we should get a redirect to /setup
         response = client.get("/", follow_redirects=False)
 
         # Should return 303 See Other (setup wizard redirect)
@@ -29,13 +30,12 @@ class TestHealthEndpoints:
         assert "Location" in response.headers
         assert response.headers["Location"] == "/setup?step=1"
 
-    def test_root_returns_200_when_setup_complete(self, client: TestClient):
-        """Test that GET /?setup=complete bypasses the setup wizard check."""
-        # The ?setup=complete query param should bypass the wizard check
+    @patch("app.utils.setup_wizard.is_setup_required", return_value=True)
+    def test_root_query_cannot_bypass_required_setup(self, _setup_required, client: TestClient):
+        """A client-controlled query parameter cannot waive required setup."""
         response = client.get("/?setup=complete", follow_redirects=False)
-
-        # Should return 200 OK (renders the index page)
-        assert response.status_code == 200
+        assert response.status_code == 303
+        assert response.headers["location"] == "/setup?step=1"
 
     def test_setup_wizard_page_accessible(self, client: TestClient):
         """Test that GET /setup?step=1 returns 200."""

--- a/tests/test_compose_contract.py
+++ b/tests/test_compose_contract.py
@@ -1,0 +1,50 @@
+"""Contracts for the zero-configuration Docker Compose installation."""
+
+from pathlib import Path
+
+import yaml
+
+COMPOSE_FILE = Path(__file__).parents[1] / "docker-compose.yaml"
+
+
+def _compose() -> dict:
+    return yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+
+
+def test_fresh_install_includes_complete_runtime_stack():
+    services = set(_compose()["services"])
+
+    assert {
+        "api",
+        "worker",
+        "beat",
+        "knowledge-research-worker",
+        "search-index-worker",
+        "postgres",
+        "redis",
+        "gotenberg",
+        "meilisearch",
+        "qdrant",
+    } <= services
+
+
+def test_api_port_and_public_urls_follow_canary_port():
+    compose = _compose()
+    environment = compose["x-docuelevate-service"]["environment"]
+
+    assert compose["services"]["api"]["ports"] == ["${DOCUELEVATE_PORT:-8000}:8000"]
+    assert environment["EXTERNAL_HOSTNAME"] == "localhost:${DOCUELEVATE_PORT:-8000}"
+    assert environment["PUBLIC_BASE_URL"] == "http://localhost:${DOCUELEVATE_PORT:-8000}"
+
+
+def test_fresh_install_uses_named_workdir_volume_by_default():
+    compose = _compose()
+
+    assert "workdir-data" in compose["volumes"]
+    assert "${DOCUELEVATE_WORKDIR:-workdir-data}:/workdir" in compose["x-docuelevate-service"]["volumes"]
+
+
+def test_all_application_processes_share_one_build_image():
+    service_defaults = _compose()["x-docuelevate-service"]
+
+    assert service_defaults["image"] == "${DOCUELEVATE_IMAGE:-docuelevate:local}"

--- a/tests/test_deployment_contract.py
+++ b/tests/test_deployment_contract.py
@@ -1,0 +1,52 @@
+"""Regression tests for Helm, Terraform, and agentic deployment contracts."""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CHART = ROOT / "helm" / "docuelevate"
+TERRAFORM = ROOT / "examples" / "terraform" / "kubernetes"
+
+
+def test_helm_app_version_matches_product_version():
+    chart = yaml.safe_load((CHART / "Chart.yaml").read_text(encoding="utf-8"))
+    assert str(chart["appVersion"]) == (ROOT / "VERSION").read_text(encoding="utf-8").strip()
+
+
+def test_helm_processes_use_the_configurable_runtime_secret():
+    templates = [
+        "api-deployment.yaml",
+        "worker-deployment.yaml",
+        "knowledge-research-worker-deployment.yaml",
+        "search-index-worker-deployment.yaml",
+        "migration-job.yaml",
+    ]
+    for template in templates:
+        content = (CHART / "templates" / template).read_text(encoding="utf-8")
+        assert 'include "docuelevate.secretName"' in content
+        assert 'include "docuelevate.fullname" . }}-secret' not in content
+
+
+def test_agentic_helm_hook_plans_before_apply_and_scopes_setup_credentials():
+    template = (CHART / "templates" / "agentic-setup.yaml").read_text(encoding="utf-8")
+    plan = "python -m app.agentic_setup plan /config/setup.json"
+    apply = "python -m app.agentic_setup apply /config/setup.json"
+    assert template.index(plan) < template.index(apply)
+    assert '"helm.sh/hook": post-install,post-upgrade' in template
+    assert ".Values.agenticSetup.existingSecret" in template
+
+    for template_name in ("api-deployment.yaml", "worker-deployment.yaml"):
+        long_running_template = (CHART / "templates" / template_name).read_text(encoding="utf-8")
+        assert "agenticSetup.existingSecret" not in long_running_template
+
+
+def test_terraform_accepts_secret_names_but_not_secret_values():
+    variables = (TERRAFORM / "variables.tf").read_text(encoding="utf-8")
+    main = (TERRAFORM / "main.tf").read_text(encoding="utf-8")
+    assert 'variable "bootstrap_secret_name"' in variables
+    assert 'variable "setup_secret_name"' in variables
+    assert 'variable "database_url"' not in variables.lower()
+    assert 'variable "session_secret"' not in variables.lower()
+    assert "existingSecret = var.bootstrap_secret_name" in main
+    assert "existingSecret = var.setup_secret_name" in main

--- a/tests/test_settings_audit_log.py
+++ b/tests/test_settings_audit_log.py
@@ -219,6 +219,28 @@ class TestRollbackSetting:
         current = get_setting_from_db(db_session, "workdir")
         assert current == "/v1"
 
+    def test_sensitive_rollback_decrypts_history_only_in_memory(self, db_session):
+        from app.models import ApplicationSettings
+        from app.utils.settings_service import get_setting_from_db, rollback_setting, save_setting_to_db
+
+        save_setting_to_db(db_session, "openai_api_key", "secret-v1", changed_by="admin")
+        save_setting_to_db(db_session, "openai_api_key", "secret-v2", changed_by="admin")
+        second_entry = (
+            db_session.query(SettingsAuditLog)
+            .filter_by(key="openai_api_key")
+            .order_by(SettingsAuditLog.id.desc())
+            .first()
+        )
+
+        assert second_entry.old_value.startswith("enc:")
+        assert second_entry.new_value.startswith("enc:")
+        assert "secret-v1" not in second_entry.old_value
+        assert rollback_setting(db_session, "openai_api_key", second_entry.id, changed_by="rollbacker") is True
+        assert get_setting_from_db(db_session, "openai_api_key") == "secret-v1"
+        stored = db_session.query(ApplicationSettings).filter_by(key="openai_api_key").one().value
+        assert stored.startswith("enc:")
+        assert "secret-v1" not in stored
+
     def test_rollback_deletes_setting_when_old_value_is_none(self, db_session):
         """Rolling back the first-ever entry (old_value=None) deletes the setting from DB."""
         from app.utils.settings_service import get_setting_from_db, rollback_setting, save_setting_to_db

--- a/tests/test_settings_service_coverage.py
+++ b/tests/test_settings_service_coverage.py
@@ -83,13 +83,12 @@ class TestSettingsServiceEncryption:
         # Test: Save a sensitive setting
         result = save_setting_to_db(db_session, "admin_password", "sensitive_password")
 
-        # Should succeed and store in plaintext with warning logged
-        assert result is True
+        # Sensitive values fail closed; plaintext storage is never acceptable.
+        assert result is False
         mock_encrypt.assert_not_called()
 
-        # Verify it was stored in plaintext
         stored = db_session.query(ApplicationSettings).filter_by(key="admin_password").first()
-        assert stored.value == "sensitive_password"
+        assert stored is None
 
     @patch("app.utils.encryption.encrypt_value")
     @patch("app.utils.encryption.is_encryption_available")

--- a/tests/test_settings_service_extended.py
+++ b/tests/test_settings_service_extended.py
@@ -27,11 +27,11 @@ from app.utils.settings_service import (
 
 @pytest.mark.unit
 class TestSaveSettingDecryptsOldValue:
-    """Tests for save_setting_to_db decrypting old value for audit log."""
+    """Sensitive settings history remains encrypted at rest."""
 
     @patch("app.utils.settings_service.get_setting_metadata")
     def test_save_sensitive_setting_decrypts_old_value_for_audit(self, mock_metadata, db_session):
-        """When updating a sensitive setting, old value is decrypted for the audit log."""
+        """Updating a secret keeps both audit values encrypted."""
         mock_metadata.return_value = {"sensitive": True}
 
         # First, save an encrypted value directly
@@ -42,21 +42,18 @@ class TestSaveSettingDecryptsOldValue:
         with (
             patch("app.utils.encryption.is_encryption_available", return_value=True),
             patch("app.utils.encryption.encrypt_value", return_value="enc:new_encrypted"),
-            patch("app.utils.encryption.decrypt_value", return_value="old_plaintext_key") as mock_decrypt,
         ):
             result = save_setting_to_db(db_session, "openai_api_key", "new_api_key", changed_by="admin")
 
         assert result is True
-        mock_decrypt.assert_called_once_with("enc:old_encrypted")
-
-        # Verify audit log has the decrypted old value
         audit = db_session.query(SettingsAuditLog).filter_by(key="openai_api_key").first()
         assert audit is not None
-        assert audit.old_value == "old_plaintext_key"
+        assert audit.old_value == "enc:old_encrypted"
+        assert audit.new_value == "enc:new_encrypted"
 
     @patch("app.utils.settings_service.get_setting_metadata")
-    def test_save_sensitive_setting_decryption_fails_uses_raw(self, mock_metadata, db_session):
-        """When decryption of old value fails, the raw stored value is used."""
+    def test_save_sensitive_setting_refuses_plaintext_fallback(self, mock_metadata, db_session):
+        """A secret is not persisted when encryption is unavailable."""
         mock_metadata.return_value = {"sensitive": True}
 
         setting = ApplicationSettings(key="openai_api_key", value="enc:corrupted")
@@ -64,55 +61,47 @@ class TestSaveSettingDecryptsOldValue:
         db_session.commit()
 
         with (
-            patch("app.utils.encryption.is_encryption_available", return_value=True),
-            patch("app.utils.encryption.encrypt_value", return_value="enc:new"),
-            patch("app.utils.encryption.decrypt_value", side_effect=Exception("Decryption failed")),
+            patch("app.utils.encryption.is_encryption_available", return_value=False),
         ):
             result = save_setting_to_db(db_session, "openai_api_key", "new_key", changed_by="admin")
 
-        assert result is True
-
-        # Audit log should have the raw encrypted value as fallback
-        audit = db_session.query(SettingsAuditLog).filter_by(key="openai_api_key").first()
-        assert audit is not None
-        assert audit.old_value == "enc:corrupted"
+        assert result is False
+        assert db_session.query(SettingsAuditLog).count() == 0
+        assert db_session.query(ApplicationSettings).filter_by(key="openai_api_key").one().value == "enc:corrupted"
 
 
 @pytest.mark.unit
 class TestDeleteSettingDecryptsOldValue:
-    """Tests for delete_setting_from_db decrypting stored value for audit log."""
+    """Deletion audit rows retain only encrypted secret material."""
 
     @patch("app.utils.settings_service.get_setting_metadata")
     def test_delete_sensitive_setting_decrypts_for_audit(self, mock_metadata, db_session):
-        """When deleting a sensitive setting, old value is decrypted for the audit log."""
+        """Deleting a sensitive setting never decrypts it into history."""
         mock_metadata.return_value = {"sensitive": True}
 
         setting = ApplicationSettings(key="openai_api_key", value="enc:secret_value")
         db_session.add(setting)
         db_session.commit()
 
-        with patch("app.utils.encryption.decrypt_value", return_value="decrypted_secret") as mock_decrypt:
-            result = delete_setting_from_db(db_session, "openai_api_key", changed_by="admin")
+        result = delete_setting_from_db(db_session, "openai_api_key", changed_by="admin")
 
         assert result is True
-        mock_decrypt.assert_called_once_with("enc:secret_value")
 
         audit = db_session.query(SettingsAuditLog).filter_by(key="openai_api_key").first()
         assert audit is not None
-        assert audit.old_value == "decrypted_secret"
+        assert audit.old_value == "enc:secret_value"
         assert audit.action == "delete"
 
     @patch("app.utils.settings_service.get_setting_metadata")
-    def test_delete_sensitive_setting_decryption_fails_uses_raw(self, mock_metadata, db_session):
-        """When decryption fails during delete, the raw value is used in audit."""
+    def test_delete_sensitive_setting_keeps_corrupt_ciphertext_opaque(self, mock_metadata, db_session):
+        """Even unreadable ciphertext is never converted to plaintext history."""
         mock_metadata.return_value = {"sensitive": True}
 
         setting = ApplicationSettings(key="openai_api_key", value="enc:bad_data")
         db_session.add(setting)
         db_session.commit()
 
-        with patch("app.utils.encryption.decrypt_value", side_effect=Exception("Bad key")):
-            result = delete_setting_from_db(db_session, "openai_api_key", changed_by="admin")
+        result = delete_setting_from_db(db_session, "openai_api_key", changed_by="admin")
 
         assert result is True
 

--- a/tests/test_setup_manifest.py
+++ b/tests/test_setup_manifest.py
@@ -1,0 +1,176 @@
+"""Agentic setup manifest validation, planning, and idempotent apply tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.models import ApplicationSettings, LocalUser, SettingsAuditLog, Tribe, TribeMembership
+from app.utils.local_auth import verify_password
+from app.utils.settings_service import get_setting_from_db
+from app.utils.setup_manifest import (
+    MANIFEST_API_VERSION,
+    MANIFEST_KIND,
+    SetupManifestError,
+    apply_setup_manifest,
+    load_setup_manifest,
+    plan_setup_manifest,
+    resolve_setup_manifest,
+)
+
+
+def _manifest() -> dict:
+    return {
+        "apiVersion": MANIFEST_API_VERSION,
+        "kind": MANIFEST_KIND,
+        "metadata": {"name": "DocuElevate Preprod Canary"},
+        "spec": {
+            "completeSetup": False,
+            "settings": {
+                "ai_provider": "litellm",
+                "admin_password": {"fromEnv": "DOCUELEVATE_SETUP_ADMIN_PASSWORD"},
+            },
+            "users": [
+                {
+                    "email": "christian@example.test",
+                    "username": "christian",
+                    "displayName": "Christian",
+                    "password": {"fromEnv": "DOCUELEVATE_SETUP_CHRISTIAN_PASSWORD"},
+                    "isAdmin": True,
+                },
+                {
+                    "email": "julia@example.test",
+                    "username": "julia",
+                    "displayName": "Julia",
+                    "password": {"fromEnv": "DOCUELEVATE_SETUP_JULIA_PASSWORD"},
+                },
+            ],
+            "tribes": [
+                {
+                    "name": "Krakau Family Preprod",
+                    "members": [
+                        {"email": "christian@example.test", "role": "admin"},
+                        {"email": "julia@example.test", "role": "member"},
+                    ],
+                }
+            ],
+        },
+    }
+
+
+_ENV = {
+    "DOCUELEVATE_SETUP_ADMIN_PASSWORD": "FallbackAdminPassword123!",
+    "DOCUELEVATE_SETUP_CHRISTIAN_PASSWORD": "ChristianPassword123!",
+    "DOCUELEVATE_SETUP_JULIA_PASSWORD": "JuliaPassword123!",
+}
+
+
+def test_example_and_json_schema_use_the_runtime_api_version():
+    root = Path(__file__).resolve().parents[1]
+    example = json.loads((root / "examples" / "agentic-setup.preprod.json").read_text(encoding="utf-8"))
+    schema = json.loads(
+        (root / "schemas" / "docuelevate-setup-v1alpha1.schema.json").read_text(encoding="utf-8")
+    )
+    assert example["apiVersion"] == MANIFEST_API_VERSION
+    assert example["kind"] == MANIFEST_KIND
+    assert schema["properties"]["apiVersion"]["const"] == MANIFEST_API_VERSION
+    assert schema["properties"]["kind"]["const"] == MANIFEST_KIND
+
+
+def test_load_manifest_requires_json_and_reads_bounded_object(tmp_path):
+    path = tmp_path / "setup.json"
+    path.write_text(json.dumps(_manifest()), encoding="utf-8")
+    assert load_setup_manifest(path)["kind"] == MANIFEST_KIND
+
+    yaml_path = tmp_path / "setup.yaml"
+    yaml_path.write_text("kind: DocuElevateSetup", encoding="utf-8")
+    with pytest.raises(SetupManifestError, match=".json"):
+        load_setup_manifest(yaml_path)
+
+
+def test_manifest_rejects_plaintext_secret_and_bootstrap_setting():
+    plaintext = _manifest()
+    plaintext["spec"]["settings"]["admin_password"] = "plaintext"
+    with pytest.raises(SetupManifestError, match="fromEnv"):
+        resolve_setup_manifest(plaintext, environ=_ENV)
+
+    bootstrap = _manifest()
+    bootstrap["spec"]["settings"]["database_url"] = "sqlite:///unsafe.db"
+    with pytest.raises(SetupManifestError, match="bootstrap"):
+        resolve_setup_manifest(bootstrap, environ=_ENV)
+
+
+def test_manifest_reports_missing_secret_reference():
+    with pytest.raises(SetupManifestError, match="DOCUELEVATE_SETUP_ADMIN_PASSWORD"):
+        resolve_setup_manifest(_manifest(), environ={})
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error"),
+    [
+        (lambda manifest: manifest["metadata"].update({"owner": "AI"}), "metadata"),
+        (lambda manifest: manifest["spec"].update({"completeSetup": "false"}), "boolean"),
+        (lambda manifest: manifest["spec"]["users"][1].update({"username": "christian"}), "username"),
+        (lambda manifest: manifest["spec"]["users"][1].update({"isAdmin": "false"}), "boolean"),
+        (lambda manifest: manifest["spec"]["tribes"][0]["members"].append(
+            {"email": "julia@example.test", "role": "member"}
+        ), "Duplicate member"),
+    ],
+)
+def test_manifest_rejects_ambiguous_or_duplicate_desired_state(mutate, error):
+    manifest = _manifest()
+    mutate(manifest)
+    with pytest.raises(SetupManifestError, match=error):
+        resolve_setup_manifest(manifest, environ=_ENV)
+
+
+def test_plan_redacts_all_secret_values(db_session):
+    resolved = resolve_setup_manifest(_manifest(), environ=_ENV)
+    plan = plan_setup_manifest(db_session, resolved)
+    rendered = json.dumps(plan)
+    assert plan["success"] is True
+    assert "<resolved-secret>" in rendered
+    assert not any(secret in rendered for secret in _ENV.values())
+
+
+def test_apply_is_idempotent_and_creates_users_personal_scopes_and_shared_tribe(db_session):
+    resolved = resolve_setup_manifest(_manifest(), environ=_ENV)
+    with patch("app.utils.setup_manifest.notify_settings_updated"):
+        result = apply_setup_manifest(db_session, resolved)
+
+    assert result["success"] is True
+    assert get_setting_from_db(db_session, "ai_provider") == "litellm"
+    assert get_setting_from_db(db_session, "admin_password") == _ENV["DOCUELEVATE_SETUP_ADMIN_PASSWORD"]
+
+    stored_secret = db_session.query(ApplicationSettings).filter_by(key="admin_password").one().value
+    audit_secret = db_session.query(SettingsAuditLog).filter_by(key="admin_password").one().new_value
+    assert stored_secret.startswith("enc:")
+    assert audit_secret.startswith("enc:")
+    assert _ENV["DOCUELEVATE_SETUP_ADMIN_PASSWORD"] not in stored_secret
+    assert _ENV["DOCUELEVATE_SETUP_ADMIN_PASSWORD"] not in audit_secret
+
+    users = {user.email: user for user in db_session.query(LocalUser).all()}
+    assert set(users) == {"christian@example.test", "julia@example.test"}
+    assert users["christian@example.test"].is_admin is True
+    assert verify_password(_ENV["DOCUELEVATE_SETUP_JULIA_PASSWORD"], users["julia@example.test"].hashed_password)
+
+    family = db_session.query(Tribe).filter_by(name="Krakau Family Preprod").one()
+    roles = {
+        membership.user_id: membership.role
+        for membership in db_session.query(TribeMembership).filter_by(tribe_id=family.id).all()
+    }
+    assert roles == {"christian@example.test": "admin", "julia@example.test": "member"}
+    for email in users:
+        assert db_session.query(TribeMembership).filter_by(user_id=email, role="admin").count() >= 1
+
+    second_plan = plan_setup_manifest(db_session, resolved)
+    assert second_plan["summary"] == {"create": 0, "update": 0, "unchanged": 5}
+
+    before_audits = db_session.query(SettingsAuditLog).count()
+    with patch("app.utils.setup_manifest.notify_settings_updated"):
+        second_apply = apply_setup_manifest(db_session, resolved)
+    assert second_apply["applied"] == []
+    assert db_session.query(SettingsAuditLog).count() == before_audits

--- a/tests/test_setup_manifest.py
+++ b/tests/test_setup_manifest.py
@@ -71,9 +71,7 @@ _ENV = {
 def test_example_and_json_schema_use_the_runtime_api_version():
     root = Path(__file__).resolve().parents[1]
     example = json.loads((root / "examples" / "agentic-setup.preprod.json").read_text(encoding="utf-8"))
-    schema = json.loads(
-        (root / "schemas" / "docuelevate-setup-v1alpha1.schema.json").read_text(encoding="utf-8")
-    )
+    schema = json.loads((root / "schemas" / "docuelevate-setup-v1alpha1.schema.json").read_text(encoding="utf-8"))
     assert example["apiVersion"] == MANIFEST_API_VERSION
     assert example["kind"] == MANIFEST_KIND
     assert schema["properties"]["apiVersion"]["const"] == MANIFEST_API_VERSION
@@ -115,9 +113,12 @@ def test_manifest_reports_missing_secret_reference():
         (lambda manifest: manifest["spec"].update({"completeSetup": "false"}), "boolean"),
         (lambda manifest: manifest["spec"]["users"][1].update({"username": "christian"}), "username"),
         (lambda manifest: manifest["spec"]["users"][1].update({"isAdmin": "false"}), "boolean"),
-        (lambda manifest: manifest["spec"]["tribes"][0]["members"].append(
-            {"email": "julia@example.test", "role": "member"}
-        ), "Duplicate member"),
+        (
+            lambda manifest: manifest["spec"]["tribes"][0]["members"].append(
+                {"email": "julia@example.test", "role": "member"}
+            ),
+            "Duplicate member",
+        ),
     ],
 )
 def test_manifest_rejects_ambiguous_or_duplicate_desired_state(mutate, error):

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -109,9 +109,11 @@ class TestIsSetupRequired:
         result = is_setup_required()
         assert isinstance(result, bool)
 
-    def test_setup_required_when_admin_password_is_none(self):
-        """Test that setup is required when admin_password is None (test environment default)."""
-        # In the test environment, admin_password defaults to None which is a placeholder value
+    @patch("app.utils.setup_wizard.settings")
+    def test_setup_required_when_admin_password_is_none(self, mock_settings):
+        """Test that setup is required when admin_password is None."""
+        mock_settings.session_secret = "a_very_long_real_session_secret_that_is_definitely_not_placeholder"
+        mock_settings.admin_password = None
         result = is_setup_required()
         assert result is True
 
@@ -149,15 +151,15 @@ class TestIsSetupRequired:
 
     @patch("app.utils.setup_wizard.settings")
     def test_handles_exception_gracefully(self, mock_settings):
-        """Test that exceptions are handled gracefully and return False (fail open)."""
+        """An unreadable security state keeps the installation in setup."""
 
         def raise_error():
             raise RuntimeError("boom")
 
         type(mock_settings).session_secret = property(lambda s: raise_error())
-        # This should not raise - it returns False on error (fail open)
+        # This should not raise and must fail closed.
         result = is_setup_required()
-        assert result is False
+        assert result is True
 
 
 @pytest.mark.unit

--- a/tests/test_upload_handlers.py
+++ b/tests/test_upload_handlers.py
@@ -249,7 +249,7 @@ class TestUploadGoogleDrive:
             self._call(fp, {}, {})
 
     def test_oauth_upload_calls_drive_api(self, tmp_path):
-        """OAuth credentials (client_id + client_secret + refresh_token) trigger OAuth flow."""
+        """Operator app credentials plus a user's refresh token trigger OAuth."""
         fp = str(tmp_path / "doc.pdf")
         _write_file(fp)
 
@@ -268,20 +268,22 @@ class TestUploadGoogleDrive:
         mock_google_auth_transport.requests.Request = MagicMock()
         mock_media_upload = MagicMock()
 
-        with patch.dict(
-            "sys.modules",
-            {
-                "googleapiclient.discovery": MagicMock(build=mock_build),
-                "googleapiclient.http": MagicMock(MediaFileUpload=mock_media_upload),
-                "google.oauth2.credentials": mock_google_oauth2.credentials,
-                "google.auth.transport.requests": mock_google_auth_transport.requests,
-                "google.oauth2.service_account": MagicMock(),
-            },
+        modules = {
+            "googleapiclient.discovery": MagicMock(build=mock_build),
+            "googleapiclient.http": MagicMock(MediaFileUpload=mock_media_upload),
+            "google.oauth2.credentials": mock_google_oauth2.credentials,
+            "google.auth.transport.requests": mock_google_auth_transport.requests,
+            "google.oauth2.service_account": MagicMock(),
+        }
+        with (
+            patch.dict("sys.modules", modules),
+            patch("app.tasks.upload_to_user_integration.settings.google_drive_client_id", "cid"),
+            patch("app.tasks.upload_to_user_integration.settings.google_drive_client_secret", "csec"),
         ):
             result = self._call(
                 fp,
                 {"folder_id": "folder-xyz"},
-                {"client_id": "cid", "client_secret": "csec", "refresh_token": "rtoken"},
+                {"refresh_token": "rtoken"},
             )
 
         assert result["status"] == "Completed"

--- a/tests/test_views_general.py
+++ b/tests/test_views_general.py
@@ -1,5 +1,7 @@
 """Tests for app/views/general.py module."""
 
+from unittest.mock import patch
+
 import pytest
 
 
@@ -116,7 +118,9 @@ class TestGeneralViews:
         # May be 200 or 404 depending on whether the file exists
         assert response.status_code in (200, 404)
 
-    def test_index_with_setup_complete(self, client):
-        """Test index page with setup=complete query param."""
+    @patch("app.utils.setup_wizard.is_setup_required", return_value=True)
+    def test_index_query_does_not_bypass_setup(self, _setup_required, client):
+        """Setup completion is server-owned, never accepted from the URL."""
         response = client.get("/?setup=complete", follow_redirects=False)
-        assert response.status_code == 200
+        assert response.status_code == 303
+        assert response.headers["location"] == "/setup?step=1"

--- a/tests/test_views_wizard.py
+++ b/tests/test_views_wizard.py
@@ -45,7 +45,7 @@ class TestWizardViews:
 
     def test_setup_wizard_skip(self, client):
         """Test skipping the setup wizard."""
-        response = client.get("/setup/skip", follow_redirects=False)
+        response = client.post("/setup/skip", follow_redirects=False)
         assert response.status_code in (200, 303)
 
     @patch("app.utils.settings_service.get_setting_from_db")
@@ -116,8 +116,9 @@ class TestWizardViewsPost:
         assert response.status_code == 303
         mock_save.assert_not_called()
 
+    @patch("app.views.wizard.get_missing_required_settings", return_value=[])
     @patch("app.views.wizard.save_setting_to_db")
-    def test_setup_wizard_save_last_step_redirects_home(self, mock_save, client):
+    def test_setup_wizard_save_last_step_records_completion(self, mock_save, _mock_missing, client):
         """Test that last step redirects to home."""
         mock_save.return_value = True
 
@@ -132,7 +133,8 @@ class TestWizardViewsPost:
         )
 
         assert response.status_code == 303
-        assert "/?setup=complete" in response.headers["location"]
+        assert response.headers["location"] == "/"
+        assert any(call.args[1] == "_setup_wizard_completed" for call in mock_save.call_args_list)
 
     @patch("app.views.wizard.save_setting_to_db")
     def test_setup_wizard_save_failed_setting(self, mock_save, client):
@@ -198,7 +200,7 @@ class TestWizardSkip:
         """Test successful skipping of setup wizard."""
         mock_save.return_value = True
 
-        response = client.get("/setup/skip", follow_redirects=False)
+        response = client.post("/setup/skip", follow_redirects=False)
 
         assert response.status_code == 303
         assert response.headers["location"] == "/"
@@ -212,7 +214,7 @@ class TestWizardSkip:
         """Test exception handling when skipping wizard."""
         mock_save.side_effect = Exception("Database error")
 
-        response = client.get("/setup/skip", follow_redirects=False)
+        response = client.post("/setup/skip", follow_redirects=False)
 
         # Should still redirect to home even on error
         assert response.status_code == 303
@@ -228,7 +230,7 @@ class TestWizardUndoSkip:
         """Test successful undo of wizard skip (covers lines 166-171)."""
         mock_delete.return_value = True
 
-        response = client.get("/setup/undo-skip", follow_redirects=False)
+        response = client.post("/setup/undo-skip", follow_redirects=False)
 
         assert response.status_code == 303
         assert "/setup?step=1" in response.headers["location"]
@@ -241,7 +243,56 @@ class TestWizardUndoSkip:
         """Test exception handling when undoing wizard skip (covers lines 172-174)."""
         mock_delete.side_effect = Exception("Database error")
 
-        response = client.get("/setup/undo-skip", follow_redirects=False)
+        response = client.post("/setup/undo-skip", follow_redirects=False)
 
         assert response.status_code == 303
         assert response.headers["location"] == "/settings"
+
+
+@pytest.mark.integration
+class TestWizardBootstrapBoundary:
+    """First-run setup is public once, then administrator-only."""
+
+    def test_real_first_run_session_can_continue_after_step_one(self, client):
+        with (
+            patch("app.views.wizard.app_settings.auth_enabled", True),
+            patch("app.views.wizard.is_setup_required", return_value=True),
+        ):
+            assert client.get("/setup?step=1", follow_redirects=False).status_code == 200
+            assert client.get("/setup?step=2", follow_redirects=False).status_code == 200
+
+    def test_non_bootstrap_visitor_cannot_jump_into_setup(self, client):
+        with patch("app.views.wizard.app_settings.auth_enabled", True):
+            response = client.get("/setup?step=2", follow_redirects=False)
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/login?next=/setup")
+
+    def test_completed_install_requires_admin_for_setup(self, client):
+        with (
+            patch("app.views.wizard.app_settings.auth_enabled", True),
+            patch("app.views.wizard.is_setup_required", return_value=False),
+        ):
+            response = client.get("/setup?step=1", follow_redirects=False)
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/login?next=/setup")
+
+    @patch("app.views.wizard.save_setting_to_db")
+    def test_unauthenticated_visitor_cannot_skip_setup(self, mock_save, client):
+        with patch("app.views.wizard.app_settings.auth_enabled", True):
+            response = client.post("/setup/skip", follow_redirects=False)
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/login?next=/setup/skip")
+        mock_save.assert_not_called()
+
+    def test_required_admin_password_cannot_be_skipped(self, client):
+        with (
+            patch("app.views.wizard.app_settings.admin_password", None),
+            patch("app.views.wizard.get_setting_from_db", return_value=None),
+        ):
+            response = client.post(
+                "/setup",
+                data={"step": "2", "admin_username": "admin", "admin_password": ""},
+                follow_redirects=False,
+            )
+        assert response.status_code == 303
+        assert response.headers["location"] == "/setup?step=2&error=required_missing"

--- a/tests/test_wizard_db_persist.py
+++ b/tests/test_wizard_db_persist.py
@@ -100,14 +100,14 @@ class TestSetupWizardUndoSkip:
         assert get_setting_from_db(db_session, "_setup_wizard_skipped") == "true"
 
         # Undo skip via the route
-        response = client.get("/setup/undo-skip", follow_redirects=False)
+        response = client.post("/setup/undo-skip", follow_redirects=False)
 
         # Should redirect
         assert response.status_code in (303, 200)
 
     def test_undo_skip_redirects_to_wizard(self, client):
         """Test that undo-skip redirects to /setup?step=1."""
-        response = client.get("/setup/undo-skip", follow_redirects=False)
+        response = client.post("/setup/undo-skip", follow_redirects=False)
         # The redirect should go to /setup?step=1 or /settings on error
         assert response.status_code in (303, 302)
         location = response.headers.get("location", "")
@@ -118,7 +118,7 @@ class TestSetupWizardUndoSkip:
         """Test that undo-skip calls delete_setting_from_db."""
         mock_delete.return_value = True
         # Just ensure the route exists and does not 404
-        response = client.get("/setup/undo-skip", follow_redirects=False)
+        response = client.post("/setup/undo-skip", follow_redirects=False)
         assert response.status_code != 404
 
 


### PR DESCRIPTION
## What changed

- hardens the first-run wizard so setup completion is server-owned, required credentials cannot be skipped, and sensitive settings fail closed
- encrypts sensitive settings audit values and scrubs legacy plaintext audit entries
- adds an idempotent, AI-readable `DocuElevateSetup` manifest with JSON Schema, plan/apply CLI, examples, and documentation
- adds Helm support for existing runtime/setup Secrets and an atomic post-install/post-upgrade setup Job
- adds a Terraform Kubernetes example that deploys the Helm chart without placing raw secrets in Terraform variables or state
- adds fresh-install Compose controls and deployment contract tests

## Why

A fresh DocuElevate installation should be reproducible from minimal infrastructure credentials, safe for multi-user bootstrap, and usable by both humans and setup agents. Runtime settings belong in the database; bootstrap and setup-only secrets remain externally managed.

## Validation

- 6,373 tests passed in the broad suite (40 skipped; Docker-backed full-stack/WebDAV tests excluded because the local Docker context is unavailable)
- 202 focused setup, manifest, wizard, audit, Compose, and deployment tests passed (8 skipped)
- Ruff passed
- Terraform format and validation passed
- Helm lint and template rendering passed
- MkDocs build passed
- diff and secret-pattern checks passed

Part of #1134.

## Scope note

This v1alpha1 manifest covers settings, users, Tribes, and setup completion. Declarative pipelines, integration instances, routing/privacy rules, and interactive OAuth grants remain follow-up work.