### PR TITLE
fix: secure notification logs and release version sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Update build metadata files if changed
         run: |
-          for f in VERSION BUILD_DATE GIT_SHA RUNTIME_INFO; do
+          for f in VERSION BUILD_DATE GIT_SHA RUNTIME_INFO helm/docuelevate/Chart.yaml; do
             if [ -f "$f" ]; then
               git add -f "$f"
             fi

--- a/app/utils/log_safety.py
+++ b/app/utils/log_safety.py
@@ -1,8 +1,14 @@
-"""Logging safeguards for providers that may include user content in DEBUG output."""
+"""Logging safeguards for providers that may include sensitive data in output."""
 
 import logging
 
-SENSITIVE_PROVIDER_LOGGERS = ("openai", "openai._base_client")
+SENSITIVE_PROVIDER_LOGGERS = (
+    "openai",
+    "openai._base_client",
+    # Apprise DEBUG messages can contain complete provider request payloads,
+    # including API tokens and recipient identifiers.
+    "apprise",
+)
 
 
 def restrict_sensitive_provider_logging(*_args: object, **_kwargs: object) -> None:

--- a/app/utils/notification.py
+++ b/app/utils/notification.py
@@ -11,6 +11,14 @@ logger = logging.getLogger(__name__)
 _apprise = None
 
 
+def _notification_service_name(server: object) -> str:
+    """Return a credential-free provider label for log messages."""
+    class_name = type(server).__name__
+    if class_name.startswith("Notify") and len(class_name) > len("Notify"):
+        return class_name[len("Notify") :]
+    return class_name or "notification provider"
+
+
 def init_apprise() -> apprise.Apprise:
     """Initialize the Apprise instance with configured notification services"""
     global _apprise
@@ -24,8 +32,11 @@ def init_apprise() -> apprise.Apprise:
                 try:
                     _apprise.add(url)
                     logger.info(f"Added notification service: {_mask_sensitive_url(url)}")
-                except Exception as e:
-                    logger.error(f"Failed to add notification service: {str(e)}")
+                except Exception as exc:
+                    logger.error(
+                        "Failed to add a configured notification service (%s)",
+                        type(exc).__name__,
+                    )
         else:
             logger.warning("No notification services configured")
 
@@ -92,8 +103,8 @@ def send_notification(
         successful_services = 0
 
         for server in apprise_obj.servers:  # Iterate through the list directly
+            service_name = _notification_service_name(server)
             try:
-                service_name = str(server).split("://")[0] if "://" in str(server) else str(server)
                 service_result = server.notify(title=title, body=message, notify_type=notify_type, attach=attachments)
 
                 if service_result:
@@ -101,8 +112,12 @@ def send_notification(
                     logger.debug(f"Notification sent via {service_name}")
                 else:
                     logger.warning(f"Failed to send notification via {service_name}")
-            except Exception as e:
-                logger.error(f"Error sending notification via {str(server)}: {str(e)}")
+            except Exception as exc:
+                logger.error(
+                    "Error sending notification via %s (%s)",
+                    service_name,
+                    type(exc).__name__,
+                )
 
         overall_result = successful_services > 0
 
@@ -113,8 +128,8 @@ def send_notification(
 
         return overall_result
 
-    except Exception as e:
-        logger.exception(f"Error sending notification: {e}")
+    except Exception as exc:
+        logger.error("Error sending notification (%s)", type(exc).__name__)
         return False
 
 

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -603,6 +603,11 @@ DocuElevate uses Python's standard `logging` module. Two environment variables c
 
 1. If `LOG_LEVEL` is explicitly set, it always wins — regardless of `DEBUG`.
 2. If only `DEBUG=true` is set (no `LOG_LEVEL`), the effective level becomes `DEBUG`.
+
+Provider libraries that may log document content or credential-bearing request
+payloads remain pinned to `WARNING` even when application logging is set to
+`DEBUG`. This currently includes the OpenAI SDK and Apprise notification
+providers.
 3. If neither is set, the default level is `INFO`.
 
 ```bash

--- a/helm/docuelevate/Chart.yaml
+++ b/helm/docuelevate/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 version: 0.2.0
 
 # Application version — kept in sync with the VERSION file.
-appVersion: "0.186.0"
+appVersion: "0.186.1"
 
 keywords:
   - document-management

--- a/scripts/generate_build_metadata.sh
+++ b/scripts/generate_build_metadata.sh
@@ -68,6 +68,30 @@ else
     VERSION="unknown"
 fi
 
+# Keep the Helm application version aligned with the product version. The
+# chart package version remains independent, but appVersion must describe the
+# image/application release represented by VERSION.
+HELM_CHART="helm/docuelevate/Chart.yaml"
+if [ -f "${HELM_CHART}" ] && [ "${VERSION}" != "unknown" ]; then
+    VERSION="${VERSION}" python3 - <<'PY'
+import os
+import re
+from pathlib import Path
+
+chart = Path("helm/docuelevate/Chart.yaml")
+content = chart.read_text(encoding="utf-8")
+updated, count = re.subn(
+    r'(?m)^appVersion:\s*["\x27]?[^"\x27\n]+["\x27]?\s*$',
+    f'appVersion: "{os.environ["VERSION"]}"',
+    content,
+)
+if count != 1:
+    raise SystemExit(f"Expected exactly one appVersion in {chart}, found {count}")
+chart.write_text(updated, encoding="utf-8")
+PY
+    echo "✓ Helm appVersion: ${VERSION}"
+fi
+
 # Look up release codename from release_names.json
 RELEASE_NAME=""
 if [ -f "release_names.json" ] && command -v python3 > /dev/null 2>&1; then

--- a/tests/test_deployment_contract.py
+++ b/tests/test_deployment_contract.py
@@ -14,6 +14,15 @@ def test_helm_app_version_matches_product_version():
     assert str(chart["appVersion"]) == (ROOT / "VERSION").read_text(encoding="utf-8").strip()
 
 
+def test_release_automation_keeps_helm_app_version_in_sync():
+    metadata_script = (ROOT / "scripts" / "generate_build_metadata.sh").read_text(encoding="utf-8")
+    release_workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert 'HELM_CHART="helm/docuelevate/Chart.yaml"' in metadata_script
+    assert 'appVersion: "{os.environ["VERSION"]}"' in metadata_script
+    assert "helm/docuelevate/Chart.yaml" in release_workflow
+
+
 def test_helm_processes_use_the_configurable_runtime_secret():
     templates = [
         "api-deployment.yaml",

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -233,6 +233,23 @@ class TestAppriseInitialization:
         # Should still return instance
         assert result == mock_apprise_instance
 
+    @patch("app.utils.notification.apprise.Apprise")
+    @patch("app.utils.notification.settings")
+    def test_init_failure_does_not_log_provider_secret(self, mock_settings, mock_apprise_class, caplog):
+        """Provider exceptions must not copy credentials into application logs."""
+        import app.utils.notification
+        from app.utils.notification import init_apprise
+
+        app.utils.notification._apprise = None
+        secret = "provider-secret-must-not-appear"
+        mock_settings.notification_urls = [f"custom://user:{secret}@example.com"]
+        mock_apprise_class.return_value.add.side_effect = RuntimeError(secret)
+
+        with caplog.at_level("DEBUG"):
+            init_apprise()
+
+        assert secret not in caplog.text
+
 
 @pytest.mark.unit
 class TestSendNotification:
@@ -371,6 +388,33 @@ class TestSendNotification:
         result = send_notification("Test", "Message")
 
         assert result is False
+
+    @patch("app.utils.notification.init_apprise")
+    @patch("app.utils.notification.settings")
+    def test_server_failure_does_not_log_provider_secret(self, mock_settings, mock_init_apprise, caplog):
+        """Neither a provider repr nor its exception may expose credentials."""
+        from app.utils.notification import send_notification
+
+        secret = "provider-secret-must-not-appear"
+
+        class NotifyExample:
+            def __str__(self):
+                return f"custom://user:{secret}@example.com"
+
+            def notify(self, **_kwargs):
+                raise RuntimeError(secret)
+
+        mock_settings.notification_urls = ["configured"]
+        mock_apprise = MagicMock()
+        mock_apprise.servers = [NotifyExample()]
+        mock_init_apprise.return_value = mock_apprise
+
+        with caplog.at_level("DEBUG"):
+            result = send_notification("Test", "Message")
+
+        assert result is False
+        assert secret not in caplog.text
+        assert "via Example" in caplog.text
 
 
 @pytest.mark.unit

--- a/tests/utils/test_log_safety.py
+++ b/tests/utils/test_log_safety.py
@@ -26,3 +26,22 @@ def test_sensitive_provider_logging_never_includes_debug_prompts(openai_loggers)
     assert parent.getEffectiveLevel() == logging.WARNING
     assert request_logger.getEffectiveLevel() == logging.WARNING
     assert not request_logger.isEnabledFor(logging.DEBUG)
+
+
+@pytest.mark.unit
+def test_apprise_logging_never_includes_debug_payloads():
+    apprise_logger = logging.getLogger("apprise")
+    plugin_logger = logging.getLogger("apprise.plugins.pushover")
+    previous_levels = (apprise_logger.level, plugin_logger.level)
+    try:
+        apprise_logger.setLevel(logging.DEBUG)
+        plugin_logger.setLevel(logging.NOTSET)
+
+        restrict_sensitive_provider_logging()
+
+        assert apprise_logger.getEffectiveLevel() == logging.WARNING
+        assert plugin_logger.getEffectiveLevel() == logging.WARNING
+        assert not plugin_logger.isEnabledFor(logging.DEBUG)
+    finally:
+        apprise_logger.setLevel(previous_levels[0])
+        plugin_logger.setLevel(previous_levels[1])


### PR DESCRIPTION
## Summary

- pin the complete Apprise logger hierarchy to `WARNING`, including when DocuElevate runs at `DEBUG`
- remove provider objects and raw exception messages from DocuElevate notification logs
- keep credential-free provider labels and exception classes for operability
- document the logging safety boundary
- add regression tests proving representative provider secrets never enter captured logs
- repair the `0.186.1` product/Helm `appVersion` drift created by semantic release
- teach release automation to update and commit Helm `appVersion` on every future release

## Verification

- `ruff format` and `ruff check` on changed Python files
- `mypy app/utils/log_safety.py app/utils/notification.py`
- 91 focused logging/notification tests passed
- 56 deployment/logging/notification tests passed
- dynamic release smoke: `NEW_VERSION=9.8.7` updated both `VERSION` and Helm `appVersion`
- initial full CI reached 6,399 passing tests; its only failure was the now-fixed pre-existing Helm version drift

Closes #1159

Production is not part of this change or rollout.