### PR TITLE
fix: build finalized release commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI Pipeline
 
 on:
+  workflow_dispatch:
   push:
     branches: [main, develop]
     tags: ['v*', '[0-9]+.*']
@@ -151,7 +152,7 @@ jobs:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
     needs: [run-tests, mypy, dependency-scan, html-lint, migration-chain]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -240,7 +241,7 @@ jobs:
     name: Update Preprod K8s Manifest
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     steps:
       - name: Compute image tag
         id: tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: write
@@ -105,3 +106,8 @@ jobs:
             git commit -m "chore(release): update build metadata files [skip ci]"
             /tmp/release-push-main
           fi
+
+      - name: Build and deploy the finalized release commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run ci.yml --ref main

--- a/tests/test_deployment_contract.py
+++ b/tests/test_deployment_contract.py
@@ -2,7 +2,10 @@
 
 from pathlib import Path
 
+import pytest
 import yaml
+
+pytestmark = pytest.mark.unit
 
 ROOT = Path(__file__).resolve().parents[1]
 CHART = ROOT / "helm" / "docuelevate"
@@ -21,6 +24,37 @@ def test_release_automation_keeps_helm_app_version_in_sync():
     assert 'HELM_CHART="helm/docuelevate/Chart.yaml"' in metadata_script
     assert 'appVersion: "{os.environ["VERSION"]}"' in metadata_script
     assert "helm/docuelevate/Chart.yaml" in release_workflow
+
+
+def test_release_automation_builds_the_finalized_release_commit():
+    ci_workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
+    release_workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8"))
+
+    # PyYAML 1.1 parses the unquoted GitHub Actions key `on` as boolean True.
+    ci_triggers = ci_workflow.get("on", ci_workflow.get(True, {}))
+    assert "workflow_dispatch" in ci_triggers
+    assert ci_workflow["jobs"]["build"]["if"] == (
+        "github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')"
+    )
+    assert ci_workflow["jobs"]["update-k8s-manifest"]["if"] == (
+        "github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')"
+    )
+
+    assert release_workflow["permissions"]["actions"] == "write"
+    release_steps = release_workflow["jobs"]["release"]["steps"]
+    metadata_index = next(
+        index
+        for index, step in enumerate(release_steps)
+        if step.get("name") == "Update build metadata files if changed"
+    )
+    dispatch_index, dispatch_step = next(
+        (index, step)
+        for index, step in enumerate(release_steps)
+        if step.get("name") == "Build and deploy the finalized release commit"
+    )
+    assert metadata_index < dispatch_index
+    assert dispatch_step["env"]["GH_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
+    assert dispatch_step["run"] == "gh workflow run ci.yml --ref main"
 
 
 def test_helm_processes_use_the_configurable_runtime_secret():


### PR DESCRIPTION
## Summary

- add an explicit manual entry point to the CI workflow
- grant Semantic Release the narrow Actions permission needed to dispatch CI
- dispatch CI only after version, changelog, build metadata, and Helm appVersion have been finalized on main
- add a deployment-contract regression test for the complete handoff

## Verification

- 6 deployment-contract tests passed
- Ruff format/check passed
- whitespace validation passed

Closes #1163

Production is not part of this change or rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Automation**
  * Added support for manually triggering production image builds and preproduction manifest updates from the main branch.
  * Release completion now automatically triggers the CI workflow to build and deploy the finalized release.
  * Updated workflow permissions to support this automation.

* **Tests**
  * Added regression coverage to verify release and CI workflow integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->