### PR TITLE
Handle encrypted PDFs without worker retry loops

### DIFF
--- a/app/tasks/process_document.py
+++ b/app/tasks/process_document.py
@@ -10,8 +10,7 @@ import shutil
 import uuid
 from typing import TYPE_CHECKING
 
-import pypdf
-from pypdf.errors import PdfReadError
+from pypdf.errors import FileNotDecryptedError, PdfReadError
 
 from app.celery_app import celery
 from app.config import settings
@@ -21,6 +20,12 @@ from app.tasks.extract_metadata_with_gpt import extract_metadata_with_gpt
 from app.tasks.process_with_ocr import process_with_ocr
 from app.tasks.retry_config import BaseTaskWithRetry
 from app.utils import get_unique_filepath_with_counter, hash_file, log_task_progress
+from app.utils.pdf_security import (
+    ENCRYPTED_PDF_ERROR_CODE,
+    ENCRYPTED_PDF_MESSAGE,
+    EncryptedPdfPasswordRequiredError,
+    open_pdf_reader,
+)
 from app.utils.routing_engine import evaluate_pre_processing_routing_rules
 from app.utils.step_manager import initialize_file_steps
 from app.utils.text_quality import check_text_quality, detect_pdf_text_source
@@ -30,6 +35,45 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
+
+
+def _mark_encrypted_pdf_password_required(task_id: str, file_id: int) -> dict[str, object]:
+    """Stop processing safely and persist an actionable encrypted-PDF state."""
+    with SessionLocal() as db:
+        _set_index_first_source_state(db, task_id, "failed", ENCRYPTED_PDF_MESSAGE)
+        db.commit()
+
+    log_task_progress(
+        task_id,
+        "check_text",
+        "failure",
+        ENCRYPTED_PDF_MESSAGE,
+        file_id=file_id,
+        detail=ENCRYPTED_PDF_ERROR_CODE,
+    )
+    for step_name in ("extract_text", "process_with_ocr"):
+        log_task_progress(
+            task_id,
+            step_name,
+            "skipped",
+            "Skipped because the PDF requires a password",
+            file_id=file_id,
+            detail=ENCRYPTED_PDF_ERROR_CODE,
+        )
+    log_task_progress(
+        task_id,
+        "process_document",
+        "failure",
+        ENCRYPTED_PDF_MESSAGE,
+        file_id=file_id,
+        detail=ENCRYPTED_PDF_ERROR_CODE,
+    )
+    return {
+        "status": "Password required",
+        "error": ENCRYPTED_PDF_MESSAGE,
+        "error_code": ENCRYPTED_PDF_ERROR_CODE,
+        "file_id": file_id,
+    }
 
 
 def _set_index_first_source_state(db: "Session", task_id: str, state: str, error: str | None = None) -> None:
@@ -723,12 +767,15 @@ def process_document(
     )
     try:
         with open(new_local_path, "rb") as file:
-            pdf_reader = pypdf.PdfReader(file)
+            pdf_reader = open_pdf_reader(file)
             has_text = False
             for page in pdf_reader.pages:
                 if page.extract_text().strip():
                     has_text = True
                     break
+    except (EncryptedPdfPasswordRequiredError, FileNotDecryptedError):
+        logger.info("[%s] Stopped processing a password-protected PDF", task_id)
+        return _mark_encrypted_pdf_password_required(task_id, file_id)
     except PdfReadError as exc:
         logger.warning(f"[{task_id}] PDF read error during embedded text check: {exc}")
         log_task_progress(
@@ -772,7 +819,7 @@ def process_document(
         )
         extracted_text = ""
         with open(new_local_path, "rb") as file:
-            pdf_reader = pypdf.PdfReader(file)
+            pdf_reader = open_pdf_reader(file)
             for page in pdf_reader.pages:
                 extracted_text += page.extract_text() + "\n"
 

--- a/app/tasks/process_document.py
+++ b/app/tasks/process_document.py
@@ -680,9 +680,18 @@ def process_document(
         # Store file_id before session closes to avoid DetachedInstanceError
         file_id = new_record.id
 
+    is_pdf = mime_type == "application/pdf" or os.path.splitext(new_local_path)[1].lower() == ".pdf"
+
     # 2. Check for embedded text (outside the DB session to avoid long open transactions)
     # Skip local text extraction if force_cloud_ocr is True
     if force_cloud_ocr:
+        if is_pdf:
+            try:
+                with open(new_local_path, "rb") as file:
+                    open_pdf_reader(file)
+            except (EncryptedPdfPasswordRequiredError, FileNotDecryptedError):
+                logger.info("[%s] Stopped forced OCR for a password-protected PDF", task_id)
+                return _mark_encrypted_pdf_password_required(task_id, file_id)
         if index_only:
             return _mark_index_first_pending(
                 task_id,
@@ -718,7 +727,6 @@ def process_document(
         return {"file": new_local_path, "status": "Queued for forced OCR", "file_id": file_id}
 
     # If the file is not a PDF, skip embedded text check and convert to PDF first
-    is_pdf = mime_type == "application/pdf" or os.path.splitext(new_local_path)[1].lower() == ".pdf"
     if not is_pdf:
         if index_only:
             return _mark_index_first_pending(

--- a/app/utils/pdf_security.py
+++ b/app/utils/pdf_security.py
@@ -1,0 +1,33 @@
+"""Safe handling for encrypted PDF inputs."""
+
+from typing import BinaryIO
+
+import pypdf
+from pypdf import PasswordType
+from pypdf.errors import FileNotDecryptedError
+
+ENCRYPTED_PDF_ERROR_CODE = "encrypted_pdf_password_required"
+ENCRYPTED_PDF_MESSAGE = (
+    "This PDF is password-protected. Upload an unprotected copy, then start processing again. "
+    "The original file was retained and was not sent to OCR or AI services."
+)
+
+
+class EncryptedPdfPasswordRequiredError(Exception):
+    """Raised when a PDF cannot be opened without a user password."""
+
+
+def open_pdf_reader(file_obj: BinaryIO) -> pypdf.PdfReader:
+    """Open a PDF, accepting owner-password-only files with an empty user password."""
+    reader = pypdf.PdfReader(file_obj)
+    if not reader.is_encrypted:
+        return reader
+
+    try:
+        password_type = reader.decrypt("")
+    except FileNotDecryptedError as exc:
+        raise EncryptedPdfPasswordRequiredError(ENCRYPTED_PDF_MESSAGE) from exc
+
+    if password_type == PasswordType.NOT_DECRYPTED:
+        raise EncryptedPdfPasswordRequiredError(ENCRYPTED_PDF_MESSAGE)
+    return reader

--- a/app/views/files.py
+++ b/app/views/files.py
@@ -481,6 +481,10 @@ def file_detail_page(request: Request, file_id: int, db: Session = Depends(get_d
         # Compute processing flow for visualization — filter to pipeline steps when available
         flow_data = _compute_processing_flow(logs, pipeline_steps=pipeline_info["steps"] if pipeline_info else None)
 
+        from app.utils.pdf_security import ENCRYPTED_PDF_ERROR_CODE
+
+        encrypted_pdf_password_required = any(log.detail == ENCRYPTED_PDF_ERROR_CODE for log in logs)
+
         # Compute step-aligned summary from status table (preferred) or fallback to logs
         try:
             from app.utils.step_manager import get_step_summary as get_step_summary_from_table
@@ -504,6 +508,7 @@ def file_detail_page(request: Request, file_id: int, db: Session = Depends(get_d
                 "flow_data": flow_data,
                 "step_summary": step_summary,
                 "pipeline_info": pipeline_info,
+                "encrypted_pdf_password_required": encrypted_pdf_password_required,
             },
         )
     except Exception as e:
@@ -707,6 +712,8 @@ def _compute_processing_flow(logs, pipeline_steps=None):
             correspond to the pipeline's enabled steps (plus bookkeeping stages like
             ``create_file_record`` and any stage that actually ran in the logs).
     """
+    from app.utils.pdf_security import ENCRYPTED_PDF_ERROR_CODE
+
     # Define the full catalogue of main processing stages
     stages = {
         "convert_to_pdf": {"label": "Convert to PDF", "next": ["check_for_duplicates", "create_file_record"]},
@@ -801,7 +808,13 @@ def _compute_processing_flow(logs, pipeline_steps=None):
             if step_name not in step_map:
                 step_map[step_name] = []
             step_map[step_name].append(
-                {"status": log.status, "message": log.message, "timestamp": log.timestamp, "task_id": log.task_id}
+                {
+                    "status": log.status,
+                    "message": log.message,
+                    "timestamp": log.timestamp,
+                    "task_id": log.task_id,
+                    "detail": getattr(log, "detail", None),
+                }
             )
 
     # Build the flow structure
@@ -816,11 +829,15 @@ def _compute_processing_flow(logs, pipeline_steps=None):
             message = latest_log["message"]
             timestamp = latest_log["timestamp"]
             task_id = latest_log["task_id"]
+            detail = latest_log["detail"]
         else:
             status = "not_run"
             message = None
             timestamp = None
             task_id = None
+            detail = None
+
+        requires_source_replacement = detail == ENCRYPTED_PDF_ERROR_CODE
 
         stage_data = {
             "key": stage_key,
@@ -829,7 +846,8 @@ def _compute_processing_flow(logs, pipeline_steps=None):
             "message": message,
             "timestamp": timestamp,
             "task_id": task_id,
-            "can_retry": status == "failure",
+            "can_retry": status == "failure" and not requires_source_replacement,
+            "requires_source_replacement": requires_source_replacement,
             "is_branch_parent": stage_info.get("has_branches", False),
         }
 

--- a/frontend/templates/file_detail.html
+++ b/frontend/templates/file_detail.html
@@ -1477,6 +1477,21 @@
     </div>
   </div>
 
+  {% if encrypted_pdf_password_required %}
+  <div class="detail-card" role="alert" style="border-left: 5px solid #d97706; background: #fffbeb;">
+    <div style="display: flex; gap: 0.85rem; align-items: flex-start;">
+      <i class="fas fa-lock" aria-hidden="true" style="color: #b45309; font-size: 1.4rem; margin-top: 0.15rem;"></i>
+      <div>
+        <h3 style="margin: 0 0 0.35rem; color: #92400e;">Password-protected PDF</h3>
+        <p style="margin: 0; color: #78350f;">
+          DocuElevate kept the original file and did not send it to OCR or AI services.
+          Upload an unprotected copy of the PDF and start processing that copy instead.
+        </p>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   <!-- Step Summary Card -->
   {% if step_summary %}
   <div class="detail-card">

--- a/tests/test_encrypted_pdf_handling.py
+++ b/tests/test_encrypted_pdf_handling.py
@@ -49,7 +49,8 @@ def test_owner_password_only_pdf_remains_processable(tmp_path):
 
 
 @pytest.mark.requires_db
-def test_process_document_stops_cleanly_for_password_protected_pdf(db_session, tmp_path):
+@pytest.mark.parametrize("force_cloud_ocr", [False, True])
+def test_process_document_stops_cleanly_for_password_protected_pdf(db_session, tmp_path, force_cloud_ocr):
     protected_pdf = tmp_path / "protected.pdf"
     _write_encrypted_pdf(protected_pdf, user_password="required-password")
 
@@ -60,7 +61,7 @@ def test_process_document_stops_cleanly_for_password_protected_pdf(db_session, t
         patch("app.tasks.process_document.process_with_ocr.delay") as queue_ocr,
         patch("app.tasks.process_document.extract_metadata_with_gpt.delay") as queue_metadata,
     ):
-        result = process_document.run(str(protected_pdf))
+        result = process_document.run(str(protected_pdf), force_cloud_ocr=force_cloud_ocr)
 
     assert result["status"] == "Password required"
     assert result["error_code"] == ENCRYPTED_PDF_ERROR_CODE

--- a/tests/test_encrypted_pdf_handling.py
+++ b/tests/test_encrypted_pdf_handling.py
@@ -1,0 +1,107 @@
+"""Regression coverage for password-protected PDF handling."""
+
+from contextlib import nullcontext
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pypdf
+import pytest
+
+from app.config import settings
+from app.models import FileRecord
+from app.tasks.process_document import process_document
+from app.utils.pdf_security import (
+    ENCRYPTED_PDF_ERROR_CODE,
+    ENCRYPTED_PDF_MESSAGE,
+    EncryptedPdfPasswordRequiredError,
+    open_pdf_reader,
+)
+from app.views.files import _compute_processing_flow
+
+pytestmark = pytest.mark.unit
+
+
+def _write_encrypted_pdf(path: Path, user_password: str, owner_credential: str = "owner-password") -> None:
+    writer = pypdf.PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+    writer.encrypt(user_password=user_password, owner_password=owner_credential)
+    with path.open("wb") as output:
+        writer.write(output)
+
+
+def test_pdf_with_real_user_password_is_rejected_before_page_access(tmp_path):
+    protected_pdf = tmp_path / "protected.pdf"
+    _write_encrypted_pdf(protected_pdf, user_password="required-password")
+
+    with protected_pdf.open("rb") as source, pytest.raises(EncryptedPdfPasswordRequiredError):
+        open_pdf_reader(source)
+
+
+def test_owner_password_only_pdf_remains_processable(tmp_path):
+    owner_only_pdf = tmp_path / "owner-only.pdf"
+    _write_encrypted_pdf(owner_only_pdf, user_password="")
+
+    with owner_only_pdf.open("rb") as source:
+        reader = open_pdf_reader(source)
+        assert len(reader.pages) == 1
+
+
+@pytest.mark.requires_db
+def test_process_document_stops_cleanly_for_password_protected_pdf(db_session, tmp_path):
+    protected_pdf = tmp_path / "protected.pdf"
+    _write_encrypted_pdf(protected_pdf, user_password="required-password")
+
+    with (
+        patch.object(settings, "workdir", str(tmp_path)),
+        patch("app.tasks.process_document.SessionLocal", return_value=nullcontext(db_session)),
+        patch("app.tasks.process_document.log_task_progress") as progress,
+        patch("app.tasks.process_document.process_with_ocr.delay") as queue_ocr,
+        patch("app.tasks.process_document.extract_metadata_with_gpt.delay") as queue_metadata,
+    ):
+        result = process_document.run(str(protected_pdf))
+
+    assert result["status"] == "Password required"
+    assert result["error_code"] == ENCRYPTED_PDF_ERROR_CODE
+    assert result["error"] == ENCRYPTED_PDF_MESSAGE
+    queue_ocr.assert_not_called()
+    queue_metadata.assert_not_called()
+
+    record = db_session.query(FileRecord).filter(FileRecord.id == result["file_id"]).one()
+    assert record.original_file_path
+    assert Path(record.original_file_path).exists()
+    assert any(
+        call.args[1:4] == ("check_text", "failure", ENCRYPTED_PDF_MESSAGE)
+        and call.kwargs["detail"] == ENCRYPTED_PDF_ERROR_CODE
+        for call in progress.call_args_list
+    )
+    assert any(
+        call.args[1:4] == ("process_with_ocr", "skipped", "Skipped because the PDF requires a password")
+        for call in progress.call_args_list
+    )
+
+
+def test_password_required_flow_suppresses_retry_and_requests_replacement():
+    log = SimpleNamespace(
+        step_name="check_text",
+        status="failure",
+        message=ENCRYPTED_PDF_MESSAGE,
+        detail=ENCRYPTED_PDF_ERROR_CODE,
+        timestamp=datetime.now(timezone.utc),
+        task_id="encrypted-pdf-task",
+    )
+
+    check_text = next(stage for stage in _compute_processing_flow([log]) if stage["key"] == "check_text")
+
+    assert check_text["status"] == "failure"
+    assert check_text["can_retry"] is False
+    assert check_text["requires_source_replacement"] is True
+
+
+def test_file_detail_contains_prominent_encrypted_pdf_remediation():
+    template = Path("frontend/templates/file_detail.html").read_text(encoding="utf-8")
+
+    assert "{% if encrypted_pdf_password_required %}" in template
+    assert 'role="alert"' in template
+    assert "did not send it to OCR or AI services" in template

--- a/tests/test_process_document.py
+++ b/tests/test_process_document.py
@@ -815,7 +815,7 @@ startxref
         patch("app.tasks.process_document.SessionLocal") as mock_session_local,
         patch("app.tasks.process_document.settings") as mock_settings,
         patch("app.tasks.process_document.log_task_progress"),
-        patch("app.tasks.process_document.pypdf.PdfReader") as mock_pdf_reader,
+        patch("app.tasks.process_document.open_pdf_reader") as mock_pdf_reader,
     ):
         # Setup mocks
         mock_settings.workdir = str(tmp_path)


### PR DESCRIPTION
## What changed

- detect PDFs that require a user password before any OCR or AI work is queued
- retain the original document and store a durable, stable failure state
- suppress automatic retry for a condition that cannot heal without a replacement file
- show a prominent remediation message on the file detail page
- preserve processing for owner-password-only PDFs that can be opened with an empty user password

## Why

Password-protected PDFs previously raised `FileNotDecryptedError` in the worker and entered the generic retry path. That created noisy failures without giving the user an actionable next step.

## Validation

- Ruff check and format
- Mypy on the affected application modules
- 169 focused processing and file-detail tests passed; 2 expected skips

Closes #1160
