### PR TITLE
Harden the Terraform deployment contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.8.5"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,21 @@ jobs:
       - run: pip install djlint>=1.36.0
       - run: djlint frontend/templates/ --lint
 
+  terraform-validate:
+    name: Terraform Deployment Contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.8.5"
+      - name: Check Terraform formatting
+        run: terraform fmt -check -recursive examples/terraform
+      - name: Initialize providers without a backend
+        run: terraform -chdir=examples/terraform/kubernetes init -backend=false -input=false
+      - name: Validate the Kubernetes deployment module
+        run: terraform -chdir=examples/terraform/kubernetes validate
+
   # ══════════════════════════════════════════════════════════════════════════
   # Stage 2: Parallel Heavy Lifters (Consolidated for Efficiency)
   # ══════════════════════════════════════════════════════════════════════════
@@ -151,7 +166,7 @@ jobs:
   build:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
-    needs: [run-tests, mypy, dependency-scan, html-lint, migration-chain]
+    needs: [run-tests, mypy, dependency-scan, html-lint, migration-chain, terraform-validate]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout Code

--- a/docs/TerraformDeployment.md
+++ b/docs/TerraformDeployment.md
@@ -61,7 +61,8 @@ The Helm release is atomic. A migration failure, invalid setup manifest, failed
 setup plan or failed setup apply causes the release to fail instead of leaving
 Terraform reporting a healthy deployment.
 
-Terraform also rejects ambiguous environment naming, a floating `latest` image,
+Terraform also rejects ambiguous environment naming with exact hyphen-delimited
+environment tokens, a floating `latest` image,
 and an agentic manifest without its short-lived setup Secret. CI runs real
 `terraform init` and `terraform validate` checks for the reference module on
 every pull request. After apply, use the non-sensitive `readiness_url` and

--- a/docs/TerraformDeployment.md
+++ b/docs/TerraformDeployment.md
@@ -61,6 +61,12 @@ The Helm release is atomic. A migration failure, invalid setup manifest, failed
 setup plan or failed setup apply causes the release to fail instead of leaving
 Terraform reporting a healthy deployment.
 
+Terraform also rejects ambiguous environment naming, a floating `latest` image,
+and an agentic manifest without its short-lived setup Secret. CI runs real
+`terraform init` and `terraform validate` checks for the reference module on
+every pull request. After apply, use the non-sensitive `readiness_url` and
+`deployed_image` outputs as the start of the acceptance check.
+
 ## Acceptance contract for an AI operator
 
 An AI may report the installation ready only after all of these checks pass:

--- a/examples/terraform/kubernetes/.terraform.lock.hcl
+++ b/examples/terraform/kubernetes/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.17.0"
   constraints = "~> 2.13"
   hashes = [
+    "h1:If79Gw54AMearm13Sk9RmWuDesCQQMUtmlJXXqISxfU=",
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = "~> 2.29"
   hashes = [
+    "h1:XCkL/mxjWTawg6gg+jlpCQhF/+SNRoCEZxbbkDTj42s=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",

--- a/examples/terraform/kubernetes/README.md
+++ b/examples/terraform/kubernetes/README.md
@@ -47,7 +47,8 @@ post-install action.
 9. Log in as every seeded user and prove document and Tribe isolation before
    treating the Canary as accepted.
 
-The module refuses a release or namespace name that omits `environment`, an
+The module refuses a release or namespace name that omits `environment` as a
+complete hyphen-delimited token (so `prod` never matches `preprod`), an
 `image_tag` of `latest`, or agentic setup without a dedicated setup Secret.
 These are plan-time safety failures, not conventions an operator must remember.
 The `readiness_url` and `deployed_image` outputs expose the two most important

--- a/examples/terraform/kubernetes/README.md
+++ b/examples/terraform/kubernetes/README.md
@@ -47,6 +47,12 @@ post-install action.
 9. Log in as every seeded user and prove document and Tribe isolation before
    treating the Canary as accepted.
 
+The module refuses a release or namespace name that omits `environment`, an
+`image_tag` of `latest`, or agentic setup without a dedicated setup Secret.
+These are plan-time safety failures, not conventions an operator must remember.
+The `readiness_url` and `deployed_image` outputs expose the two most important
+acceptance facts without reading credentials or Terraform state internals.
+
 Provider authentication is intentionally not defined here. Supply Kubernetes
 and Helm provider credentials through your normal CI or workstation identity;
 do not commit a kubeconfig or cluster token.

--- a/examples/terraform/kubernetes/main.tf
+++ b/examples/terraform/kubernetes/main.tf
@@ -1,6 +1,7 @@
 locals {
-  agentic_setup_enabled = var.agentic_setup_manifest_path != null
-  agentic_manifest      = local.agentic_setup_enabled ? file(var.agentic_setup_manifest_path) : ""
+  agentic_setup_enabled    = var.agentic_setup_manifest_path != null
+  agentic_manifest         = local.agentic_setup_enabled ? file(var.agentic_setup_manifest_path) : ""
+  environment_name_pattern = "(^|-)${lower(var.environment)}(-|$)"
 
   docuelevate_values = {
     image = {
@@ -65,12 +66,12 @@ resource "helm_release" "docuelevate" {
 
   lifecycle {
     precondition {
-      condition     = strcontains(lower(var.release_name), lower(var.environment))
+      condition     = can(regex(local.environment_name_pattern, lower(var.release_name)))
       error_message = "release_name must include the environment name (for example docuelevate-preprod-canary)."
     }
 
     precondition {
-      condition     = strcontains(lower(var.namespace), lower(var.environment))
+      condition     = can(regex(local.environment_name_pattern, lower(var.namespace)))
       error_message = "namespace must include the environment name so Canary, Preprod and production cannot be confused."
     }
 

--- a/examples/terraform/kubernetes/main.tf
+++ b/examples/terraform/kubernetes/main.tf
@@ -63,5 +63,27 @@ resource "helm_release" "docuelevate" {
     var.additional_helm_values,
   )
 
+  lifecycle {
+    precondition {
+      condition     = strcontains(lower(var.release_name), lower(var.environment))
+      error_message = "release_name must include the environment name (for example docuelevate-preprod-canary)."
+    }
+
+    precondition {
+      condition     = strcontains(lower(var.namespace), lower(var.environment))
+      error_message = "namespace must include the environment name so Canary, Preprod and production cannot be confused."
+    }
+
+    precondition {
+      condition     = lower(var.image_tag) != "latest"
+      error_message = "image_tag must be an immutable release or commit tag; latest is not allowed."
+    }
+
+    precondition {
+      condition     = !local.agentic_setup_enabled || trimspace(var.setup_secret_name) != ""
+      error_message = "setup_secret_name is required when agentic_setup_manifest_path is set."
+    }
+  }
+
   depends_on = [kubernetes_namespace_v1.docuelevate]
 }

--- a/examples/terraform/kubernetes/outputs.tf
+++ b/examples/terraform/kubernetes/outputs.tf
@@ -10,6 +10,16 @@ output "application_url" {
   value = "https://${var.external_hostname}"
 }
 
+output "readiness_url" {
+  description = "Acceptance endpoint that must report database and Redis ready before the deployment is complete."
+  value       = "https://${var.external_hostname}/api/diagnostic/healthz/ready"
+}
+
+output "deployed_image" {
+  description = "Pinned application image selected by the reviewed Terraform plan."
+  value       = "${var.image_repository}:${var.image_tag}"
+}
+
 output "agentic_setup_enabled" {
   value = local.agentic_setup_enabled
 }

--- a/examples/terraform/kubernetes/variables.tf
+++ b/examples/terraform/kubernetes/variables.tf
@@ -20,6 +20,11 @@ variable "environment" {
   description = "Environment label applied when this module creates the namespace."
   type        = string
   default     = "preprod"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.environment))
+    error_message = "environment must be a lowercase Kubernetes-safe name such as preprod or canary."
+  }
 }
 
 variable "chart_path" {
@@ -37,11 +42,21 @@ variable "image_repository" {
 variable "image_tag" {
   description = "Immutable image tag to deploy. Never use latest."
   type        = string
+
+  validation {
+    condition     = trimspace(var.image_tag) != ""
+    error_message = "image_tag must not be empty."
+  }
 }
 
 variable "external_hostname" {
   description = "Public hostname used by DocuElevate and OAuth callbacks."
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$", var.external_hostname))
+    error_message = "external_hostname must be a hostname without a URL scheme or path."
+  }
 }
 
 variable "bootstrap_secret_name" {

--- a/tests/test_deployment_contract.py
+++ b/tests/test_deployment_contract.py
@@ -99,8 +99,9 @@ def test_terraform_guards_environment_identity_and_agentic_secret_boundary():
     main = (TERRAFORM / "main.tf").read_text(encoding="utf-8")
     outputs = (TERRAFORM / "outputs.tf").read_text(encoding="utf-8")
 
-    assert "strcontains(lower(var.release_name), lower(var.environment))" in main
-    assert "strcontains(lower(var.namespace), lower(var.environment))" in main
+    assert 'environment_name_pattern = "(^|-)${lower(var.environment)}(-|$)"' in main
+    assert "can(regex(local.environment_name_pattern, lower(var.release_name)))" in main
+    assert "can(regex(local.environment_name_pattern, lower(var.namespace)))" in main
     assert 'lower(var.image_tag) != "latest"' in main
     assert '!local.agentic_setup_enabled || trimspace(var.setup_secret_name) != ""' in main
     assert 'output "readiness_url"' in outputs
@@ -115,4 +116,6 @@ def test_ci_runs_real_terraform_validation_before_building_images():
     assert "terraform fmt -check -recursive examples/terraform" in run_commands
     assert "terraform -chdir=examples/terraform/kubernetes init -backend=false -input=false" in run_commands
     assert "terraform -chdir=examples/terraform/kubernetes validate" in run_commands
+    checkout = terraform_job["steps"][0]
+    assert checkout["with"]["persist-credentials"] is False
     assert "terraform-validate" in workflow["jobs"]["build"]["needs"]

--- a/tests/test_deployment_contract.py
+++ b/tests/test_deployment_contract.py
@@ -93,3 +93,26 @@ def test_terraform_accepts_secret_names_but_not_secret_values():
     assert 'variable "session_secret"' not in variables.lower()
     assert "existingSecret = var.bootstrap_secret_name" in main
     assert "existingSecret = var.setup_secret_name" in main
+
+
+def test_terraform_guards_environment_identity_and_agentic_secret_boundary():
+    main = (TERRAFORM / "main.tf").read_text(encoding="utf-8")
+    outputs = (TERRAFORM / "outputs.tf").read_text(encoding="utf-8")
+
+    assert "strcontains(lower(var.release_name), lower(var.environment))" in main
+    assert "strcontains(lower(var.namespace), lower(var.environment))" in main
+    assert 'lower(var.image_tag) != "latest"' in main
+    assert '!local.agentic_setup_enabled || trimspace(var.setup_secret_name) != ""' in main
+    assert 'output "readiness_url"' in outputs
+    assert 'output "deployed_image"' in outputs
+
+
+def test_ci_runs_real_terraform_validation_before_building_images():
+    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
+    terraform_job = workflow["jobs"]["terraform-validate"]
+
+    run_commands = [step.get("run", "") for step in terraform_job["steps"]]
+    assert "terraform fmt -check -recursive examples/terraform" in run_commands
+    assert "terraform -chdir=examples/terraform/kubernetes init -backend=false -input=false" in run_commands
+    assert "terraform -chdir=examples/terraform/kubernetes validate" in run_commands
+    assert "terraform-validate" in workflow["jobs"]["build"]["needs"]


### PR DESCRIPTION
## What changed

- make real Terraform formatting, provider initialization and module validation a CI gate
- reject ambiguous release/namespace names that omit the target environment
- reject the floating `latest` image tag
- require the dedicated short-lived setup Secret whenever agentic setup is enabled
- expose non-sensitive deployed-image and readiness outputs
- document the enforced acceptance contract

## Why

The existing Terraform/Helm path already supported declarative installation, but its Terraform syntax was only covered by static source assertions. These changes make the deployment path executable and fail unsafe Canary/Preprod plans before apply.

## Validation

- Terraform 1.8.5 `fmt -check`, `init -backend=false`, and `validate`
- 8 deployment-contract tests passed
- Ruff check and format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment safety checks for environment naming, image tags, and agentic setup configuration.
  * Added readiness and deployed-image outputs for post-deployment verification.

* **Bug Fixes**
  * Improved validation for environment, image tag, and hostname inputs.

* **Documentation**
  * Expanded deployment guidance and acceptance-check instructions.

* **Tests**
  * Added automated coverage for deployment safeguards and Terraform validation in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->