### PR TITLE
fix: redact configuration diagnostics fail closed

### DIFF
--- a/app/tasks/uptime_kuma_tasks.py
+++ b/app/tasks/uptime_kuma_tasks.py
@@ -22,11 +22,13 @@ def ping_uptime_kuma():
         return
 
     try:
-        logger.info(f"Pinging Uptime Kuma at {settings.uptime_kuma_url}")
+        logger.info("Pinging configured Uptime Kuma endpoint")
         response = requests.get(settings.uptime_kuma_url, timeout=10)
         response.raise_for_status()
         logger.info(f"Successfully pinged Uptime Kuma: {response.status_code}")
         return True
-    except requests.exceptions.RequestException as e:
-        logger.error(f"Failed to ping Uptime Kuma: {e}")
+    except requests.exceptions.RequestException as exc:
+        # Requests may include the full push URL (including its secret token)
+        # in exception messages. Log only the failure class.
+        logger.error("Failed to ping Uptime Kuma (%s)", type(exc).__name__)
         return False

--- a/app/utils/config_validator/masking.py
+++ b/app/utils/config_validator/masking.py
@@ -43,6 +43,16 @@ _OPERATIONAL_TOKEN_FRAGMENTS = (
     "token_reservation",
     "token_threshold",
 )
+_NON_SECRET_SETTING_NAMES = {
+    "cors_allow_credentials",
+    "dropbox_allow_global_credentials_for_integrations",
+    "notify_on_credential_failure",
+    "sftp_disable_host_key_verification",
+    "social_auth_dropbox_use_global_credentials",
+    "social_auth_generic_oauth2_token_url",
+    "social_auth_google_use_global_credentials",
+    "social_auth_microsoft_use_global_credentials",
+}
 
 
 def is_sensitive_setting(name: str) -> bool:
@@ -53,6 +63,8 @@ def is_sensitive_setting(name: str) -> bool:
     visible.
     """
     normalized = name.lower()
+    if normalized in _NON_SECRET_SETTING_NAMES:
+        return False
     if normalized in _SENSITIVE_URL_SETTINGS:
         return True
     if any(fragment in normalized for fragment in _SENSITIVE_NAME_FRAGMENTS):

--- a/app/utils/config_validator/masking.py
+++ b/app/utils/config_validator/masking.py
@@ -4,6 +4,72 @@ Module for masking sensitive information in configuration values
 
 from sqlalchemy.engine import make_url
 
+CONFIGURED_VALUE = "<configured>"
+NOT_CONFIGURED_VALUE = "<not configured>"
+
+_SENSITIVE_NAME_PARTS = {
+    "credential",
+    "credentials",
+    "cookie",
+    "dsn",
+    "key",
+    "password",
+    "passphrase",
+    "secret",
+    "token",
+}
+_SENSITIVE_NAME_FRAGMENTS = (
+    "access_key",
+    "api_key",
+    "auth_token",
+    "client_secret",
+    "credentials_json",
+    "private_key",
+    "refresh_token",
+    "session_secret",
+    "virtual_key",
+)
+_SENSITIVE_URL_SETTINGS = {
+    "audit_siem_http_custom_headers",
+    "database_url",
+    "notification_urls",
+    "redis_url",
+    "uptime_kuma_url",
+}
+_OPERATIONAL_TOKEN_FRAGMENTS = (
+    "token_budget",
+    "token_count",
+    "token_limit",
+    "token_reservation",
+    "token_threshold",
+)
+
+
+def is_sensitive_setting(name: str) -> bool:
+    """Return whether a setting may contain authentication material.
+
+    Singular ``token`` parts are secret-bearing, while operational settings
+    such as ``max_completion_tokens`` and token budgets intentionally remain
+    visible.
+    """
+    normalized = name.lower()
+    if normalized in _SENSITIVE_URL_SETTINGS:
+        return True
+    if any(fragment in normalized for fragment in _SENSITIVE_NAME_FRAGMENTS):
+        return True
+    if any(fragment in normalized for fragment in _OPERATIONAL_TOKEN_FRAGMENTS):
+        return False
+    return any(part in _SENSITIVE_NAME_PARTS for part in normalized.split("_"))
+
+
+def configured_state(value: object) -> str:
+    """Describe only whether a secret exists, never any part of its value."""
+    if value is None:
+        return NOT_CONFIGURED_VALUE
+    if isinstance(value, (str, list, dict, set, tuple)) and not value:
+        return NOT_CONFIGURED_VALUE
+    return CONFIGURED_VALUE
+
 
 def mask_sensitive_value(value: str | None) -> str | None:
     """

--- a/app/utils/config_validator/masking.py
+++ b/app/utils/config_validator/masking.py
@@ -10,6 +10,7 @@ NOT_CONFIGURED_VALUE = "<not configured>"
 _SENSITIVE_NAME_PARTS = {
     "credential",
     "credentials",
+    "certificate",
     "cookie",
     "dsn",
     "key",
@@ -78,7 +79,7 @@ def configured_state(value: object) -> str:
     """Describe only whether a secret exists, never any part of its value."""
     if value is None:
         return NOT_CONFIGURED_VALUE
-    if isinstance(value, (str, list, dict, set, tuple)) and not value:
+    if isinstance(value, (str, bytes, list, dict, set, tuple)) and not value:
         return NOT_CONFIGURED_VALUE
     return CONFIGURED_VALUE
 

--- a/app/utils/config_validator/settings_display.py
+++ b/app/utils/config_validator/settings_display.py
@@ -5,7 +5,7 @@ Module for displaying and organizing settings information
 import logging
 
 from app.config import settings
-from app.utils.config_validator.masking import mask_database_url, redact_sensitive_value
+from app.utils.config_validator.masking import configured_state, is_sensitive_setting
 
 logger = logging.getLogger(__name__)
 
@@ -14,49 +14,16 @@ _PYDANTIC_INTERNALS = {"model_computed_fields", "model_config", "model_extra", "
 
 
 def dump_all_settings() -> None:
-    """Log all settings values for diagnostic purposes"""
+    """Log settings without ever rendering authentication material."""
     logger.info("--- DUMPING ALL SETTINGS FOR DIAGNOSTIC PURPOSES ---")
     for key in dir(settings):
         if not key.startswith("_") and key not in _PYDANTIC_INTERNALS and not callable(getattr(settings, key)):
             value = getattr(settings, key)
-            # Mask sensitive values in logs
-            if key == "database_url":
-                value = mask_database_url(str(value)) if value else value
-            elif (
-                key.lower().find("password") >= 0
-                or key.lower().find("secret") >= 0
-                or key.lower().find("token") >= 0
-                or key.lower().find("key") >= 0
-            ):
-                if value:
-                    if isinstance(value, str) and len(value) > 10:
-                        visible_start = max(1, len(value) // 3)
-                        visible_end = max(1, len(value) // 4)
-                        value = (
-                            f"{value[:visible_start]}"
-                            f"{'*' * (len(value) - visible_start - visible_end)}"
-                            f"{value[-visible_end:]}"
-                        )
-                    else:
-                        value = (
-                            f"{value[:2]}{'*' * (len(value) - 4)}{value[-2:]}"
-                            if isinstance(value, str) and len(value) > 4
-                            else "****"
-                        )
-
-            # Special handling for notification URLs
-            if key == "notification_urls" and value:
-                try:
-                    from app.utils.notification import _mask_sensitive_url
-
-                    if isinstance(value, list):
-                        masked_urls = [_mask_sensitive_url(url) for url in value]
-                        logger.info(f"{key}: {masked_urls}")
-                    else:
-                        logger.info(f"{key}: {_mask_sensitive_url(value)}")
-                    continue  # Skip the default logging
-                except (ImportError, AttributeError):
-                    pass  # Fall back to default logging if _mask_sensitive_url is not available
+            # String and structured settings default to presence-only. This
+            # prevents a newly added credential from leaking merely because
+            # its name does not yet match the sensitive-name classifier.
+            if is_sensitive_setting(key) or isinstance(value, (str, bytes, list, tuple, set, dict)):
+                value = configured_state(value)
 
             logger.info(f"{key}: {value}")
     logger.info("--- END OF SETTINGS DUMP ---")
@@ -257,43 +224,16 @@ def get_settings_for_display(show_values: bool = False) -> dict[str, list[dict[s
         for key in setting_keys:
             if hasattr(settings, key):
                 value = getattr(settings, key)
-                is_database_url = key == "database_url"
-                if is_database_url and value:
-                    value = mask_database_url(str(value))
-
-                # List of patterns that indicate sensitive values
-                sensitive_patterns = [
-                    "password",
-                    "secret",
-                    "token",
-                    "api_key",
-                    "private_key",
-                    "credentials",
-                    "access_key",
-                    "ai_key",
-                ]
-
-                # Check if this is a sensitive value that should be masked
-                is_sensitive = is_database_url or any(pattern in key.lower() for pattern in sensitive_patterns)
-
-                # Special handling for "auth" to avoid matching prefixes like "authentik"
-                if not is_sensitive and "auth" in key.lower():
-                    # Only mark as sensitive if "auth" is a standalone word or at the end
-                    # This avoids matching "authentik" as sensitive
-                    parts = key.lower().split("_")
-                    is_sensitive = any(part == "auth" for part in parts) or key.lower().endswith("auth")
-
-                # Mask sensitive values regardless of debug mode
-                # Other values are only hidden if debug mode is off AND show_values is False
-                if (is_sensitive or not show_values) and value:
-                    if is_sensitive and not is_database_url:
-                        value = redact_sensitive_value(value)
-
                 # Check if the setting is configured (has a non-None value)
                 # For boolean settings, consider them configured even if False
                 is_configured = value is not None
                 if is_configured and isinstance(value, str):
                     is_configured = len(value) > 0
+
+                # ``show_values`` never overrides secret redaction. This also
+                # handles structured credentials as one opaque value.
+                if is_sensitive_setting(key):
+                    value = configured_state(value)
 
                 items.append({"name": key, "value": value, "is_configured": is_configured})
 

--- a/app/utils/config_validator/settings_display.py
+++ b/app/utils/config_validator/settings_display.py
@@ -35,7 +35,8 @@ def get_settings_for_display(show_values: bool = False) -> dict[str, list[dict[s
     Returns a dictionary with categories as keys and lists of setting items as values.
     Each setting item is a dict with name, value, and is_configured.
 
-    If show_values is False, sensitive values are masked.
+    ``show_values`` is retained for API compatibility. Sensitive values are
+    always reduced to configuration state regardless of this flag.
     """
     # First include system info with version in result
     result = {
@@ -227,7 +228,7 @@ def get_settings_for_display(show_values: bool = False) -> dict[str, list[dict[s
                 # Check if the setting is configured (has a non-None value)
                 # For boolean settings, consider them configured even if False
                 is_configured = value is not None
-                if is_configured and isinstance(value, str):
+                if is_configured and isinstance(value, (str, bytes, list, tuple, set, dict)):
                     is_configured = len(value) > 0
 
                 # ``show_values`` never overrides secret redaction. This also

--- a/tests/test_database_url_masking.py
+++ b/tests/test_database_url_masking.py
@@ -234,7 +234,7 @@ def test_diagnostic_settings_dump_never_logs_database_password(caplog):
 
     rendered_logs = caplog.text
     assert "top-secret" not in rendered_logs
-    assert "postgresql://docuelevate:***@database.internal:5432/docuelevate" in rendered_logs
+    assert "database_url: <configured>" in rendered_logs
 
 
 @pytest.mark.unit
@@ -246,5 +246,5 @@ def test_settings_diagnostic_display_masks_database_password_even_when_values_re
         result = settings_display.get_settings_for_display(show_values=True)
 
     database_entry = next(item for item in result["Core"] if item["name"] == "database_url")
-    assert database_entry["value"] == "postgresql://docuelevate:***@database.internal:5432/docuelevate"
+    assert database_entry["value"] == "<configured>"
     assert "top-secret" not in str(result)

--- a/tests/test_settings_display.py
+++ b/tests/test_settings_display.py
@@ -177,9 +177,7 @@ class TestGetSettingsForDisplay:
         ):
             result = get_settings_for_display(show_values=True)
 
-        entry = next(
-            item for item in result["Other"] if item["name"] == "social_auth_saml2_certificate"
-        )
+        entry = next(item for item in result["Other"] if item["name"] == "social_auth_saml2_certificate")
         assert entry["value"] == "<configured>"
         assert certificate not in str(result)
 

--- a/tests/test_settings_display.py
+++ b/tests/test_settings_display.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 import pytest
 
-from app.utils.config_validator.settings_display import dump_all_settings, get_settings_for_display
 from app.utils.config_validator.masking import is_sensitive_setting
+from app.utils.config_validator.settings_display import dump_all_settings, get_settings_for_display
 
 
 @pytest.mark.unit

--- a/tests/test_settings_display.py
+++ b/tests/test_settings_display.py
@@ -23,6 +23,63 @@ class TestDumpAllSettings:
         # Should have logged start and end markers
         assert mock_logger.info.call_count > 2  # At least start, some settings, and end
 
+    def test_structured_credentials_are_reduced_to_configuration_state(self, caplog):
+        private_material = "PRIVATE-MATERIAL-MUST-NEVER-APPEAR"
+        credentials = f'{{"private_key":"{private_material}","client_email":"svc@example.test"}}'
+
+        with (
+            patch("app.utils.config_validator.settings_display.settings") as patched_settings,
+            patch("builtins.dir", return_value=["google_drive_credentials_json"]),
+        ):
+            patched_settings.google_drive_credentials_json = credentials
+            with caplog.at_level("INFO", logger="app.utils.config_validator.settings_display"):
+                dump_all_settings()
+
+        assert private_material not in caplog.text
+        assert "svc@example.test" not in caplog.text
+        assert "google_drive_credentials_json: <configured>" in caplog.text
+
+    def test_secret_prefixes_and_suffixes_are_never_logged(self, caplog):
+        secret = "prefix-super-secret-suffix"
+
+        with (
+            patch("app.utils.config_validator.settings_display.settings") as patched_settings,
+            patch("builtins.dir", return_value=["openai_api_key"]),
+        ):
+            patched_settings.openai_api_key = secret
+            with caplog.at_level("INFO", logger="app.utils.config_validator.settings_display"):
+                dump_all_settings()
+
+        assert secret not in caplog.text
+        assert "prefix" not in caplog.text
+        assert "suffix" not in caplog.text
+        assert "openai_api_key: <configured>" in caplog.text
+
+    def test_numeric_token_budget_remains_diagnostic(self, caplog):
+        with (
+            patch("app.utils.config_validator.settings_display.settings") as patched_settings,
+            patch("builtins.dir", return_value=["corpus_backfill_daily_llm_token_budget"]),
+        ):
+            patched_settings.corpus_backfill_daily_llm_token_budget = 12345
+            with caplog.at_level("INFO", logger="app.utils.config_validator.settings_display"):
+                dump_all_settings()
+
+        assert "corpus_backfill_daily_llm_token_budget: 12345" in caplog.text
+
+    def test_unknown_string_setting_defaults_to_presence_only(self, caplog):
+        future_secret = "future-provider-value-must-not-appear"
+
+        with (
+            patch("app.utils.config_validator.settings_display.settings") as patched_settings,
+            patch("builtins.dir", return_value=["future_provider_config"]),
+        ):
+            patched_settings.future_provider_config = future_secret
+            with caplog.at_level("INFO", logger="app.utils.config_validator.settings_display"):
+                dump_all_settings()
+
+        assert future_secret not in caplog.text
+        assert "future_provider_config: <configured>" in caplog.text
+
 
 @pytest.mark.unit
 class TestGetSettingsForDisplay:
@@ -80,6 +137,19 @@ class TestGetSettingsForDisplay:
                 assert "name" in item
                 assert "value" in item
                 assert "is_configured" in item
+
+    def test_show_values_cannot_reveal_structured_credentials(self):
+        credentials = '{"private_key":"never-render-this","client_email":"svc@example.test"}'
+        with patch(
+            "app.utils.config_validator.settings_display.settings.google_drive_credentials_json",
+            credentials,
+        ):
+            result = get_settings_for_display(show_values=True)
+
+        entry = next(item for item in result["Google Drive"] if item["name"] == "google_drive_credentials_json")
+        assert entry["value"] == "<configured>"
+        assert "never-render-this" not in str(result)
+        assert "svc@example.test" not in str(result)
 
 
 @pytest.mark.unit

--- a/tests/test_settings_display.py
+++ b/tests/test_settings_display.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from app.utils.config_validator.settings_display import dump_all_settings, get_settings_for_display
+from app.utils.config_validator.masking import is_sensitive_setting
 
 
 @pytest.mark.unit
@@ -79,6 +80,20 @@ class TestDumpAllSettings:
 
         assert future_secret not in caplog.text
         assert "future_provider_config: <configured>" in caplog.text
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "cors_allow_credentials",
+            "dropbox_allow_global_credentials_for_integrations",
+            "notify_on_credential_failure",
+            "sftp_disable_host_key_verification",
+            "social_auth_google_use_global_credentials",
+            "social_auth_generic_oauth2_token_url",
+        ],
+    )
+    def test_non_secret_policy_settings_are_not_misclassified(self, name):
+        assert not is_sensitive_setting(name)
 
 
 @pytest.mark.unit

--- a/tests/test_settings_display.py
+++ b/tests/test_settings_display.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from app.utils.config_validator.masking import is_sensitive_setting
+from app.utils.config_validator.masking import configured_state, is_sensitive_setting
 from app.utils.config_validator.settings_display import dump_all_settings, get_settings_for_display
 
 
@@ -80,6 +80,9 @@ class TestDumpAllSettings:
 
         assert future_secret not in caplog.text
         assert "future_provider_config: <configured>" in caplog.text
+
+    def test_empty_bytes_are_not_configured(self):
+        assert configured_state(b"") == "<not configured>"
 
     @pytest.mark.parametrize(
         "name",
@@ -165,6 +168,28 @@ class TestGetSettingsForDisplay:
         assert entry["value"] == "<configured>"
         assert "never-render-this" not in str(result)
         assert "svc@example.test" not in str(result)
+
+    def test_saml_certificate_is_never_returned(self):
+        certificate = "-----BEGIN CERTIFICATE-----sensitive-material-----END CERTIFICATE-----"
+        with patch(
+            "app.utils.config_validator.settings_display.settings.social_auth_saml2_certificate",
+            certificate,
+        ):
+            result = get_settings_for_display(show_values=True)
+
+        entry = next(
+            item for item in result["Other"] if item["name"] == "social_auth_saml2_certificate"
+        )
+        assert entry["value"] == "<configured>"
+        assert certificate not in str(result)
+
+    def test_empty_sensitive_collection_is_consistently_unconfigured(self):
+        with patch("app.utils.config_validator.settings_display.settings.notification_urls", []):
+            result = get_settings_for_display(show_values=True)
+
+        entry = next(item for item in result["Notifications"] if item["name"] == "notification_urls")
+        assert entry["value"] == "<not configured>"
+        assert entry["is_configured"] is False
 
 
 @pytest.mark.unit

--- a/tests/test_uptime_kuma.py
+++ b/tests/test_uptime_kuma.py
@@ -28,7 +28,7 @@ class TestUptimeKumaTasks:
 
     @patch("app.tasks.uptime_kuma_tasks.requests.get")
     @patch("app.tasks.uptime_kuma_tasks.settings")
-    def test_ping_uptime_kuma_success(self, mock_settings, mock_get):
+    def test_ping_uptime_kuma_success(self, mock_settings, mock_get, caplog):
         """Test successful ping to Uptime Kuma"""
         from app.tasks.uptime_kuma_tasks import ping_uptime_kuma
 
@@ -40,12 +40,14 @@ class TestUptimeKumaTasks:
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
-        result = ping_uptime_kuma()
+        with caplog.at_level("INFO", logger="app.tasks.uptime_kuma_tasks"):
+            result = ping_uptime_kuma()
 
         # Should return True on success
         assert result is True
         mock_get.assert_called_once_with("https://uptime.example.com/ping/123", timeout=10)
         mock_response.raise_for_status.assert_called_once()
+        assert "https://uptime.example.com/ping/123" not in caplog.text
 
     @patch("app.tasks.uptime_kuma_tasks.requests.get")
     @patch("app.tasks.uptime_kuma_tasks.settings")
@@ -117,6 +119,24 @@ class TestUptimeKumaTasks:
         # Should return False on any request exception
         assert result is False
         mock_get.assert_called_once()
+
+    @patch("app.tasks.uptime_kuma_tasks.requests.get")
+    @patch("app.tasks.uptime_kuma_tasks.settings")
+    def test_ping_failure_never_logs_push_url(self, mock_settings, mock_get, caplog):
+        """Request exceptions can include the secret-bearing URL."""
+        from app.tasks.uptime_kuma_tasks import ping_uptime_kuma
+
+        push_url = "https://uptime.example.com/api/push/private-token"
+        mock_settings.uptime_kuma_url = push_url
+        mock_get.side_effect = requests.exceptions.HTTPError(f"500 Server Error for url: {push_url}")
+
+        with caplog.at_level("ERROR", logger="app.tasks.uptime_kuma_tasks"):
+            result = ping_uptime_kuma()
+
+        assert result is False
+        assert push_url not in caplog.text
+        assert "private-token" not in caplog.text
+        assert "HTTPError" in caplog.text
 
     @patch("app.tasks.uptime_kuma_tasks.requests.get")
     @patch("app.tasks.uptime_kuma_tasks.settings")


### PR DESCRIPTION
## What changed

- replace partial secret masking in startup diagnostics with presence-only markers
- redact structured credentials, private keys, connection URLs, webhooks, DSNs, and other authentication material as one opaque value
- default every string or structured diagnostic setting to presence-only, so newly added credentials cannot leak because of an unfamiliar field name
- retain numeric operational values such as LLM token budgets for diagnostics
- make the settings display ignore `show_values` for sensitive fields

## Root cause

The diagnostic settings dump identified secrets by a small set of substrings and partially exposed matching values. Structured fields such as `google_drive_credentials_json` were not classified and could be logged verbatim.

## Validation

- 56 focused unit tests passed
- Ruff passed
- Mypy passed for the changed source files
- regression coverage verifies that private-key material, structured credential fields, and secret prefixes/suffixes never appear in logs

This is a security-critical prerequisite before merging the Terraform deployment PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Sensitive configuration values are now consistently concealed in logs and settings displays.
  * Structured credentials, authentication material, and secret contents are represented only by configured/not-configured indicators.
  * Database connection passwords and other sensitive values are protected from accidental exposure.

* **Bug Fixes**
  * Prevented secret prefixes, suffixes, private keys, emails, and credential details from appearing in diagnostics.
  * Preserved visibility for approved non-secret settings and numeric diagnostic values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->