### PR TITLE
feat: release onboarding document spaces

### DIFF
--- a/docs/TerraformDeployment.md
+++ b/docs/TerraformDeployment.md
@@ -85,6 +85,9 @@ An AI may report the installation ready only after all of these checks pass:
 - the deployed image tag and environment names match the intended target.
 
 The current `v1alpha1` manifest reconciles settings, local users and Tribes.
+It can seed the same isolated personal and optional shared Family/Team spaces
+that users otherwise create in the onboarding journey; later onboarding is
+idempotent and reuses those memberships rather than creating duplicates.
 Pipelines, integration instances, routing rules and user-consent OAuth grants
 are not silently approximated. Until those resource types are added to the
 schema, configure them through their supported product journeys and keep them


### PR DESCRIPTION
## Summary
- document that Terraform can seed the same personal and optional shared Family/Team spaces as onboarding
- clarify that later onboarding reuses those memberships idempotently
- restore the conventional feature signal that was lost in the squash title of #1168 so Semantic Release can publish the onboarding feature

## Validation
- `git diff --check`
- documentation-only follow-up to the fully tested implementation in #1168

## Scope
Preprod release only. Production remains pinned to the dedicated legacy image.