### PR TITLE
fix: make Celery Redis result storage failover-safe

### DIFF
--- a/app/api/graphql_api.py
+++ b/app/api/graphql_api.py
@@ -184,6 +184,8 @@ _SENSITIVE_SETTING_KEYS: frozenset[str] = frozenset(
         "session_secret",
         "database_url",
         "redis_url",
+        "celery_broker_url",
+        "celery_result_backend",
         "dropbox_app_secret",
         "dropbox_refresh_token",
         "google_drive_credentials_json",

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from celery import Celery
+from celery import Celery, bootsteps
 from celery.signals import (
     after_setup_logger,
     after_setup_task_logger,
@@ -13,6 +13,7 @@ from celery.signals import (
 )
 
 from app.config import settings
+from app.utils.celery_redis_backend import assert_redis_backend_writable, is_redis_backend
 from app.utils.log_safety import restrict_sensitive_provider_logging
 
 logger = logging.getLogger(__name__)
@@ -25,13 +26,23 @@ after_setup_task_logger.connect(restrict_sensitive_provider_logging)
 
 celery = Celery(
     "document_processor",
-    broker=settings.redis_url,
-    backend=settings.redis_url,
+    broker=settings.effective_celery_broker_url,
+    backend=settings.effective_celery_result_backend,
 )
+
+# Celery's stock Redis backend does not retry ReadOnlyError after a Redis
+# primary is demoted.  Our backend resets its cached pool before retrying so
+# HAProxy can route the next connection to the new writable primary.
+if is_redis_backend(settings.effective_celery_result_backend):
+    celery.backend_cls = "app.utils.celery_redis_backend:FailoverAwareRedisBackend"
 
 
 # Optionally add this line to retain connection retry behavior at startup:
 celery.conf.broker_connection_retry_on_startup = True
+celery.conf.result_backend_always_retry = True
+celery.conf.result_backend_max_retries = 20
+celery.conf.result_backend_base_sleep_between_retries_ms = 100
+celery.conf.result_backend_max_sleep_between_retries_ms = 2000
 
 # Redis emulates priorities with separate lists.  Explicitly enable priority
 # ordering so normal priority-0 uploads are consumed before priority-9 corpus
@@ -48,6 +59,28 @@ celery.conf.task_routes = {
     "app.tasks.batch_tasks.sync_search_index": {"queue": "search_index"},
     "app.tasks.*": {"queue": "document_processor"},
 }
+
+
+class ResultBackendWriteabilityCheck(bootsteps.StartStopStep):
+    """Refuse to consume tasks when the Redis result backend is read-only."""
+
+    label = "Redis result-backend writeability check"
+
+    def start(self, worker) -> None:
+        backend_url = settings.effective_celery_result_backend
+        if not is_redis_backend(backend_url):
+            logger.info("Skipping Redis writeability check for non-Redis result backend")
+            return
+
+        try:
+            assert_redis_backend_writable(backend_url)
+        except RuntimeError as exc:
+            logger.critical("Worker startup aborted: %s", exc)
+            raise
+        logger.info("Redis result backend is writable")
+
+
+celery.steps["worker"].add(ResultBackendWriteabilityCheck)
 
 
 @worker_process_init.connect

--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,24 @@ class Settings(BaseSettings):
 
     database_url: str
     redis_url: str = "redis://redis:6379/0"
+    celery_broker_url: Optional[str] = Field(
+        default=None,
+        description="Optional Celery broker URL; falls back to REDIS_URL.",
+    )
+    celery_result_backend: Optional[str] = Field(
+        default=None,
+        description="Optional Celery result-backend URL; falls back to REDIS_URL.",
+    )
+
+    @property
+    def effective_celery_broker_url(self) -> str:
+        """Resolve the broker independently while preserving REDIS_URL compatibility."""
+        return self.celery_broker_url or self.redis_url
+
+    @property
+    def effective_celery_result_backend(self) -> str:
+        """Resolve the result backend independently from the broker."""
+        return self.celery_result_backend or self.redis_url
 
     # Database connection-pool tuning (ignored for SQLite, which uses NullPool).
     db_pool_size: int = Field(

--- a/app/utils/celery_redis_backend.py
+++ b/app/utils/celery_redis_backend.py
@@ -1,0 +1,93 @@
+"""Failover-aware Redis result backend helpers for Celery workers."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+import redis
+from celery import Celery
+from celery.backends.redis import RedisBackend
+from redis.exceptions import ReadOnlyError
+
+logger = logging.getLogger(__name__)
+
+_REDIS_SCHEMES = ("redis://", "rediss://", "unix://")
+
+
+def is_redis_backend(url: str | None) -> bool:
+    """Return whether *url* points at a Redis-compatible Celery backend."""
+    return bool(url and url.lower().startswith(_REDIS_SCHEMES))
+
+
+def assert_redis_backend_writable(url: str, *, timeout_seconds: float = 2.0) -> None:
+    """Fail unless *url* resolves to a writable Redis primary.
+
+    ``PING`` alone is not enough: a replica responds successfully but rejects
+    Celery's task-result writes.  The probe therefore checks ``ROLE`` and then
+    performs a short-lived write/delete round trip before a worker may consume
+    work.
+    """
+    client = redis.Redis.from_url(
+        url,
+        socket_connect_timeout=timeout_seconds,
+        socket_timeout=timeout_seconds,
+    )
+    probe_key = f"docuelevate:worker-preflight:{uuid.uuid4()}"
+    wrote_probe = False
+    try:
+        role_response = client.role()
+        role = role_response[0] if role_response else None
+        if isinstance(role, bytes):
+            role = role.decode("ascii", errors="replace")
+        if str(role).lower() != "master":
+            raise RuntimeError("Redis result backend resolved to a read-only replica")
+
+        wrote_probe = bool(client.set(probe_key, "1", ex=10, nx=True))
+        if not wrote_probe:
+            raise RuntimeError("Redis result backend rejected the worker write probe")
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        raise RuntimeError("Redis result backend is unavailable or not writable") from exc
+    finally:
+        if wrote_probe:
+            try:
+                client.delete(probe_key)
+            except Exception:
+                logger.warning("Could not remove Redis worker preflight key", exc_info=True)
+        client.connection_pool.disconnect()
+
+
+class FailoverAwareRedisBackend(RedisBackend):
+    """Redis result backend that reconnects after primary demotion.
+
+    Celery does not consider ``ReadOnlyError`` retryable by default.  With a
+    TCP load balancer, an existing connection can remain attached to the old
+    primary after Redis promotes another node.  Treating the error as
+    retryable and disconnecting the pool forces the retry through the current
+    writable-primary route.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        url: str | None = None,
+        app: Celery | None = None,
+        **kwargs: Any,
+    ) -> None:
+        effective_url = url or (app.conf.result_backend if app is not None else None)
+        super().__init__(*args, url=effective_url, app=app, **kwargs)
+
+    def exception_safe_to_retry(self, exc: Exception) -> bool:
+        return isinstance(exc, ReadOnlyError) or super().exception_safe_to_retry(exc)
+
+    def on_backend_retryable_error(self, exc: Exception) -> None:
+        if isinstance(exc, ReadOnlyError):
+            logger.warning("Redis result backend was demoted to read-only; reconnecting to the writable primary")
+        try:
+            self.client.connection_pool.disconnect()
+        except Exception:
+            logger.warning("Could not reset the Redis result-backend connection pool", exc_info=True)
+        super().on_backend_retryable_error(exc)

--- a/app/utils/config_validator/masking.py
+++ b/app/utils/config_validator/masking.py
@@ -32,6 +32,8 @@ _SENSITIVE_NAME_FRAGMENTS = (
 )
 _SENSITIVE_URL_SETTINGS = {
     "audit_siem_http_custom_headers",
+    "celery_broker_url",
+    "celery_result_backend",
     "database_url",
     "notification_urls",
     "redis_url",

--- a/app/utils/config_validator/settings_display.py
+++ b/app/utils/config_validator/settings_display.py
@@ -54,6 +54,8 @@ def get_settings_for_display(show_values: bool = False) -> dict[str, list[dict[s
             "workdir",
             "database_url",
             "redis_url",
+            "celery_broker_url",
+            "celery_result_backend",
             "gotenberg_url",
             "allow_file_delete",  # Added allow_file_delete to Core settings
         ],

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -34,10 +34,26 @@ SETTING_METADATA = {
     },
     "redis_url": {
         "category": "Core",
-        "description": "Redis connection URL for Celery task queue",
+        "description": "Default Redis connection URL for Celery broker and result storage",
         "type": "string",
-        "sensitive": False,
+        "sensitive": True,
         "required": True,
+        "restart_required": True,
+    },
+    "celery_broker_url": {
+        "category": "Core",
+        "description": "Optional dedicated Redis URL for the Celery task broker; defaults to Redis URL",
+        "type": "string",
+        "sensitive": True,
+        "required": False,
+        "restart_required": True,
+    },
+    "celery_result_backend": {
+        "category": "Core",
+        "description": "Optional dedicated Redis URL for Celery task results; defaults to Redis URL",
+        "type": "string",
+        "sensitive": True,
+        "required": False,
         "restart_required": True,
     },
     "db_pool_size": {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,8 @@ x-docuelevate-service: &docuelevate-service
     PYTHONPATH: /app
     WORKDIR: /workdir
     REDIS_URL: redis://redis:6379/0
+    CELERY_BROKER_URL: redis://redis:6379/0
+    CELERY_RESULT_BACKEND: redis://redis:6379/0
     GOTENBERG_URL: http://gotenberg:3000
     MEILISEARCH_URL: http://meilisearch:7700
     MEILISEARCH_INDEX_NAME: documents

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -15,7 +15,9 @@ Configuration is primarily done through environment variables specified in a `.e
 | `DB_MAX_OVERFLOW`      | Additional connections beyond `DB_POOL_SIZE` under burst load (PostgreSQL/MySQL only). | `20` |
 | `DB_POOL_TIMEOUT`      | Seconds to wait for a pool connection before raising `TimeoutError` (PostgreSQL/MySQL only). | `30` |
 | `DB_POOL_RECYCLE`      | Recycle connections after this many seconds to avoid stale connections (PostgreSQL/MySQL only). | `1800` |
-| `REDIS_URL`            | URL for Redis, used by Celery for broker & result store. | `redis://redis:6379/0`         |
+| `REDIS_URL`            | Shared Redis URL for caching and as the default Celery route. | `redis://redis:6379/0`         |
+| `CELERY_BROKER_URL`    | Optional dedicated Celery broker URL; falls back to `REDIS_URL`. | unset |
+| `CELERY_RESULT_BACKEND` | Optional dedicated Celery result-backend URL; must resolve to a writable primary and falls back to `REDIS_URL`. | unset |
 | `WORKDIR`              | Working directory for the application.                  | `/workdir`                     |
 | `GOTENBERG_URL`        | Gotenberg PDF processing URL.                           | `http://gotenberg:3000`        |
 | `EXTERNAL_HOSTNAME`    | The external hostname for the application.             | `docuelevate.example.com`      |

--- a/docs/ProductionReadiness.md
+++ b/docs/ProductionReadiness.md
@@ -174,6 +174,21 @@ RATE_LIMITING_ENABLED=true   # default — ensure not overridden to false
 REDIS_URL=redis://redis:6379/0
 ```
 
+For high-availability Redis deployments, route both Celery endpoints through
+a primary-aware service or load balancer. DocuElevate verifies the result
+backend's Redis role and an ephemeral write before a worker consumes tasks.
+It also reconnects and retries result writes when an established connection
+receives `ReadOnlyError` after primary demotion:
+
+```env
+CELERY_BROKER_URL=redis://redis-primary-router:6379/0
+CELERY_RESULT_BACKEND=redis://redis-primary-router:6379/0
+```
+
+Never point `CELERY_RESULT_BACKEND` at a generic service that can select a
+replica. A worker deliberately refuses to start when only a read-only route is
+available.
+
 See the [Configuration Guide — Rate Limiting](ConfigurationGuide.md#rate-limiting) for per-endpoint tuning.
 
 ### Secrets Management

--- a/helm/docuelevate/templates/_helpers.tpl
+++ b/helm/docuelevate/templates/_helpers.tpl
@@ -92,6 +92,24 @@ then fall back to the bundled Redis service URL.
 {{- end }}
 {{- end }}
 
+{{/* Resolve an optional dedicated Celery broker URL. */}}
+{{- define "docuelevate.celeryBrokerUrl" -}}
+{{- if .Values.secrets.CELERY_BROKER_URL }}
+{{- .Values.secrets.CELERY_BROKER_URL }}
+{{- else }}
+{{- include "docuelevate.redisUrl" . }}
+{{- end }}
+{{- end }}
+
+{{/* Resolve an optional dedicated Celery result-backend URL. */}}
+{{- define "docuelevate.celeryResultBackend" -}}
+{{- if .Values.secrets.CELERY_RESULT_BACKEND }}
+{{- .Values.secrets.CELERY_RESULT_BACKEND }}
+{{- else }}
+{{- include "docuelevate.redisUrl" . }}
+{{- end }}
+{{- end }}
+
 {{/*
 Resolve GOTENBERG_URL — use env override if set, otherwise build from service name.
 */}}

--- a/helm/docuelevate/templates/runtime-config.yaml
+++ b/helm/docuelevate/templates/runtime-config.yaml
@@ -8,8 +8,11 @@ metadata:
     {{- include "docuelevate.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  REDIS_URL: {{ include "docuelevate.redisUrl" . | quote }}
+  CELERY_BROKER_URL: {{ include "docuelevate.celeryBrokerUrl" . | quote }}
+  CELERY_RESULT_BACKEND: {{ include "docuelevate.celeryResultBackend" . | quote }}
   {{- range $key, $value := .Values.secrets }}
-  {{- if ne $key "existingSecret" }}
+  {{- if and (ne $key "existingSecret") (ne $key "REDIS_URL") (ne $key "CELERY_BROKER_URL") (ne $key "CELERY_RESULT_BACKEND") }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
   {{- end }}

--- a/helm/docuelevate/values.yaml
+++ b/helm/docuelevate/values.yaml
@@ -69,6 +69,8 @@ secrets:
   existingSecret: ""
   DATABASE_URL: ""         # e.g. postgresql://user:pass@postgres:5432/docuelevate
   REDIS_URL: ""            # leave blank to use bundled Redis
+  CELERY_BROKER_URL: ""    # optional; falls back to REDIS_URL
+  CELERY_RESULT_BACKEND: "" # optional; must resolve to a writable primary
   SESSION_SECRET: ""       # min 32-char random string — generate with: openssl rand -hex 32
   OPENAI_API_KEY: ""
   AZURE_AI_KEY: ""

--- a/tests/test_celery_app.py
+++ b/tests/test_celery_app.py
@@ -28,6 +28,18 @@ class TestCeleryAppConfig:
         assert celery.conf.broker_url is not None
         assert celery.conf.result_backend is not None
 
+    def test_celery_uses_failover_aware_redis_backend(self):
+        """Redis task results must reconnect after primary demotion."""
+        from app.celery_app import celery
+        from app.config import settings
+        from app.utils.celery_redis_backend import FailoverAwareRedisBackend
+
+        assert celery.backend_cls == "app.utils.celery_redis_backend:FailoverAwareRedisBackend"
+        assert isinstance(celery.backend, FailoverAwareRedisBackend)
+        assert celery.backend.url == settings.effective_celery_result_backend
+        assert celery.conf.result_backend_always_retry is True
+        assert celery.conf.result_backend_max_retries == 20
+
     def test_celery_default_queue(self):
         """Test that default queue is set to document_processor."""
         from app.celery_app import celery
@@ -61,6 +73,25 @@ class TestCeleryAppConfig:
             "queue_order_strategy": "priority",
             "priority_steps": list(range(10)),
         }
+
+    @patch("app.celery_app.assert_redis_backend_writable")
+    def test_worker_preflight_checks_result_backend_before_start(self, mock_check):
+        """A worker must verify writeability before it starts consuming tasks."""
+        from app.celery_app import ResultBackendWriteabilityCheck, settings
+
+        ResultBackendWriteabilityCheck(MagicMock()).start(MagicMock())
+
+        mock_check.assert_called_once_with(settings.effective_celery_result_backend)
+
+    @patch("app.celery_app.assert_redis_backend_writable", side_effect=RuntimeError("read-only"))
+    def test_worker_preflight_aborts_on_read_only_backend(self, mock_check):
+        """A replica-only result route must fail worker startup clearly."""
+        from app.celery_app import ResultBackendWriteabilityCheck
+
+        with pytest.raises(RuntimeError, match="read-only"):
+            ResultBackendWriteabilityCheck(MagicMock()).start(MagicMock())
+
+        mock_check.assert_called_once()
 
     @patch("app.database.engine.dispose")
     def test_prefork_child_replaces_inherited_database_pool(self, mock_dispose):

--- a/tests/test_celery_app.py
+++ b/tests/test_celery_app.py
@@ -93,6 +93,20 @@ class TestCeleryAppConfig:
 
         mock_check.assert_called_once()
 
+    @patch("app.celery_app.assert_redis_backend_writable")
+    @patch("app.celery_app.is_redis_backend", return_value=False)
+    @patch("app.celery_app.settings")
+    def test_worker_preflight_skips_non_redis_result_backend(self, mock_settings, mock_is_redis, mock_check):
+        """Database-backed result storage must not receive Redis commands."""
+        from app.celery_app import ResultBackendWriteabilityCheck
+
+        mock_settings.effective_celery_result_backend = "db+postgresql://database/results"
+
+        ResultBackendWriteabilityCheck(MagicMock()).start(MagicMock())
+
+        mock_is_redis.assert_called_once_with("db+postgresql://database/results")
+        mock_check.assert_not_called()
+
     @patch("app.database.engine.dispose")
     def test_prefork_child_replaces_inherited_database_pool(self, mock_dispose):
         """A child process must not reuse a DB connection opened by its parent."""

--- a/tests/test_celery_redis_backend.py
+++ b/tests/test_celery_redis_backend.py
@@ -20,6 +20,8 @@ class TestRedisWriteabilityProbe:
         assert is_redis_backend("redis://redis:6379/0")
         assert is_redis_backend("rediss://redis.example/0")
         assert is_redis_backend("unix:///run/redis.sock")
+        assert is_redis_backend("REDIS://redis:6379/0")
+        assert not is_redis_backend(None)
         assert not is_redis_backend("db+postgresql://database/results")
 
     @patch("app.utils.celery_redis_backend.redis.Redis.from_url")
@@ -55,6 +57,30 @@ class TestRedisWriteabilityProbe:
 
         assert "secret" not in str(exc_info.value)
 
+    @patch("app.utils.celery_redis_backend.redis.Redis.from_url")
+    def test_rejected_write_probe_fails_and_disconnects(self, mock_from_url):
+        client = mock_from_url.return_value
+        client.role.return_value = ["master", 0, []]
+        client.set.return_value = False
+
+        with pytest.raises(RuntimeError, match="rejected the worker write probe"):
+            assert_redis_backend_writable("redis://primary:6379/0")
+
+        client.delete.assert_not_called()
+        client.connection_pool.disconnect.assert_called_once()
+
+    @patch("app.utils.celery_redis_backend.redis.Redis.from_url")
+    def test_cleanup_failure_is_logged_without_failing_preflight(self, mock_from_url, caplog):
+        client = mock_from_url.return_value
+        client.role.return_value = [b"master", 0, []]
+        client.set.return_value = True
+        client.delete.side_effect = ConnectionError("cleanup failed")
+
+        assert_redis_backend_writable("redis://primary:6379/0")
+
+        assert "Could not remove Redis worker preflight key" in caplog.text
+        client.connection_pool.disconnect.assert_called_once()
+
 
 @pytest.mark.unit
 class TestFailoverAwareBackend:
@@ -67,6 +93,15 @@ class TestFailoverAwareBackend:
         backend = self._backend_without_init()
 
         assert backend.exception_safe_to_retry(ReadOnlyError("READONLY")) is True
+
+    @patch.object(RedisBackend, "exception_safe_to_retry", return_value=True)
+    def test_non_read_only_retry_classification_delegates_to_celery(self, mock_super):
+        backend = self._backend_without_init()
+        error = ConnectionError("disconnected")
+
+        assert backend.exception_safe_to_retry(error) is True
+
+        mock_super.assert_called_once_with(error)
 
     def test_store_result_reconnects_and_retries_after_demotion(self):
         app = Celery("redis-failover-test")
@@ -95,4 +130,15 @@ class TestFailoverAwareBackend:
         backend.on_backend_retryable_error(error)
 
         backend.client.connection_pool.disconnect.assert_called_once()
+        mock_super.assert_called_once_with(error)
+
+    @patch.object(RedisBackend, "on_backend_retryable_error")
+    def test_pool_reset_failure_still_delegates_retry_to_celery(self, mock_super, caplog):
+        backend = self._backend_without_init()
+        backend.client.connection_pool.disconnect.side_effect = ConnectionError("already closed")
+        error = ConnectionError("disconnected")
+
+        backend.on_backend_retryable_error(error)
+
+        assert "Could not reset the Redis result-backend connection pool" in caplog.text
         mock_super.assert_called_once_with(error)

--- a/tests/test_celery_redis_backend.py
+++ b/tests/test_celery_redis_backend.py
@@ -1,0 +1,98 @@
+"""Tests for failover-aware Celery Redis result handling."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from celery import Celery
+from celery.backends.redis import RedisBackend
+from redis.exceptions import ConnectionError, ReadOnlyError
+
+from app.utils.celery_redis_backend import (
+    FailoverAwareRedisBackend,
+    assert_redis_backend_writable,
+    is_redis_backend,
+)
+
+
+@pytest.mark.unit
+class TestRedisWriteabilityProbe:
+    def test_recognizes_supported_redis_schemes(self):
+        assert is_redis_backend("redis://redis:6379/0")
+        assert is_redis_backend("rediss://redis.example/0")
+        assert is_redis_backend("unix:///run/redis.sock")
+        assert not is_redis_backend("db+postgresql://database/results")
+
+    @patch("app.utils.celery_redis_backend.redis.Redis.from_url")
+    def test_primary_requires_successful_write_round_trip(self, mock_from_url):
+        client = mock_from_url.return_value
+        client.role.return_value = [b"master", 0, []]
+        client.set.return_value = True
+
+        assert_redis_backend_writable("redis://primary:6379/0")
+
+        client.set.assert_called_once()
+        client.delete.assert_called_once()
+        client.connection_pool.disconnect.assert_called_once()
+
+    @patch("app.utils.celery_redis_backend.redis.Redis.from_url")
+    def test_replica_is_rejected_without_a_write(self, mock_from_url):
+        client = mock_from_url.return_value
+        client.role.return_value = [b"slave", "primary", 6379, "connected", 0]
+
+        with pytest.raises(RuntimeError, match="read-only replica"):
+            assert_redis_backend_writable("redis://replica:6379/0")
+
+        client.set.assert_not_called()
+        client.connection_pool.disconnect.assert_called_once()
+
+    @patch("app.utils.celery_redis_backend.redis.Redis.from_url")
+    def test_connection_failure_is_reported_without_endpoint_details(self, mock_from_url):
+        client = mock_from_url.return_value
+        client.role.side_effect = ConnectionError("secret-hostname:6379 refused")
+
+        with pytest.raises(RuntimeError, match="unavailable or not writable") as exc_info:
+            assert_redis_backend_writable("redis://user:secret@secret-hostname:6379/0")
+
+        assert "secret" not in str(exc_info.value)
+
+
+@pytest.mark.unit
+class TestFailoverAwareBackend:
+    def _backend_without_init(self):
+        backend = object.__new__(FailoverAwareRedisBackend)
+        backend.__dict__["client"] = MagicMock()
+        return backend
+
+    def test_read_only_error_is_retryable(self):
+        backend = self._backend_without_init()
+
+        assert backend.exception_safe_to_retry(ReadOnlyError("READONLY")) is True
+
+    def test_store_result_reconnects_and_retries_after_demotion(self):
+        app = Celery("redis-failover-test")
+        app.conf.update(
+            result_backend_always_retry=True,
+            result_backend_max_retries=2,
+            result_backend_base_sleep_between_retries_ms=1,
+            result_backend_max_sleep_between_retries_ms=1,
+        )
+        backend = FailoverAwareRedisBackend(app=app, url="redis://unused:6379/0")
+        backend.__dict__["client"] = MagicMock()
+        backend._store_result = MagicMock(side_effect=[ReadOnlyError("READONLY"), None])
+        backend._sleep = MagicMock()
+
+        result = backend.store_result("task-1", {"ok": True}, "SUCCESS")
+
+        assert result == {"ok": True}
+        assert backend._store_result.call_count == 2
+        backend.client.connection_pool.disconnect.assert_called_once()
+
+    @patch.object(RedisBackend, "on_backend_retryable_error")
+    def test_retry_disconnects_cached_connection_pool(self, mock_super):
+        backend = self._backend_without_init()
+        error = ReadOnlyError("READONLY")
+
+        backend.on_backend_retryable_error(error)
+
+        backend.client.connection_pool.disconnect.assert_called_once()
+        mock_super.assert_called_once_with(error)

--- a/tests/test_compose_contract.py
+++ b/tests/test_compose_contract.py
@@ -57,3 +57,11 @@ def test_default_worker_concurrency_fits_small_fresh_install_hosts():
     command = _compose()["services"]["worker"]["command"]
 
     assert "--concurrency=${DOCUELEVATE_WORKER_CONCURRENCY:-1}" in command
+
+
+def test_all_celery_redis_routes_are_explicit_and_writable_by_default():
+    environment = _compose()["x-docuelevate-service"]["environment"]
+
+    assert environment["REDIS_URL"] == "redis://redis:6379/0"
+    assert environment["CELERY_BROKER_URL"] == "redis://redis:6379/0"
+    assert environment["CELERY_RESULT_BACKEND"] == "redis://redis:6379/0"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,9 +99,24 @@ class TestConfigurationValidation:
         )
 
         assert config.redis_url == "redis://redis:6379/0"
+        assert config.effective_celery_broker_url == "redis://redis:6379/0"
+        assert config.effective_celery_result_backend == "redis://redis:6379/0"
         assert config.workdir == "/workdir"
         assert config.gotenberg_url == "http://gotenberg:3000"
         assert config.openai_api_key == ""
+
+    def test_celery_urls_can_be_overridden_independently(self):
+        """Broker and result traffic can use separate primary-aware routes."""
+        config = Settings(
+            database_url="sqlite:///test.db",
+            redis_url="redis://cache:6379/0",
+            celery_broker_url="redis://broker:6379/0",
+            celery_result_backend="redis://results-primary:6379/0",
+            auth_enabled=False,
+        )
+
+        assert config.effective_celery_broker_url == "redis://broker:6379/0"
+        assert config.effective_celery_result_backend == "redis://results-primary:6379/0"
 
 
 @pytest.mark.unit

--- a/tests/test_deployment_contract.py
+++ b/tests/test_deployment_contract.py
@@ -71,6 +71,17 @@ def test_helm_processes_use_the_configurable_runtime_secret():
         assert 'include "docuelevate.fullname" . }}-secret' not in content
 
 
+def test_helm_resolves_broker_and_result_backend_to_a_primary_route():
+    helpers = (CHART / "templates" / "_helpers.tpl").read_text(encoding="utf-8")
+    runtime_secret = (CHART / "templates" / "runtime-config.yaml").read_text(encoding="utf-8")
+
+    assert 'define "docuelevate.celeryBrokerUrl"' in helpers
+    assert 'define "docuelevate.celeryResultBackend"' in helpers
+    assert 'include "docuelevate.redisUrl" .' in helpers
+    assert 'CELERY_BROKER_URL: {{ include "docuelevate.celeryBrokerUrl" . | quote }}' in runtime_secret
+    assert 'CELERY_RESULT_BACKEND: {{ include "docuelevate.celeryResultBackend" . | quote }}' in runtime_secret
+
+
 def test_agentic_helm_hook_plans_before_apply_and_scopes_setup_credentials():
     template = (CHART / "templates" / "agentic-setup.yaml").read_text(encoding="utf-8")
     plan = "python -m app.agentic_setup plan /config/setup.json"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -166,6 +166,13 @@ class TestSettingsService:
             f"and will not appear on the settings page: {sorted(missing)}"
         )
 
+    def test_redis_connection_urls_are_sensitive_restart_settings(self):
+        """Redis URLs can contain credentials and only apply after process restart."""
+        for setting in ("redis_url", "celery_broker_url", "celery_result_backend"):
+            metadata = SETTING_METADATA[setting]
+            assert metadata["sensitive"] is True
+            assert metadata["restart_required"] is True
+
     def test_setting_metadata_has_required_fields(self):
         """Test that every SETTING_METADATA entry has the required keys."""
         required_keys = {"category", "description", "type", "sensitive", "required", "restart_required"}

--- a/tests/test_settings_display.py
+++ b/tests/test_settings_display.py
@@ -98,6 +98,10 @@ class TestDumpAllSettings:
     def test_non_secret_policy_settings_are_not_misclassified(self, name):
         assert not is_sensitive_setting(name)
 
+    @pytest.mark.parametrize("name", ["celery_broker_url", "celery_result_backend"])
+    def test_celery_connection_urls_are_sensitive(self, name):
+        assert is_sensitive_setting(name)
+
 
 @pytest.mark.unit
 class TestGetSettingsForDisplay:


### PR DESCRIPTION
## What changed

- allow dedicated `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND` routes with backward-compatible `REDIS_URL` fallback
- refuse worker startup unless a Redis result backend reports the primary role and passes an ephemeral write/delete probe
- retry `ReadOnlyError` result writes after disconnecting the cached Redis pool so HAProxy can route to the promoted primary
- make Compose and Helm emit explicit broker/result routes and fix the previously unused Helm Redis URL resolver
- treat all Redis/Celery connection URLs as credentials-bearing configuration in diagnostics and GraphQL
- document the HA Redis contract and add regression coverage

## Root cause

Celery does not classify Redis `ReadOnlyError` as retryable. An established TCP session could remain connected to a demoted Redis primary, so task-result `SETEX` operations failed even though HAProxy health checks already identified another primary. A simple `PING` cannot distinguish a writable primary from a healthy replica.

## Impact

Workers fail closed before consuming tasks when only a replica is reachable. During a real promotion, result writes discard the stale pool and retry through the current primary route instead of failing the completed document task. Existing single-Redis installations continue to use `REDIS_URL` without configuration changes.

## Validation

- Ruff passed for all `app/` and `tests/` files
- Mypy passed for all 226 application modules
- 116 focused Redis, Celery, configuration, deployment, and redaction tests passed
- real Redis primary accepted; real replica rejected
- real Celery worker reached ready state on primary and exited non-zero before consuming tasks on replica
- Helm rendered bundled, external, and split Redis routes correctly
- Kubernetes manifest dry-run and HAProxy 3.0 config validation passed for the companion Preprod GitOps change
- local all-tests attempt reached 12% without failures but the constrained local container was OOM-killed; the full 6,515-test suite is delegated to PR CI

Closes #1177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate configuration options for Celery’s message broker and result backend, with fallback to the shared Redis setting.
  * Improved high-availability Redis support with primary-aware routing, failover retries, and startup checks that prevent workers from using read-only backends.
  * Added deployment defaults for Docker Compose and Helm.

* **Bug Fixes**
  * Sensitive Celery and Redis connection settings are now masked consistently.

* **Documentation**
  * Updated configuration and production-readiness guidance for Celery and highly available Redis deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->