### PR TITLE
fix: preserve configured onboarding plan labels

### DIFF
--- a/app/views/onboarding.py
+++ b/app/views/onboarding.py
@@ -9,7 +9,7 @@ from app.config import Settings
 from app.config import settings as _settings
 from app.models import UserIntegration, UserProfile
 from app.utils.config_validator.providers import get_provider_status
-from app.utils.subscription import get_all_tiers
+from app.utils.subscription import TIER_DEFAULTS, get_all_tiers
 from app.views.base import APIRouter, get_db, require_login, templates
 
 logger = logging.getLogger(__name__)
@@ -30,6 +30,32 @@ _DESTINATION_META: list[dict] = [
     {"id": "ftp", "name": "FTP", "icon": "fas fa-server"},
     {"id": "icloud", "name": "iCloud Drive", "icon": "fab fa-apple"},
 ]
+
+
+def _prepare_onboarding_tiers(tiers: list[dict]) -> list[dict]:
+    """Add optional translation keys without replacing configured plan copy.
+
+    Built-in plans are localised while their name or tagline still matches the
+    shipped default. Once an administrator changes either field, onboarding
+    displays that database-backed value verbatim instead of stale stock copy.
+    """
+    prepared: list[dict] = []
+    for tier in tiers:
+        item = dict(tier)
+        tier_id = str(item.get("id", ""))
+        default = TIER_DEFAULTS.get(tier_id)
+        item["name_translation_key"] = (
+            f"onboarding.tier_{tier_id}_name"
+            if default is not None and item.get("name") == default.get("name")
+            else None
+        )
+        item["tagline_translation_key"] = (
+            f"onboarding.tier_{tier_id}_tagline"
+            if default is not None and item.get("tagline") == default.get("tagline")
+            else None
+        )
+        prepared.append(item)
+    return prepared
 
 
 def _get_configured_destinations(cfg: Settings) -> list[dict]:
@@ -101,7 +127,7 @@ async def onboarding_page(request: Request, db: Session = Depends(get_db)):
         if integration.direction == "DESTINATION"
     ]
     legacy_destinations = _get_configured_destinations(_settings)
-    tiers = get_all_tiers(db)
+    tiers = _prepare_onboarding_tiers(get_all_tiers(db))
     ai_configured = bool(get_provider_status()["AI Provider"]["configured"])
     is_preprod = "preprod" in request.url.hostname.lower() if request.url.hostname else False
 

--- a/frontend/templates/onboarding.html
+++ b/frontend/templates/onboarding.html
@@ -221,7 +221,7 @@
                     :class="selectedTier === '{{ tier.id }}' ? 'border-indigo-500 bg-indigo-50' : 'border-gray-200 hover:border-gray-300 bg-white'"
                     :aria-pressed="(selectedTier === '{{ tier.id }}').toString()">
               <div class="flex items-center justify-between mb-1">
-                <span class="font-bold text-gray-800">{{ _("onboarding.tier_" ~ tier.id ~ "_name") }}</span>
+                <span class="font-bold text-gray-800">{{ _(tier.name_translation_key) if tier.name_translation_key else tier.name }}</span>
                 <span class="text-lg font-extrabold text-indigo-600">
                   {% if tier.price_monthly == 0 %}
                     {{ _("onboarding.free") }}
@@ -235,7 +235,7 @@
                   {% endif %}
                 </span>
               </div>
-              <p class="text-gray-500 text-xs">{{ _("onboarding.tier_" ~ tier.id ~ "_tagline") }}</p>
+              <p class="text-gray-500 text-xs">{{ _(tier.tagline_translation_key) if tier.tagline_translation_key else tier.tagline }}</p>
               {% if tier.id != "free" and tier.get("trial_days") %}
               <span class="inline-block mt-1.5 text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full">
                 {{ tier.trial_days }} {{ _("onboarding.day_trial") }}
@@ -504,10 +504,9 @@ const onboardingI18n = {
   completionFailed: {{ _("onboarding.error_completion") | tojson }},
   networkError: {{ _("onboarding.error_network") | tojson }},
   tierLabels: {
-    free: {{ _("onboarding.tier_free_name") | tojson }},
-    starter: {{ _("onboarding.tier_starter_name") | tojson }},
-    professional: {{ _("onboarding.tier_professional_name") | tojson }},
-    business: {{ _("onboarding.tier_business_name") | tojson }}
+    {% for tier in tiers %}
+    {{ tier.id | tojson }}: {{ (_(tier.name_translation_key) if tier.name_translation_key else tier.name) | tojson }}{% if not loop.last %},{% endif %}
+    {% endfor %}
   },
   stepLabels: [
     {{ _("onboarding.step_welcome") | tojson }},

--- a/tests/test_views_onboarding.py
+++ b/tests/test_views_onboarding.py
@@ -57,6 +57,84 @@ def _make_mock_request(session_user: dict | None = None) -> MagicMock:
     return mock_req
 
 
+@pytest.mark.unit
+class TestPrepareOnboardingTiers:
+    """Plan copy remains localised until an administrator customises it."""
+
+    def test_stock_plan_copy_uses_translation_keys_without_mutating_input(self):
+        from app.utils.subscription import TIER_DEFAULTS
+        from app.views.onboarding import _prepare_onboarding_tiers
+
+        tier = dict(TIER_DEFAULTS["free"])
+
+        result = _prepare_onboarding_tiers([tier])
+
+        assert result[0]["name_translation_key"] == "onboarding.tier_free_name"
+        assert result[0]["tagline_translation_key"] == "onboarding.tier_free_tagline"
+        assert "name_translation_key" not in tier
+
+    def test_renamed_builtin_plan_preserves_database_name_and_tagline(self):
+        from app.utils.subscription import TIER_DEFAULTS
+        from app.views.onboarding import _prepare_onboarding_tiers
+
+        tier = {
+            **TIER_DEFAULTS["business"],
+            "name": "Family Archive",
+            "tagline": "Shared document care for the whole tribe",
+        }
+
+        [result] = _prepare_onboarding_tiers([tier])
+
+        assert result["name"] == "Family Archive"
+        assert result["tagline"] == "Shared document care for the whole tribe"
+        assert result["name_translation_key"] is None
+        assert result["tagline_translation_key"] is None
+
+    def test_template_localises_stock_copy_but_renders_custom_copy_verbatim(self):
+        from app.utils.subscription import TIER_DEFAULTS
+        from app.views.base import templates
+        from app.views.onboarding import _prepare_onboarding_tiers
+
+        tiers = _prepare_onboarding_tiers(
+            [
+                dict(TIER_DEFAULTS["free"]),
+                {
+                    **TIER_DEFAULTS["business"],
+                    "name": "Family Archive",
+                    "tagline": "Shared document care for the whole tribe",
+                },
+            ]
+        )
+        translations = {
+            "onboarding.tier_free_name": "Kostenlos",
+            "onboarding.tier_free_tagline": "Ohne Kreditkarte ausprobieren",
+        }
+        request = MagicMock()
+        request.url.path = "/onboarding"
+
+        rendered = templates.env.get_template("onboarding.html").render(
+            request=request,
+            _=lambda key, **_kwargs: translations.get(key, key),
+            user={},
+            tiers=tiers,
+            is_complimentary=False,
+            instance_label="DocuElevate",
+            suggested_storage_path="/DocuElevate",
+            configured_destinations=[],
+            legacy_destinations=[],
+            integration_sources=[],
+            integration_destinations=[],
+            ai_configured=False,
+            suggested_languages=[],
+            supported_languages={},
+        )
+
+        assert "Kostenlos" in rendered
+        assert "Ohne Kreditkarte ausprobieren" in rendered
+        assert "Family Archive" in rendered
+        assert "Shared document care for the whole tribe" in rendered
+
+
 # ---------------------------------------------------------------------------
 # Tests for _get_configured_destinations
 # ---------------------------------------------------------------------------
@@ -623,7 +701,10 @@ class TestOnboardingPage:
         try:
             with (
                 patch("app.views.onboarding.templates") as mock_templates,
-                patch("app.views.onboarding.get_all_tiers", return_value=["free"]),
+                patch(
+                    "app.views.onboarding.get_all_tiers",
+                    return_value=[{"id": "free", "name": "Free", "tagline": "Try DocuElevate free — no credit card needed"}],
+                ),
                 patch("app.views.onboarding._get_configured_destinations", return_value=[{"id": "s3"}]),
             ):
                 mock_templates.TemplateResponse.return_value = mock_template_response
@@ -636,7 +717,8 @@ class TestOnboardingPage:
             assert context["configured_destinations"] == []
             assert context["legacy_destinations"] == [{"id": "s3"}]
             assert context["instance_label"] == "DocuElevate"
-            assert context["tiers"] == ["free"]
+            assert context["tiers"][0]["id"] == "free"
+            assert context["tiers"][0]["name_translation_key"] == "onboarding.tier_free_name"
             assert context["is_complimentary"] is False
             assert isinstance(context["ai_configured"], bool)
         finally:

--- a/tests/test_views_onboarding.py
+++ b/tests/test_views_onboarding.py
@@ -703,7 +703,9 @@ class TestOnboardingPage:
                 patch("app.views.onboarding.templates") as mock_templates,
                 patch(
                     "app.views.onboarding.get_all_tiers",
-                    return_value=[{"id": "free", "name": "Free", "tagline": "Try DocuElevate free — no credit card needed"}],
+                    return_value=[
+                        {"id": "free", "name": "Free", "tagline": "Try DocuElevate free — no credit card needed"}
+                    ],
                 ),
                 patch("app.views.onboarding._get_configured_destinations", return_value=[{"id": "s3"}]),
             ):


### PR DESCRIPTION
## What changed

- keep database-backed plan names and taglines in onboarding after an administrator customises them
- continue localising untouched built-in plan copy
- use the same resolved labels in the plan cards and final onboarding summary
- add focused helper and real Jinja rendering coverage

## Root cause

The onboarding template ignored the values returned by `get_all_tiers(db)` and always rendered static `onboarding.tier_*` translation keys. Renaming a built-in plan in Plan Designer therefore left stale stock copy in onboarding.

## Validation

- `26 passed` in `tests/test_views_onboarding.py`
- real template render covers a localised stock plan and a renamed built-in plan together
- Ruff passed for changed Python files
- djLint passed for `frontend/templates/onboarding.html`

Closes #1180