### PR TITLE
Make fresh installs safe and agent-ready

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -181,7 +181,7 @@ ADMIN_GROUP_NAME=admin
 # **Multi-User Mode**
 # When enabled, each user has their own document space with isolated uploads,
 # search, and file management. Requires AUTH_ENABLED=true.
-MULTI_USER_ENABLED=false
+MULTI_USER_ENABLED=true
 # Allow users to self-register with an email address and password.
 # Set to true to enable the /signup page. Requires MULTI_USER_ENABLED=true.
 # When SMTP is configured, a verification email is sent before the account is activated.
@@ -190,7 +190,7 @@ MULTI_USER_ENABLED=false
 # Default upload limit per user per day (0 = unlimited)
 DEFAULT_DAILY_UPLOAD_LIMIT=0
 # Show unowned documents (owner_id=NULL) to all users (true) or only admins (false)
-UNOWNED_DOCS_VISIBLE_TO_ALL=true
+UNOWNED_DOCS_VISIBLE_TO_ALL=false
 # Auto-assign this owner ID to documents ingested without a session (e.g. IMAP, API)
 # Leave empty/unset to keep them unowned until claimed.
 # DEFAULT_OWNER_ID=

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -1,6 +1,6 @@
 # DocuElevate Milestones
 
-**Last Updated:** 2026-07-18
+**Last Updated:** 2026-07-19
 
 This document outlines the release milestones, versioning strategy, and detailed feature breakdown for DocuElevate.
 
@@ -23,8 +23,12 @@ DocuElevate follows [Semantic Versioning 2.0.0](https://semver.org/):
 
 DocuElevate ships continuously via automated semantic versioning. Use **GitHub Releases** for the latest build artifacts and **GitHub Milestones** (below) for roadmap tracking.
 
-**Current stable release at this review:** `v0.188.0` (2026-07-17). The release
+**Current stable release at this review:** `v0.188.2` (2026-07-19). The release
 number is not a claim that the future named milestone outcomes are complete.
+
+The production deployment has its own manually approved release boundary and can
+remain pinned to an older Evergreen image while newer builds are exercised in
+Preprod and disposable Canary environments.
 
 ### Last Completed Named Milestone Anchor: v0.5.0 (Released February 8, 2026)
 - Database-backed settings management with encryption

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # DocuElevate Roadmap
 
-**Last Updated:** 2026-07-18
-**Version:** 2.2
+**Last Updated:** 2026-07-19
+**Version:** 2.3
 
 ## Vision
 
@@ -19,13 +19,14 @@ For the detailed milestone breakdown and target dates, see [MILESTONES.md](MILES
 
 ## Current Focus and Delivery Order
 
-The automated release number (`0.188.0` at the time of this review) is independent
+The automated release number (`0.188.2` at the time of this review) is independent
 from the named planning anchors below. The team should execute work in dependency
 order, not in numeric-anchor order:
 
 1. **Close the active security and privacy gaps** — rotate the affected Preprod
-   credentials (#1162), harden single-user privacy controls (#1170), and keep
-   secret values out of GitOps, diagnostics, and browser responses.
+   credentials (#1162), complete owner/Tribe assignment for legacy corpora, and
+   keep secret values out of GitOps, diagnostics, and browser responses. The
+   single-user privacy regression (#1170) is closed; its guardrails stay mandatory.
 2. **Make a clean installation genuinely useful** — finish the disposable
    fresh-install journey (#1134, #1151), including integrations, a first processed
    document, a second isolated user, recovery paths, and browser E2E evidence.
@@ -35,9 +36,12 @@ order, not in numeric-anchor order:
 4. **Finish retrieval quality rather than widening brute-force context** — tune
    hybrid ranking (#871), add an evaluation harness (#880), and only then close
    Chat with Library (#478) against cited-answer quality and latency targets.
-5. **Remove operational single points of failure** — restore executable database
-   backups (#1062, #1102), harden maintenance monitors (#1103, #1121), and finish
-   the single-host-loss resilience plan (#902).
+5. **Remove operational single points of failure** — executable backup creation
+   and restore acceptance are complete (#1062, #1102). Next, make credential
+   monitor state transactional (#1190), verify protected archives before retention
+   (#1191), account for abandoned partial archives (#1192), estimate first-backup
+   capacity conservatively (#1193), harden maintenance monitors (#1103, #1121),
+   and finish the single-host-loss resilience plan (#902).
 6. **Build later enterprise and ecosystem layers on proven contracts** — workflow
    editing, RBAC, full organization management, audit, plugins, governance, MCP,
    and agent actions remain sequenced behind the user-facing foundations above.
@@ -45,6 +49,10 @@ order, not in numeric-anchor order:
 GitHub issues and milestones are the source of truth for executable scope. This
 document explains sequencing and product intent; it should not duplicate a sprint
 backlog.
+
+Production promotion is not implied by a merge or Preprod acceptance. The
+production deployment remains pinned to its explicitly approved Evergreen legacy
+image until a separate manual production approval is given.
 
 The current issue inventory also contains post-merge follow-ups. Before starting
 one, verify it against `main` and existing regression tests; close already-delivered

--- a/app/config.py
+++ b/app/config.py
@@ -345,7 +345,7 @@ class Settings(BaseSettings):
             "Enable multi-user mode with individual document spaces per user. "
             "When enabled, each authenticated user sees only their own documents, "
             "uploads, and search results. Shared settings (AI, OCR) remain global. "
-            "Requires auth_enabled=True. Default: False (single-user/shared mode)."
+            "Requires auth_enabled=True. Default: False (auth-free compatibility fallback)."
         ),
     )
     default_daily_upload_limit: int = Field(
@@ -362,7 +362,7 @@ class Settings(BaseSettings):
             "In multi-user mode, controls whether documents without an owner (owner_id is NULL) "
             "are visible to all authenticated users. When True, unowned documents appear in every "
             "user's file list alongside their own files. When False, only admins can see unowned "
-            "documents. Default: True."
+            "documents. Default: True for compatibility; bundled deployments override this to False."
         ),
     )
     default_owner_id: Optional[str] = Field(

--- a/app/main.py
+++ b/app/main.py
@@ -214,18 +214,15 @@ async def lifespan(app: FastAPI):
 
     ensure_ocr_languages_async()
 
-    # Force settings dump to log for troubleshooting
-    from app.utils.config_validator import dump_all_settings
-
-    dump_all_settings()
-
-    # Validate configuration
-    config_issues = check_all_configs()
+    # Validate only features the operator has started configuring.  A fresh
+    # installation is intentionally useful without SMTP, notifications, or an
+    # external storage destination; strict checks remain available in Settings.
+    config_issues = check_all_configs(configured_only=True)
 
     # Log overall status
-    has_issues = any(config_issues["email"]) or any(
-        len(issues) > 0 for provider, issues in config_issues["storage"].items()
-    )
+    has_issues = any(config_issues.get("auth", [])) or any(config_issues.get("email", []))
+    has_issues = has_issues or any(len(issues) > 0 for issues in config_issues.get("storage", {}).values())
+    has_issues = has_issues or any(config_issues.get("notification", []))
     if has_issues:
         logging.warning("Application started with configuration issues - some features may be unavailable")
     else:

--- a/app/tasks/batch_tasks.py
+++ b/app/tasks/batch_tasks.py
@@ -614,6 +614,18 @@ def _get_all_search_index_ids(index: object) -> set[int]:
     return existing_ids
 
 
+def _is_missing_search_index_error(exc: Exception) -> bool:
+    """Return whether Meilisearch reports an index that does not exist yet.
+
+    A pristine installation has no search index until its first document is
+    committed.  The Python client represents that expected state with an API
+    error whose stable machine-readable code is ``index_not_found``.  Keep
+    this deliberately narrow so connectivity, authentication, and malformed
+    request failures still fail the reconciliation job visibly.
+    """
+    return getattr(exc, "code", None) == "index_not_found"
+
+
 @celery.task(name="app.tasks.batch_tasks.sync_search_index")
 def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE, continue_until_complete: bool = False) -> dict:
     """
@@ -658,10 +670,21 @@ def sync_search_index(batch_size: int = _SEARCH_SYNC_BATCH_SIZE, continue_until_
         index = client.get_index(settings.meilisearch_index_name)
         existing_ids = _get_all_search_index_ids(index)
     except Exception as exc:
-        detail = f"Error fetching existing Meilisearch IDs: {exc}"
-        logger.error("[batch] sync_search_index: %s", detail)
-        _update_job_status(job_name, "failed", detail)
-        return {"indexed": 0, "skipped": 0, "error": str(exc)}
+        if _is_missing_search_index_error(exc):
+            # A fresh Meilisearch instance has no index.  Treat it as an empty
+            # corpus; index_documents() creates and configures the index when
+            # the first document is committed.  With no documents, the clean
+            # zero-result below is truthful and avoids creating empty state.
+            existing_ids = set()
+            logger.info(
+                "[batch] Meilisearch index %s does not exist yet; starting with an empty index",
+                settings.meilisearch_index_name,
+            )
+        else:
+            detail = f"Error fetching existing Meilisearch IDs: {exc}"
+            logger.error("[batch] sync_search_index: %s", detail)
+            _update_job_status(job_name, "failed", detail)
+            return {"indexed": 0, "skipped": 0, "error": str(exc)}
 
     try:
         with SessionLocal() as db:

--- a/app/utils/config_validator/validators.py
+++ b/app/utils/config_validator/validators.py
@@ -64,7 +64,12 @@ def validate_auth_config() -> list[str]:
             getattr(settings, f"social_auth_{p}_enabled", False) for p in ("google", "microsoft", "apple", "dropbox")
         )
 
-        if not using_simple_auth and not using_oidc and not using_social_login:
+        # A fresh installation deliberately starts without an external identity
+        # provider.  The setup wizard/local signup flow is a valid authentication
+        # path until the operator configures OAuth or OIDC.
+        using_local_signup = bool(getattr(settings, "allow_local_signup", False))
+
+        if not using_simple_auth and not using_oidc and not using_social_login and not using_local_signup:
             issues.append("Neither simple authentication, OIDC, nor social login are properly configured")
 
         # If using OIDC, check for provider name
@@ -246,8 +251,19 @@ def validate_notification_config() -> list[str]:
     return issues
 
 
-def check_all_configs() -> dict[str, list[str] | dict[str, list[str]]]:
-    """Run all configuration validations and log results"""
+def _has_any_setting(*names: str) -> bool:
+    """Return whether an optional feature has any operator-supplied config."""
+    return any(getattr(settings, name, None) not in (None, "", [], ()) for name in names)
+
+
+def check_all_configs(*, configured_only: bool = False) -> dict[str, list[str] | dict[str, list[str]]]:
+    """Run configuration validations and log actionable results.
+
+    ``configured_only`` is used at application startup.  Optional integrations
+    that have not been started are not broken and therefore must not make a
+    clean installation look unhealthy.  The strict validators remain available
+    to the settings and credential-checking surfaces.
+    """
     from app.utils.config_validator.settings_display import dump_all_settings
 
     logger.info("Validating application configuration...")
@@ -265,22 +281,55 @@ def check_all_configs() -> dict[str, list[str] | dict[str, list[str]]]:
 
     # Check email config
     email_issues = validate_email_config()
-    if email_issues:
+    email_configured = _has_any_setting("email_host", "email_username", "email_password")
+    if configured_only and not email_configured:
+        email_issues = []
+    if configured_only and not email_configured:
+        logger.info("Email is not configured; optional email intake skipped")
+    elif email_issues:
         logger.warning(f"Email configuration issues: {', '.join(email_issues)}")
     else:
         logger.info("Email configuration OK")
 
     # Check storage configs
     storage_issues = validate_storage_configs()
+    provider_configured: dict[str, bool] = {provider: True for provider in storage_issues}
+    if configured_only:
+        provider_settings = {
+            "dropbox": ("dropbox_app_key", "dropbox_app_secret", "dropbox_refresh_token"),
+            "nextcloud": ("nextcloud_upload_url", "nextcloud_username", "nextcloud_password"),
+            "sftp": ("sftp_host", "sftp_private_key", "sftp_password"),
+            "email": ("dest_email_host", "dest_email_default_recipient"),
+            "evernote": ("evernote_auth_token",),
+            "s3": ("s3_bucket_name", "aws_access_key_id", "aws_secret_access_key"),
+            "ftp": ("ftp_host", "ftp_username", "ftp_password"),
+            "webdav": ("webdav_url", "webdav_username", "webdav_password"),
+            "google_drive": ("google_drive_credentials_json", "google_drive_folder_id"),
+            "paperless": ("paperless_host", "paperless_ngx_api_token"),
+            "onedrive": ("onedrive_client_id", "onedrive_client_secret", "onedrive_refresh_token"),
+            "uptime_kuma": ("uptime_kuma_url",),
+        }
+        provider_configured = {provider: _has_any_setting(*provider_settings[provider]) for provider in storage_issues}
+        storage_issues = {
+            provider: issues if provider_configured[provider] else [] for provider, issues in storage_issues.items()
+        }
     for provider, issues in storage_issues.items():
-        if issues:
+        if configured_only and not provider_configured[provider]:
+            logger.info("%s is not configured; optional integration skipped", provider.replace("_", " ").title())
+        elif issues:
             logger.warning(f"{provider.capitalize()} configuration issues: {', '.join(issues)}")
         else:
             logger.info(f"{provider.capitalize()} configuration OK")
 
     # Check notification configuration
-    notification_issues = validate_notification_config()
-    if notification_issues:
+    notification_configured = _has_any_setting("notification_urls")
+    if configured_only and not notification_configured:
+        notification_issues = []
+    else:
+        notification_issues = validate_notification_config()
+    if configured_only and not notification_configured:
+        logger.info("Notifications are not configured; optional notifications skipped")
+    elif notification_issues:
         logger.warning(f"Notification configuration issues: {', '.join(notification_issues)}")
     else:
         logger.info("Notification configuration OK")

--- a/app/utils/setup_manifest.py
+++ b/app/utils/setup_manifest.py
@@ -403,6 +403,15 @@ def apply_setup_manifest(db: Session, resolved: dict[str, Any]) -> dict[str, Any
 
     notify_settings_updated()
     missing = get_missing_required_settings()
+    # A database-backed local administrator supersedes the legacy global
+    # ADMIN_USERNAME/ADMIN_PASSWORD pair.  Requiring both would make the
+    # declarative multi-user setup write a second application-wide credential
+    # even though the created administrator is already able to authenticate.
+    has_local_admin = (
+        db.query(LocalUser).filter(LocalUser.is_admin.is_(True), LocalUser.is_active.is_(True)).first() is not None
+    )
+    if has_local_admin:
+        missing = [key for key in missing if key not in {"admin_username", "admin_password"}]
     setup_completed = False
     if resolved["complete_setup"] and not missing:
         if not save_setting_to_db(db, "_setup_wizard_completed", "true", changed_by="agentic_setup"):

--- a/app/utils/user_scope.py
+++ b/app/utils/user_scope.py
@@ -125,9 +125,11 @@ def apply_owner_filter(query: Query, request: Request) -> Query:
     users may see non-private documents, but never another owner's private
     documents.
 
-    When ``unowned_docs_visible_to_all`` is ``True`` (default), documents
-    with ``owner_id IS NULL`` (unclaimed) are also included for every
-    authenticated user so they can be discovered and claimed.
+    When ``unowned_docs_visible_to_all`` is ``True``, documents with
+    ``owner_id IS NULL`` (unclaimed) are also included for every authenticated
+    user so they can be discovered and claimed.  Bundled authenticated
+    deployments set it to ``False`` so an absent owner never widens access
+    accidentally.
 
     When multi-user mode is disabled the query is returned unchanged.
 

--- a/app/views/backup.py
+++ b/app/views/backup.py
@@ -3,7 +3,6 @@ Backup management dashboard view – admin only.
 """
 
 import logging
-import os
 
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
@@ -33,11 +32,13 @@ async def backup_dashboard(request: Request, db: Session = Depends(get_db)):
             if r.backup_type in counts:
                 counts[r.backup_type] += 1
 
-        # Compute total local size
-        total_size = sum(r.size_bytes for r in records if r.local_path and os.path.exists(r.local_path))
         from app.tasks.backup_tasks import _archive_ext_for_backend, _db_backend, backup_storage_status
 
         storage = backup_storage_status()
+        # Use the same filesystem snapshot as the backup safety checks.  DB
+        # records can include stale paths or omit archives created outside the
+        # current result window and must not be presented as disk usage.
+        total_size = int(storage["backup_bytes"])
         last_failure = records[0] if records and records[0].status == "failed" else None
 
         return templates.TemplateResponse(

--- a/app/views/general.py
+++ b/app/views/general.py
@@ -30,12 +30,14 @@ async def serve_index(request: Request, db: Session = Depends(get_db)):
     from app.utils.settings_service import get_setting_from_db
     from app.utils.setup_wizard import is_setup_required
 
-    # Check if setup was explicitly skipped
+    # Setup may be completed by either the browser wizard or the declarative
+    # agentic flow.  Both are server-owned DB markers.
     setup_skipped = get_setting_from_db(db, "_setup_wizard_skipped")
+    setup_completed = get_setting_from_db(db, "_setup_wizard_completed")
 
     # Setup state is server-owned. A query parameter must never be able to
     # bypass an incomplete first-run configuration.
-    if not setup_skipped and is_setup_required():
+    if not setup_skipped and not setup_completed and is_setup_required():
         logger.info("System requires initial setup, redirecting to wizard")
         return RedirectResponse(url="/setup?step=1", status_code=303)
 

--- a/docs/AgenticSetup.md
+++ b/docs/AgenticSetup.md
@@ -8,7 +8,8 @@ the browser wizard.
 
 The intended prompt is therefore practical: “Install DocuElevate as a Preprod
 Canary, create Christian and Julia, place both in the family Tribe, configure
-the AI provider and leave only interactive OAuth approvals for me.”
+the AI provider if credentials are available, and leave only interactive OAuth
+approvals for me.”
 
 ## Safety contract
 
@@ -34,6 +35,10 @@ the AI provider and leave only interactive OAuth approvals for me.”
 
 Start from
 [`examples/agentic-setup.preprod.json`](https://github.com/christianlouis/DocuElevate/blob/main/examples/agentic-setup.preprod.json).
+For a genuinely bare installation without AI or cloud-provider credentials, use
+[`examples/agentic-setup.keyless-preprod.json`](https://github.com/christianlouis/DocuElevate/blob/main/examples/agentic-setup.keyless-preprod.json).
+It creates two isolated users and their shared Preprod Tribe while keeping every
+optional integration skipped and resumable in the browser.
 The current schema is `docuelevate.org/v1alpha1` with kind
 `DocuElevateSetup`. Unknown fields and unsupported resources fail validation;
 they are never silently ignored.

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -540,8 +540,9 @@ Social login lets users sign in with their existing Google, Microsoft, Apple, Dr
 ### Multi-User Mode
 
 When multi-user mode is enabled, each authenticated user gets their own isolated document space.
-Uploads, search results, and file management are scoped to the individual user. Shared settings
-(AI configuration, OCR providers, storage destinations) remain global.
+Uploads, search results, and file management are scoped to the individual user and Tribe. Operator
+settings such as the database and shared AI/OCR infrastructure remain global; user integrations and
+their credentials are stored in the database and scoped to their owner rather than shared globally.
 
 Admin users (determined by `ADMIN_GROUP_NAME`) bypass the user filter and can see all documents.
 
@@ -549,10 +550,15 @@ Requires `AUTH_ENABLED=true`.
 
 | **Variable**                | **Description**                                                                 | **Default** |
 |-----------------------------|---------------------------------------------------------------------------------|-------------|
-| `MULTI_USER_ENABLED`        | Enable multi-user mode with individual document spaces per user.               | `false`     |
+| `MULTI_USER_ENABLED`        | Enable multi-user mode with individual document spaces per user.               | `false`*    |
 | `DEFAULT_DAILY_UPLOAD_LIMIT`| Maximum document uploads allowed per user per day. `0` = unlimited.            | `0`         |
-| `UNOWNED_DOCS_VISIBLE_TO_ALL` | Show unclaimed documents (no owner) to all users. When `false`, only admins see them. | `true` |
+| `UNOWNED_DOCS_VISIBLE_TO_ALL` | Show unclaimed documents (no owner) to all users. When `false`, only admins see them. | `true`* |
 | `DEFAULT_OWNER_ID`          | Automatically assign this owner to newly ingested documents without a session (e.g. IMAP, API). Leave empty to keep unowned. | *(empty)* |
+
+\* These are compatibility fallbacks for embedding DocuElevate without
+authentication. The bundled Docker Compose and `.env.demo` explicitly use the
+recommended secure defaults: `AUTH_ENABLED=true`, `MULTI_USER_ENABLED=true`, and
+`UNOWNED_DOCS_VISIBLE_TO_ALL=false`.
 
 #### Unclaimed Documents
 
@@ -562,7 +568,7 @@ without a user session have `owner_id = NULL` unless `DEFAULT_OWNER_ID` is set. 
 Documents ingested via **per-user integrations** (IMAP or Watch Folder integrations configured through
 the Integrations dashboard) are automatically attributed to the owning user's `owner_id` and are never unclaimed.
 
-- When `UNOWNED_DOCS_VISIBLE_TO_ALL=true` (default), every authenticated user sees unclaimed
+- When `UNOWNED_DOCS_VISIBLE_TO_ALL=true`, every authenticated user sees unclaimed
   documents alongside their own files. This allows users to discover and claim them.
 - When `UNOWNED_DOCS_VISIBLE_TO_ALL=false`, only admins can see unclaimed documents.
 
@@ -1983,7 +1989,8 @@ AUTHENTIK_CONFIG_URL=https://auth.example.com/.well-known/openid-configuration
 OAUTH_PROVIDER_NAME=Authentik SSO
 
 # Multi-user mode (requires AUTH_ENABLED=true)
-MULTI_USER_ENABLED=false
+MULTI_USER_ENABLED=true
+UNOWNED_DOCS_VISIBLE_TO_ALL=false
 DEFAULT_DAILY_UPLOAD_LIMIT=0
 
 # Storage services

--- a/docs/SetupWizard.md
+++ b/docs/SetupWizard.md
@@ -105,7 +105,7 @@ bypass an incomplete installation.
 
 **Recommended next steps:**
 
-1. **Configure a storage destination** — Set up at least one output destination where processed documents will be sent:
+1. **Choose optional destinations** — Every processed document is retained in DocuElevate's built-in archive. Add external destinations only when you want another copy or an automated hand-off:
    - [Dropbox Setup](DropboxSetup.md)
    - [Google Drive Setup](GoogleDriveSetup.md)
    - [OneDrive Setup](OneDriveSetup.md)

--- a/examples/agentic-setup.keyless-preprod.json
+++ b/examples/agentic-setup.keyless-preprod.json
@@ -1,0 +1,46 @@
+{
+  "apiVersion": "docuelevate.org/v1alpha1",
+  "kind": "DocuElevateSetup",
+  "metadata": {
+    "name": "DocuElevate Preprod Keyless Canary"
+  },
+  "spec": {
+    "completeSetup": true,
+    "settings": {},
+    "users": [
+      {
+        "email": "christian@example.test",
+        "username": "christian",
+        "displayName": "Christian",
+        "password": {
+          "fromEnv": "DOCUELEVATE_SETUP_CHRISTIAN_PASSWORD"
+        },
+        "isAdmin": true
+      },
+      {
+        "email": "julia@example.test",
+        "username": "julia",
+        "displayName": "Julia",
+        "password": {
+          "fromEnv": "DOCUELEVATE_SETUP_JULIA_PASSWORD"
+        },
+        "isAdmin": false
+      }
+    ],
+    "tribes": [
+      {
+        "name": "Krakau Family Preprod",
+        "members": [
+          {
+            "email": "christian@example.test",
+            "role": "admin"
+          },
+          {
+            "email": "julia@example.test",
+            "role": "member"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures_integration.py
+++ b/tests/fixtures_integration.py
@@ -38,13 +38,17 @@ def postgres_container() -> Generator:
     with PostgresContainer("postgres:15-alpine") as postgres:
         # Wait for PostgreSQL to be ready
         time.sleep(2)
+        postgres_url = postgres.get_connection_url().replace(
+            "postgresql+psycopg2://",
+            "postgresql+psycopg://",
+        )
 
         # Set environment variable for the app to use
-        os.environ["DATABASE_URL"] = postgres.get_connection_url()
+        os.environ["DATABASE_URL"] = postgres_url
 
         yield {
             "container": postgres,
-            "url": postgres.get_connection_url(),
+            "url": postgres_url,
             "host": postgres.get_container_host_ip(),
             "port": postgres.get_exposed_port(5432),
             "username": postgres.username,
@@ -89,9 +93,21 @@ def gotenberg_container() -> Generator:
 
     This provides actual document conversion capabilities.
     """
+    external_url = os.getenv("TEST_GOTENBERG_URL")
+    if external_url:
+        # Local/CI environments may already provide the exact Gotenberg service
+        # used by the application.  Reuse it to avoid nesting Chromium when the
+        # test runner itself is containerized.
+        yield {
+            "container": None,
+            "url": external_url.rstrip("/"),
+            "host": None,
+            "port": None,
+        }
+        return
+
     container = DockerContainer("gotenberg/gotenberg:8")
     container.with_exposed_ports(3000)
-    container.with_command("gotenberg --chromium-disable-javascript=false --chromium-allow-list=file:///.*")
 
     container.start()
     time.sleep(5)  # Gotenberg takes a bit longer to start
@@ -166,7 +182,9 @@ def sftp_container() -> Generator:
         "port": port,
         "username": "testuser",
         "password": _TEST_CREDENTIAL,
-        "folder": "/home/testuser/upload",
+        # atmoz/sftp chroots the user into /home/testuser, so clients see the
+        # provisioned upload directory at /upload rather than the host path.
+        "folder": "/upload",
     }
 
     container.stop()
@@ -186,9 +204,10 @@ def minio_container() -> Generator:
         access_key = minio.access_key
         secret_key = minio.secret_key
 
+        endpoint = minio.get_config()["endpoint"]
         yield {
             "container": minio,
-            "url": minio.get_config()["endpoint"],
+            "url": f"http://{endpoint}",
             "access_key": access_key,
             "secret_key": secret_key,
             "region": "us-east-1",
@@ -259,6 +278,21 @@ def celery_app(redis_container):
     This allows testing actual task queueing and execution.
     """
     from app.celery_app import celery
+    from app.config import settings
+
+    previous_urls = (
+        settings.redis_url,
+        settings.celery_broker_url,
+        settings.celery_result_backend,
+    )
+
+    # The production worker has a startup bootstep that verifies the configured
+    # Redis result backend is writable.  Point both Settings and Celery at the
+    # ephemeral Redis service; updating Celery alone leaves that safety check on
+    # the process-start default and makes an otherwise healthy E2E worker fail.
+    settings.redis_url = redis_container["url"]
+    settings.celery_broker_url = redis_container["url"]
+    settings.celery_result_backend = redis_container["url"]
 
     # Update Celery configuration to use test Redis
     celery.conf.update(
@@ -268,8 +302,17 @@ def celery_app(redis_container):
         task_eager_propagates=True,
         result_expires=3600,
     )
+    # Celery caches thread-safe and thread-local backends separately.  Clear
+    # both storage locations without invoking the property setter (which only
+    # accepts a concrete backend instance).
+    celery._backend_cache = None  # noqa: SLF001
+    celery._local.__dict__.pop("backend", None)  # noqa: SLF001
 
-    return celery
+    yield celery
+
+    settings.redis_url, settings.celery_broker_url, settings.celery_result_backend = previous_urls
+    celery._backend_cache = None  # noqa: SLF001
+    celery._local.__dict__.pop("backend", None)  # noqa: SLF001
 
 
 @pytest.fixture(scope="session")
@@ -279,6 +322,8 @@ def celery_worker(celery_app, redis_container):
 
     This runs tasks asynchronously like in production.
     """
+    import gc
+
     from celery.contrib.testing.worker import start_worker
 
     # Start worker in test mode
@@ -288,7 +333,18 @@ def celery_worker(celery_app, redis_container):
         loglevel="info",
         concurrency=2,
     ) as worker:
-        yield worker
+        try:
+            yield worker
+        finally:
+            # AsyncResult destructors unsubscribe from Redis.  Collect them and
+            # stop the result consumer while the ephemeral backend is still
+            # alive; otherwise teardown emits misleading reconnect failures
+            # after testcontainers has already removed Redis.
+            gc.collect()
+            result_consumer = getattr(celery_app.backend, "result_consumer", None)
+            if result_consumer is not None:
+                result_consumer.stop()
+            gc.collect()
 
 
 @pytest.fixture
@@ -312,6 +368,13 @@ def db_session_real(postgres_container):
     # Create session
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = SessionLocal()
+
+    # Mirror normal ingestion startup: PostgreSQL enforces the tenant/Tribe
+    # foreign keys that SQLite unit tests can otherwise hide.
+    from app.utils.tribe_scope import ensure_document_scope
+
+    ensure_document_scope(session, owner_id=None)
+    session.commit()
 
     try:
         yield session

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,6 +37,18 @@ class TestHealthEndpoints:
         assert response.status_code == 303
         assert response.headers["location"] == "/setup?step=1"
 
+    @patch("app.utils.setup_wizard.is_setup_required", return_value=True)
+    @patch("app.utils.settings_service.get_setting_from_db")
+    def test_agentic_setup_completion_marker_bypasses_legacy_fallback_check(
+        self, get_setting, _setup_required, client: TestClient
+    ):
+        """A server-owned completion marker wins over absent fallback admin envs."""
+        get_setting.side_effect = lambda _db, key: "true" if key == "_setup_wizard_completed" else None
+
+        response = client.get("/", follow_redirects=False)
+
+        assert response.status_code != 303 or response.headers.get("location") != "/setup?step=1"
+
     def test_setup_wizard_page_accessible(self, client: TestClient):
         """Test that GET /setup?step=1 returns 200."""
         response = client.get("/setup?step=1")

--- a/tests/test_api_integrations.py
+++ b/tests/test_api_integrations.py
@@ -1113,7 +1113,8 @@ class TestConnectionTestEndpoint:
             "config": {"url": "https://example.com/webdav"},
             "credentials": {"username": "user1", "password": "password123"},
         }
-        resp = int_client.post("/api/integrations/test", json=payload)
+        with unittest.mock.patch("app.utils.network.is_private_ip", return_value=False):
+            resp = int_client.post("/api/integrations/test", json=payload)
 
         assert resp.status_code == 200
         data = resp.json()
@@ -1140,7 +1141,8 @@ class TestConnectionTestEndpoint:
             "config": {"url": "https://example.com/webdav"},
             "credentials": {"username": "user1", "password": "wrong"},
         }
-        resp = int_client.post("/api/integrations/test", json=payload)
+        with unittest.mock.patch("app.utils.network.is_private_ip", return_value=False):
+            resp = int_client.post("/api/integrations/test", json=payload)
 
         assert resp.status_code == 200
         data = resp.json()
@@ -1157,7 +1159,8 @@ class TestConnectionTestEndpoint:
             "config": {"url": "https://example.com/webdav"},
             "credentials": {},
         }
-        resp = int_client.post("/api/integrations/test", json=payload)
+        with unittest.mock.patch("app.utils.network.is_private_ip", return_value=False):
+            resp = int_client.post("/api/integrations/test", json=payload)
 
         assert resp.status_code == 200
         data = resp.json()

--- a/tests/test_config_validators.py
+++ b/tests/test_config_validators.py
@@ -1,5 +1,6 @@
 """Tests for app/utils/config_validator/validators.py module."""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -208,6 +209,7 @@ class TestValidateAuthConfig:
             mock_settings.social_auth_microsoft_enabled = False
             mock_settings.social_auth_apple_enabled = False
             mock_settings.social_auth_dropbox_enabled = False
+            mock_settings.allow_local_signup = False
             result = validate_auth_config()
             assert "Neither simple authentication, OIDC, nor social login are properly configured" in result
 
@@ -318,6 +320,56 @@ class TestCheckAllConfigs:
         assert "notification" in result
         assert "auth" in result
 
+    def test_fresh_install_does_not_report_unconfigured_optional_services(self):
+        """Startup mode treats untouched optional integrations as absent, not broken."""
+        fresh_settings = SimpleNamespace(
+            debug=False,
+            auth_enabled=True,
+            session_secret="s" * 32,
+            allow_local_signup=True,
+            admin_username=None,
+            admin_password=None,
+            notification_urls=[],
+        )
+        with patch("app.utils.config_validator.validators.settings", fresh_settings):
+            result = check_all_configs(configured_only=True)
+
+        assert result["auth"] == []
+        assert result["email"] == []
+        assert result["notification"] == []
+        assert all(provider_issues == [] for provider_issues in result["storage"].values())
+
+    def test_fresh_install_logs_optional_services_as_skipped_not_configured(self, caplog):
+        """Green startup logs must not claim absent integrations are configured."""
+        fresh_settings = SimpleNamespace(
+            debug=False,
+            auth_enabled=False,
+            notification_urls=[],
+        )
+        with patch("app.utils.config_validator.validators.settings", fresh_settings):
+            check_all_configs(configured_only=True)
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert "Email is not configured; optional email intake skipped" in messages
+        assert "Dropbox is not configured; optional integration skipped" in messages
+        assert "Notifications are not configured; optional notifications skipped" in messages
+        assert "Dropbox configuration OK" not in messages
+
+    def test_partially_configured_optional_service_remains_actionable(self):
+        """Once configuration starts, missing required fields are still reported."""
+        partial_settings = SimpleNamespace(
+            debug=False,
+            auth_enabled=False,
+            s3_bucket_name="documents",
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            notification_urls=[],
+        )
+        with patch("app.utils.config_validator.validators.settings", partial_settings):
+            result = check_all_configs(configured_only=True)
+
+        assert "AWS credentials are not configured" in result["storage"]["s3"]
+
     @patch("app.utils.config_validator.settings_display.dump_all_settings")
     def test_debug_mode_enabled(self, mock_dump):
         """Test that settings are dumped when debug mode is enabled."""
@@ -371,6 +423,20 @@ class TestValidateAuthConfigEdgeCases:
             issues = validate_auth_config()
             # Should have no issues when auth is disabled
             assert len(issues) == 0
+
+    def test_local_signup_is_valid_fresh_install_authentication(self):
+        """The setup journey is a valid auth path before an IdP is configured."""
+        fresh_settings = SimpleNamespace(
+            auth_enabled=True,
+            session_secret="s" * 32,
+            allow_local_signup=True,
+            admin_username=None,
+            admin_password=None,
+        )
+        with patch("app.utils.config_validator.validators.settings", fresh_settings):
+            issues = validate_auth_config()
+
+        assert not any("Neither simple authentication" in issue for issue in issues)
 
 
 @pytest.mark.unit

--- a/tests/test_convert_to_pdf.py
+++ b/tests/test_convert_to_pdf.py
@@ -1,6 +1,6 @@
 """Tests for app/tasks/convert_to_pdf.py module."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -23,12 +23,10 @@ class TestConvertToPdfMimeTypes:
         with patch("app.tasks.convert_to_pdf.settings") as mock_settings:
             mock_settings.gotenberg_url = None
 
-            mock_self = MagicMock()
-            mock_self.request.id = "test-task-id"
-
             from app.tasks.convert_to_pdf import convert_to_pdf
 
-            result = convert_to_pdf.__wrapped__(mock_self, "/tmp/test.docx")
+            convert_to_pdf.request.id = "test-task-id"
+            result = convert_to_pdf.__wrapped__("/tmp/test.docx")
             assert result is None
 
     @patch("app.tasks.convert_to_pdf.requests")
@@ -45,10 +43,8 @@ class TestConvertToPdfMimeTypes:
             mock_settings.gotenberg_url = "http://localhost:3000"
             mock_settings.http_request_timeout = 30
 
-            mock_self = MagicMock()
-            mock_self.request.id = "test-task-id"
-
             from app.tasks.convert_to_pdf import convert_to_pdf
 
-            result = convert_to_pdf.__wrapped__(mock_self, str(test_file))
+            convert_to_pdf.request.id = "test-task-id"
+            result = convert_to_pdf.__wrapped__(str(test_file))
             assert result is None

--- a/tests/test_coverage_polish.py
+++ b/tests/test_coverage_polish.py
@@ -363,16 +363,14 @@ class TestConvertToPdfDetection:
             mock_settings.gotenberg_url = "http://localhost:3000"
             mock_settings.http_request_timeout = 30
 
-            mock_self = MagicMock()
-            mock_self.request.id = "task-notype"
-
             with (
                 patch("app.tasks.convert_to_pdf._detect_mime_type", return_value=(None, None)),
                 patch("app.tasks.convert_to_pdf._detect_extension", return_value=""),
             ):
                 from app.tasks.convert_to_pdf import convert_to_pdf
 
-                result = convert_to_pdf.__wrapped__(mock_self, str(test_file))
+                convert_to_pdf.request.id = "task-notype"
+                result = convert_to_pdf.__wrapped__(str(test_file))
                 assert result is None
 
     def test_detect_mime_type_from_magic_filetype_fallback(self, tmp_path):
@@ -584,7 +582,8 @@ class TestURLUploadAdditionalCoverage:
         mock_task.id = "task-empty-path"
         mock_process.delay.return_value = mock_task
 
-        response = client.post("/api/process-url", json={"url": "https://example.com/"})
+        with patch("app.api.url_upload.is_private_ip", return_value=False):
+            response = client.post("/api/process-url", json={"url": "https://example.com/"})
         assert response.status_code == 200
 
     def test_validate_url_safety_blocks_aws_link_local(self):

--- a/tests/test_e2e_full_stack.py
+++ b/tests/test_e2e_full_stack.py
@@ -15,12 +15,17 @@ import requests
 # Import testcontainers requirement
 pytest.importorskip("testcontainers", reason="testcontainers not installed")
 
-try:
-    import psycopg2  # noqa: F401
+# Keep the expensive real-service fixtures opt-in to this E2E module.  The
+# regular unit suite must not import them, while this module must be runnable on
+# its own without relying on external pytest command-line configuration.
+pytest_plugins = ("tests.fixtures_integration",)
 
-    _has_psycopg2 = True
+try:
+    import psycopg  # noqa: F401
+
+    _has_psycopg = True
 except ModuleNotFoundError:
-    _has_psycopg2 = False
+    _has_psycopg = False
 
 
 _TEST_CREDENTIAL = "pass"  # noqa: S105
@@ -80,6 +85,7 @@ class TestEndToEndWithRedis:
             # Verify task completed successfully
             assert task_result["status"] == "Completed"
             assert task_result["file"] == sample_text_file
+            result.forget()
 
             # Verify file was actually uploaded to WebDAV server
             filename = os.path.basename(sample_text_file)
@@ -115,20 +121,25 @@ class TestEndToEndWithRedis:
         # Check Redis is accessible
         assert r.ping()
 
-        # Get current queue length
-        initial_queue_length = r.llen("celery")
+        # Use a dedicated queue that the session worker does not consume.  The
+        # old test queued an invalid upload onto the production-like queue and
+        # left a delayed retry behind, contaminating subsequent E2E scenarios.
+        probe_queue = "e2e_queue_probe"
+        initial_queue_length = r.llen(probe_queue)
+        result = None
+        try:
+            result = upload_to_webdav.apply_async(
+                args=["/tmp/test.txt"],
+                kwargs={"file_id": 1},
+                queue=probe_queue,
+            )
 
-        # Queue a task (don't execute, just verify queueing)
-        with patch("app.tasks.upload_to_webdav.settings") as mock_settings:
-            mock_settings.webdav_url = "http://test.com"
-            mock_settings.webdav_username = "user"
-            mock_settings.webdav_password = _TEST_CREDENTIAL
-
-            # This will queue the task in Redis
-            result = upload_to_webdav.apply_async(args=["/tmp/test.txt"], kwargs={"file_id": 1})
-
-            # Verify task ID was generated
             assert result.id is not None
+            assert r.llen(probe_queue) == initial_queue_length + 1
+        finally:
+            if result is not None:
+                result.forget()
+            r.delete(probe_queue)
 
     def test_multiple_tasks_parallel_execution(
         self,
@@ -191,6 +202,7 @@ class TestEndToEndWithRedis:
             for result, file_path in results:
                 task_result = result.get(timeout=5)
                 assert task_result["status"] == "Completed"
+                result.forget()
 
                 # Verify file on server
                 filename = os.path.basename(file_path)
@@ -218,6 +230,8 @@ class TestEndToEndWithRedis:
             patch("app.tasks.upload_to_webdav.settings") as mock_settings,
             patch("app.tasks.upload_to_webdav.log_task_progress"),
             patch("app.tasks.upload_to_webdav.requests.put") as mock_put,
+            patch.object(upload_to_webdav, "retry_delays", [1, 1]),
+            patch.object(upload_to_webdav, "retry_jitter", False),
         ):
             mock_settings.webdav_url = "http://test.com/"
             mock_settings.webdav_username = "user"
@@ -246,8 +260,12 @@ class TestEndToEndWithRedis:
             start_time = time.time()
             while not result.ready():
                 if time.time() - start_time > timeout:
-                    break  # Task might still be retrying
+                    pytest.fail("Retrying WebDAV task did not complete within timeout")
                 time.sleep(0.5)
+
+            assert result.get(timeout=5)["status"] == "Completed"
+            assert mock_put.call_count == 2
+            result.forget()
 
 
 @pytest.mark.integration
@@ -293,8 +311,8 @@ class TestFullInfrastructure:
         assert infra["minio"]["access_key"] is not None
 
     @pytest.mark.skipif(
-        not _has_psycopg2,
-        reason="psycopg2 not installed",
+        not _has_psycopg,
+        reason="psycopg not installed",
     )
     def test_database_with_real_postgres(self, postgres_container, db_session_real):
         """
@@ -304,8 +322,10 @@ class TestFullInfrastructure:
 
         # Create a file record
         file_record = FileRecord(
-            filename="test.pdf",
-            file_path="/tmp/test.pdf",
+            filehash="postgres-e2e-test-pdf",
+            original_filename="test.pdf",
+            local_filename="/tmp/test.pdf",
+            original_file_path="/tmp/test.pdf",
             file_size=1024,
             mime_type="application/pdf",
         )
@@ -317,9 +337,9 @@ class TestFullInfrastructure:
         assert file_record.id is not None
 
         # Query it back
-        queried = db_session_real.query(FileRecord).filter_by(filename="test.pdf").first()
+        queried = db_session_real.query(FileRecord).filter_by(original_filename="test.pdf").first()
         assert queried is not None
-        assert queried.filename == "test.pdf"
+        assert queried.original_filename == "test.pdf"
         assert queried.file_size == 1024
 
     def test_upload_to_multiple_targets(
@@ -363,6 +383,7 @@ class TestFullInfrastructure:
             # Verify WebDAV upload
             result = webdav_result.get(timeout=10)
             assert result["status"] == "Completed"
+            webdav_result.forget()
 
             # Verify file on WebDAV server
             filename = os.path.basename(sample_text_file)
@@ -388,14 +409,22 @@ class TestFullInfrastructure:
         </html>
         """)
 
-        # Convert to PDF using Gotenberg
-        with open(html_file, "rb") as f:
-            files = {"files": f}
+        # Gotenberg's health endpoint can become available shortly before its
+        # Chromium module accepts conversions.  Retry only the documented 503
+        # warm-up response; every other failure remains immediately visible.
+        html = html_file.read_bytes()
+        for _attempt in range(30):
+            # Match the production conversion task exactly: Gotenberg accepts
+            # the entry document under the index.html form field.
+            files = {"index.html": ("index.html", html, "text/html")}
             response = requests.post(
                 f"{gotenberg_container['url']}/forms/chromium/convert/html", files=files, timeout=30
             )
+            if response.status_code != 503:
+                break
+            time.sleep(1)
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert response.headers["Content-Type"] == "application/pdf"
         assert len(response.content) > 0
         assert response.content.startswith(b"%PDF")
@@ -522,8 +551,10 @@ class TestProductionLikeScenarios:
 
         # Step 1: Store in database
         file_record = FileRecord(
-            filename="invoice.pdf",
-            file_path=str(test_doc),
+            filehash="postgres-e2e-invoice-pdf",
+            original_filename="invoice.pdf",
+            local_filename=str(test_doc),
+            original_file_path=str(test_doc),
             file_size=test_doc.stat().st_size,
             mime_type="application/pdf",
         )
@@ -567,6 +598,7 @@ class TestProductionLikeScenarios:
             # Step 5: Verify completion
             task_result = result.get(timeout=10)
             assert task_result["status"] == "Completed"
+            result.forget()
 
             # Step 6: Verify file on WebDAV
             file_url = f"{infra['webdav']['url']}/processed/invoice.pdf"

--- a/tests/test_imap_tasks.py
+++ b/tests/test_imap_tasks.py
@@ -652,7 +652,8 @@ class TestPullInbox:
     @patch("app.tasks.imap_tasks.find_all_mail_folder")
     @patch("app.tasks.imap_tasks.imaplib.IMAP4_SSL")
     @patch("app.tasks.imap_tasks.load_processed_emails")
-    def test_gmail_uses_all_mail_folder(self, mock_load, mock_imap_class, mock_find_all):
+    @patch("app.tasks.imap_tasks.is_private_ip", return_value=False)
+    def test_gmail_uses_all_mail_folder(self, _mock_private_ip, mock_load, mock_imap_class, mock_find_all):
         """Test that Gmail uses All Mail folder when found."""
         mock_load.return_value = {}
         mock_mail = MagicMock()
@@ -679,7 +680,8 @@ class TestPullInbox:
     @patch("app.tasks.imap_tasks.find_all_mail_folder")
     @patch("app.tasks.imap_tasks.imaplib.IMAP4_SSL")
     @patch("app.tasks.imap_tasks.load_processed_emails")
-    def test_gmail_fallback_to_inbox(self, mock_load, mock_imap_class, mock_find_all):
+    @patch("app.tasks.imap_tasks.is_private_ip", return_value=False)
+    def test_gmail_fallback_to_inbox(self, _mock_private_ip, mock_load, mock_imap_class, mock_find_all):
         """Test that Gmail falls back to INBOX when All Mail not found."""
         mock_load.return_value = {}
         mock_mail = MagicMock()
@@ -822,8 +824,10 @@ class TestPullInbox:
     @patch("app.tasks.imap_tasks.load_processed_emails")
     @patch("app.tasks.imap_tasks.save_processed_emails")
     @patch("app.tasks.imap_tasks.settings")
+    @patch("app.tasks.imap_tasks.is_private_ip", return_value=False)
     def test_gmail_labels_and_star(
         self,
+        _mock_private_ip,
         mock_settings,
         mock_save,
         mock_load,
@@ -873,8 +877,10 @@ class TestPullInbox:
     @patch("app.tasks.imap_tasks.load_processed_emails")
     @patch("app.tasks.imap_tasks.save_processed_emails")
     @patch("app.tasks.imap_tasks.settings")
+    @patch("app.tasks.imap_tasks.is_private_ip", return_value=False)
     def test_gmail_labels_disabled_when_gmail_apply_labels_false(
         self,
+        _mock_private_ip,
         mock_settings,
         mock_save,
         mock_load,
@@ -1073,8 +1079,10 @@ class TestPullInbox:
     @patch("app.tasks.imap_tasks.load_processed_emails")
     @patch("app.tasks.imap_tasks.save_processed_emails")
     @patch("app.tasks.imap_tasks.settings")
+    @patch("app.tasks.imap_tasks.is_private_ip", return_value=False)
     def test_readonly_mode_skips_gmail_modifications(
         self,
+        _mock_private_ip,
         mock_settings,
         mock_save,
         mock_load,

--- a/tests/test_multi_user.py
+++ b/tests/test_multi_user.py
@@ -443,12 +443,11 @@ class TestMultiUserConfig:
     """Verify the multi-user configuration settings."""
 
     @pytest.mark.unit
-    def test_multi_user_default_disabled(self):
-        """multi_user_enabled should default to False."""
+    def test_multi_user_compatibility_default_disabled(self):
+        """The code fallback remains usable without authentication."""
         from app.config import settings
 
-        # Default is False (overridable via env)
-        assert hasattr(settings, "multi_user_enabled")
+        assert settings.multi_user_enabled is False
 
     @pytest.mark.unit
     def test_default_daily_upload_limit_exists(self):
@@ -617,9 +616,9 @@ class TestUnownedDocsConfig:
     """Verify the new multi-user configuration settings."""
 
     @pytest.mark.unit
-    def test_unowned_docs_visible_default_true(self):
-        """unowned_docs_visible_to_all should default to True."""
-        assert hasattr(settings, "unowned_docs_visible_to_all")
+    def test_unowned_docs_visible_compatibility_default_true(self):
+        """The code fallback preserves legacy auth-free visibility."""
+        assert settings.unowned_docs_visible_to_all is True
 
     @pytest.mark.unit
     def test_default_owner_id_default_none(self):

--- a/tests/test_scheduled_jobs.py
+++ b/tests/test_scheduled_jobs.py
@@ -1019,6 +1019,81 @@ class TestSyncSearchIndex:
         mock_update.assert_called_once()
         assert mock_update.call_args[0][1] == "success"
 
+    def test_pristine_install_treats_missing_index_as_empty(self, sj_engine):
+        """A first sync creates the index through the normal indexing path."""
+        from app.tasks.batch_tasks import sync_search_index
+
+        session = sessionmaker(bind=sj_engine)()
+        _make_file_record(session, filehash="hash_pristine_search", ocr_text="first searchable document")
+        session.close()
+
+        class MissingIndexError(RuntimeError):
+            code = "index_not_found"
+
+        mock_client = MagicMock()
+        mock_index = MagicMock()
+        mock_client.get_index.return_value = mock_index
+        mock_index.get_documents.side_effect = MissingIndexError("Index documents not found")
+
+        with (
+            patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client),
+            patch("app.utils.meilisearch_client.index_documents", side_effect=len) as mock_idx,
+            patch("app.tasks.batch_tasks._update_job_status") as mock_update,
+            patch("app.tasks.batch_tasks.SessionLocal") as mock_sl,
+            patch("app.tasks.batch_tasks.settings") as mock_settings,
+        ):
+            mock_settings.meilisearch_index_name = "documents"
+            real_session = sessionmaker(bind=sj_engine)()
+            mock_sl.return_value.__enter__ = MagicMock(return_value=real_session)
+            mock_sl.return_value.__exit__ = MagicMock(return_value=False)
+            result = sync_search_index(batch_size=10)
+            real_session.close()
+
+        assert result == {
+            "indexed": 1,
+            "skipped": 0,
+            "remaining": 0,
+            "indexable": 1,
+            "already_indexed": 0,
+            "continued": False,
+        }
+        mock_idx.assert_called_once()
+        mock_update.assert_called_once()
+        assert mock_update.call_args[0][1] == "success"
+
+    def test_pristine_empty_install_reports_clean_zero_result(self, sj_engine):
+        """An empty fresh install succeeds without forcing an empty index."""
+        from app.tasks.batch_tasks import sync_search_index
+
+        class MissingIndexError(RuntimeError):
+            code = "index_not_found"
+
+        mock_client = MagicMock()
+        mock_index = MagicMock()
+        mock_client.get_index.return_value = mock_index
+        mock_index.get_documents.side_effect = MissingIndexError("Index documents not found")
+
+        with (
+            patch("app.utils.meilisearch_client.get_meilisearch_client", return_value=mock_client),
+            patch("app.utils.meilisearch_client.index_documents") as mock_idx,
+            patch("app.tasks.batch_tasks._update_job_status") as mock_update,
+            patch("app.tasks.batch_tasks.SessionLocal") as mock_sl,
+            patch("app.tasks.batch_tasks.settings") as mock_settings,
+        ):
+            mock_settings.meilisearch_index_name = "documents"
+            real_session = sessionmaker(bind=sj_engine)()
+            mock_sl.return_value.__enter__ = MagicMock(return_value=real_session)
+            mock_sl.return_value.__exit__ = MagicMock(return_value=False)
+            result = sync_search_index(batch_size=10)
+            real_session.close()
+
+        assert result["indexed"] == 0
+        assert result["remaining"] == 0
+        assert result["indexable"] == 0
+        assert result["already_indexed"] == 0
+        mock_idx.assert_not_called()
+        assert mock_update.call_args[0][1] == "success"
+
     def test_handles_meilisearch_fetch_error(self):
         """Error fetching existing IDs from Meilisearch results in failed status."""
         from app.tasks.batch_tasks import sync_search_index

--- a/tests/test_setup_manifest.py
+++ b/tests/test_setup_manifest.py
@@ -71,9 +71,13 @@ _ENV = {
 def test_example_and_json_schema_use_the_runtime_api_version():
     root = Path(__file__).resolve().parents[1]
     example = json.loads((root / "examples" / "agentic-setup.preprod.json").read_text(encoding="utf-8"))
+    keyless_example = json.loads((root / "examples" / "agentic-setup.keyless-preprod.json").read_text(encoding="utf-8"))
     schema = json.loads((root / "schemas" / "docuelevate-setup-v1alpha1.schema.json").read_text(encoding="utf-8"))
     assert example["apiVersion"] == MANIFEST_API_VERSION
     assert example["kind"] == MANIFEST_KIND
+    assert keyless_example["apiVersion"] == MANIFEST_API_VERSION
+    assert keyless_example["kind"] == MANIFEST_KIND
+    assert keyless_example["spec"]["settings"] == {}
     assert schema["properties"]["apiVersion"]["const"] == MANIFEST_API_VERSION
     assert schema["properties"]["kind"]["const"] == MANIFEST_KIND
 
@@ -175,3 +179,24 @@ def test_apply_is_idempotent_and_creates_users_personal_scopes_and_shared_tribe(
         second_apply = apply_setup_manifest(db_session, resolved)
     assert second_apply["applied"] == []
     assert db_session.query(SettingsAuditLog).count() == before_audits
+
+
+def test_keyless_apply_completes_with_database_backed_local_admin(db_session):
+    """A local admin replaces the legacy global fallback admin credentials."""
+    manifest = _manifest()
+    manifest["spec"]["completeSetup"] = True
+    manifest["spec"]["settings"].pop("admin_password")
+    resolved = resolve_setup_manifest(manifest, environ=_ENV)
+
+    with (
+        patch(
+            "app.utils.setup_manifest.get_missing_required_settings", return_value=["admin_username", "admin_password"]
+        ),
+        patch("app.utils.setup_manifest.notify_settings_updated"),
+    ):
+        result = apply_setup_manifest(db_session, resolved)
+
+    assert result["success"] is True
+    assert result["setup_completed"] is True
+    assert result["missing_required_settings"] == []
+    assert get_setting_from_db(db_session, "_setup_wizard_completed") == "true"

--- a/tests/test_upload_webdav_integration.py
+++ b/tests/test_upload_webdav_integration.py
@@ -22,6 +22,18 @@ _TEST_CREDENTIAL = "testpass"  # noqa: S105
 _TEST_WRONG_CREDENTIAL = "wrongpass"  # noqa: S105
 
 
+def _start_container_or_skip(container: DockerContainer) -> None:
+    """Skip Docker-only integration tests when no daemon is available."""
+    try:
+        container.start()
+    except Exception as exc:  # noqa: BLE001 - testcontainers raises backend-specific exceptions
+        try:
+            container.stop()
+        except Exception:  # noqa: BLE001, S110 - best-effort cleanup after failed startup
+            pass
+        pytest.skip(f"Docker is unavailable for WebDAV integration tests ({type(exc).__name__})")
+
+
 @pytest.mark.integration
 @pytest.mark.requires_docker
 class TestWebDAVIntegration:
@@ -42,7 +54,7 @@ class TestWebDAVIntegration:
         container.with_env("PASSWORD", _TEST_CREDENTIAL)
 
         # Start the container
-        container.start()
+        _start_container_or_skip(container)
 
         # Wait for server to be ready
         time.sleep(2)
@@ -324,7 +336,7 @@ class TestWebDAVServerVerification:
         container.with_env("USERNAME", "admin")
         container.with_env("PASSWORD", "admin123")
 
-        container.start()
+        _start_container_or_skip(container)
         time.sleep(2)
 
         host = container.get_container_host_ip()

--- a/tests/test_views_backup.py
+++ b/tests/test_views_backup.py
@@ -133,8 +133,8 @@ class TestBackupDashboard:
         assert context["counts"] == {"hourly": 0, "daily": 0, "weekly": 0}
 
     @pytest.mark.asyncio
-    async def test_total_size_includes_existing_local_files(self):
-        """backup_dashboard sums size_bytes only for records with an existing local_path."""
+    async def test_total_size_uses_filesystem_storage_snapshot(self):
+        """backup_dashboard reports the same real disk usage as backup safety checks."""
         from app.views.backup import backup_dashboard
 
         r_exists = MagicMock()
@@ -156,23 +156,28 @@ class TestBackupDashboard:
         mock_request = self._make_admin_request()
         mock_db = self._make_mock_db(records=records)
 
-        def _fake_exists(path):
-            return path == "/tmp/backup_exists.db.gz"
-
         with (
             patch("app.views.backup.templates") as mock_templates,
-            patch("app.views.backup.os.path.exists", side_effect=_fake_exists),
+            patch(
+                "app.tasks.backup_tasks.backup_storage_status",
+                return_value={
+                    "backup_bytes": 4096,
+                    "free_bytes": 8192,
+                    "max_local_bytes": 16384,
+                    "min_free_bytes": 1024,
+                },
+            ),
         ):
             mock_templates.TemplateResponse.return_value = MagicMock()
             await backup_dashboard(mock_request, db=mock_db)
 
         _tpl_name, context = mock_templates.TemplateResponse.call_args[0]
-        # Only r_exists (512) should be counted; r_missing path doesn't exist; r_no_path has no path
-        assert context["total_size"] == 512
+        # Record metadata deliberately disagrees; the filesystem snapshot wins.
+        assert context["total_size"] == 4096
 
     @pytest.mark.asyncio
-    async def test_total_size_zero_when_no_local_files_exist(self):
-        """backup_dashboard total_size is 0 when no local files are present."""
+    async def test_total_size_zero_when_storage_snapshot_is_empty(self):
+        """backup_dashboard total_size is zero when no backup archives exist."""
         from app.views.backup import backup_dashboard
 
         r = MagicMock()
@@ -185,7 +190,15 @@ class TestBackupDashboard:
 
         with (
             patch("app.views.backup.templates") as mock_templates,
-            patch("app.views.backup.os.path.exists", return_value=False),
+            patch(
+                "app.tasks.backup_tasks.backup_storage_status",
+                return_value={
+                    "backup_bytes": 0,
+                    "free_bytes": 8192,
+                    "max_local_bytes": 16384,
+                    "min_free_bytes": 1024,
+                },
+            ),
         ):
             mock_templates.TemplateResponse.return_value = MagicMock()
             await backup_dashboard(mock_request, db=mock_db)


### PR DESCRIPTION
## Outcome

Makes a fresh DocuElevate installation safe and useful without legacy environment configuration, and aligns setup documentation and roadmap state.

- defaults bundled installs to authenticated multi-user isolation
- makes startup validation truthful for optional, unconfigured services
- supports keyless agentic setup backed by the application database
- fixes first-run Meilisearch indexing, user-scoped scheduling, and backup storage reporting
- strengthens real integration and full-stack test coverage

## Acceptance

- 6,776 non-E2E tests passed (10 skipped), sharded only because of local Docker memory
- 11/11 real full-stack E2E tests passed
- 10/10 real WebDAV integration tests passed
- Ruff and format checks passed; diff check passed
- Chrome fresh-user journey passed end to end: signup, onboarding, family/tribe setup, skip paths, PDF upload, embedded-text extraction with OCR skipped, optional AI/storage degradation, isolated file list, integration-empty state, and search

## Deployment boundary

Merge/deploy is Preprod only. Production remains pinned to the approved legacy image and must not be changed without explicit manual approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo and bundled deployments now use multi-user mode with unclaimed documents hidden by default.
  * Added a keyless Preprod setup example supporting two users and a shared Tribe.
* **Bug Fixes**
  * Setup no longer redirects users after completion.
  * Search indexing now recovers cleanly when an index is missing.
  * Backup dashboard storage totals now reflect the verified storage snapshot.
* **Documentation**
  * Clarified multi-user access, setup guidance, deployment approvals, and optional storage destinations.
* **Improvements**
  * Startup configuration checks now focus on configured integrations and provide clearer issue reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->