### PR TITLE
Make session secret rotation safe and transactional

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -312,6 +312,14 @@ class Settings(BaseSettings):
     admin_username: Optional[str] = None
     admin_password: Optional[str] = None
     session_secret: Optional[str] = None
+    session_secret_previous: Optional[str] = Field(
+        default=None,
+        description=(
+            "Temporary previous SESSION_SECRET used only during an operator-managed "
+            "database encryption-key rotation. Remove it after all encrypted rows have "
+            "been re-encrypted and verified with the current SESSION_SECRET."
+        ),
+    )
     session_lifetime_days: int = Field(
         default=30,
         description=(
@@ -1780,6 +1788,18 @@ class Settings(BaseSettings):
             raise ValueError("SESSION_SECRET must be set when AUTH_ENABLED=True")
         if info.data.get("auth_enabled") and v and len(v) < 32:
             raise ValueError("SESSION_SECRET must be at least 32 characters long")
+        return v
+
+    @field_validator("session_secret_previous")
+    @classmethod
+    def validate_previous_session_secret(cls, v: str | None, info: object) -> str | None:
+        """Keep the temporary fallback key strong and prevent a no-op rotation."""
+        if not v:
+            return None
+        if len(v) < 32:
+            raise ValueError("SESSION_SECRET_PREVIOUS must be at least 32 characters long")
+        if v == info.data.get("session_secret"):
+            raise ValueError("SESSION_SECRET_PREVIOUS must differ from SESSION_SECRET")
         return v
 
     # Get build date from environment or file

--- a/app/rotate_encryption_key.py
+++ b/app/rotate_encryption_key.py
@@ -1,0 +1,39 @@
+"""Operator command for rotating database encryption after SESSION_SECRET changes."""
+
+from __future__ import annotations
+
+import argparse
+
+from app.config import settings
+from app.database import SessionLocal
+from app.utils.encryption import EncryptionRotationError
+from app.utils.encryption_rotation import rotate_database_encryption
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Re-encrypt database credentials with the current SESSION_SECRET without printing values."
+    )
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Do not modify rows; fail unless every encrypted value uses the current key.",
+    )
+    args = parser.parse_args()
+
+    if not args.verify_only and not settings.session_secret_previous:
+        parser.error("SESSION_SECRET_PREVIOUS is required for a key rotation")
+
+    with SessionLocal() as db:
+        try:
+            report = rotate_database_encryption(db, verify_only=args.verify_only)
+        except EncryptionRotationError as exc:
+            print(f"Encryption rotation failed: {exc}")
+            return 1
+
+    print(f"Encryption rotation counts: scanned={report.scanned} rotated={report.rotated} invalid={report.invalid}")
+    return 1 if report.invalid else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/utils/config_loader.py
+++ b/app/utils/config_loader.py
@@ -42,8 +42,12 @@ def load_settings_from_db(settings_obj: object, db_session: Session) -> None:
             key = db_setting.key
             value = db_setting.value
 
-            # Decrypt sensitive settings before applying to the settings object
             metadata = get_setting_metadata(key)
+            if metadata.get("environment_only", False):
+                logger.warning("Ignoring environment-only database setting: %s", key)
+                continue
+
+            # Decrypt sensitive settings before applying to the settings object
             if metadata.get("sensitive", False) and value:
                 try:
                     from app.utils.encryption import decrypt_value

--- a/app/utils/encryption.py
+++ b/app/utils/encryption.py
@@ -14,6 +14,19 @@ logger = logging.getLogger(__name__)
 
 # Lazy-load cryptography to avoid import errors if not installed
 _cipher_suite = None
+_primary_cipher = None
+
+
+class EncryptionRotationError(RuntimeError):
+    """Raised when encrypted data cannot be safely rotated to the primary key."""
+
+
+def _derive_fernet(secret: str) -> object:
+    """Derive a Fernet instance from a DocuElevate session secret."""
+    from cryptography.fernet import Fernet
+
+    key_bytes = hashlib.sha256(secret.encode("utf-8")).digest()
+    return Fernet(base64.urlsafe_b64encode(key_bytes))
 
 
 def _get_cipher_suite() -> object | None:
@@ -28,24 +41,23 @@ def _get_cipher_suite() -> object | None:
     Returns:
         Fernet cipher suite instance
     """
-    global _cipher_suite
+    global _cipher_suite, _primary_cipher
 
     if _cipher_suite is None:
         try:
-            from cryptography.fernet import Fernet
+            from cryptography.fernet import MultiFernet
 
             from app.config import settings
 
-            # Derive a Fernet-compatible key from SESSION_SECRET
-            # Fernet requires a 32-byte base64-encoded key
-            secret = settings.session_secret.encode("utf-8")
+            if not settings.session_secret:
+                raise ValueError("SESSION_SECRET is not configured")
 
-            # Use SHA256 to get exactly 32 bytes, then base64 encode
-            key_bytes = hashlib.sha256(secret).digest()
-            fernet_key = base64.urlsafe_b64encode(key_bytes)
-
-            _cipher_suite = Fernet(fernet_key)
-            logger.debug("Encryption cipher suite initialized")
+            _primary_cipher = _derive_fernet(settings.session_secret)
+            ciphers = [_primary_cipher]
+            if settings.session_secret_previous:
+                ciphers.append(_derive_fernet(settings.session_secret_previous))
+            _cipher_suite = MultiFernet(ciphers)
+            logger.debug("Encryption cipher suite initialized with %d key(s)", len(ciphers))
 
         except ImportError:
             logger.warning(
@@ -59,6 +71,13 @@ def _get_cipher_suite() -> object | None:
             _cipher_suite = None
 
     return _cipher_suite
+
+
+def reset_cipher_cache() -> None:
+    """Clear cached ciphers after settings changes and in isolated tests."""
+    global _cipher_suite, _primary_cipher
+    _cipher_suite = None
+    _primary_cipher = None
 
 
 def encrypt_value(plaintext: Optional[str]) -> Optional[str]:
@@ -123,6 +142,61 @@ def decrypt_value(ciphertext: Optional[str]) -> Optional[str]:
     except Exception as e:
         logger.error(f"Decryption failed: {e}")
         return "[DECRYPTION FAILED]"
+
+
+def rotate_encrypted_value(value: Optional[str]) -> tuple[Optional[str], bool]:
+    """Re-encrypt *value* with the current ``SESSION_SECRET`` when needed.
+
+    Plaintext legacy values are encrypted as part of the same operation. Values
+    already decryptable by the primary key are left byte-for-byte unchanged so
+    the database rotation command is idempotent.
+    """
+    if value is None or value == "":
+        return value, False
+
+    cipher = _get_cipher_suite()
+    if cipher is None or _primary_cipher is None:
+        raise EncryptionRotationError("Encryption is unavailable")
+
+    if not value.startswith("enc:"):
+        encrypted = encrypt_value(value)
+        if not encrypted or not encrypted.startswith("enc:"):
+            raise EncryptionRotationError("Could not encrypt a legacy plaintext value")
+        return encrypted, True
+
+    token = value[4:].encode("utf-8")
+    from cryptography.fernet import InvalidToken
+
+    try:
+        _primary_cipher.decrypt(token)
+        return value, False
+    except InvalidToken:
+        logger.debug("Encrypted value requires rotation to the primary key")
+
+    try:
+        plaintext = cipher.decrypt(token)
+        rotated = _primary_cipher.encrypt(plaintext)
+        return "enc:" + rotated.decode("utf-8"), True
+    except InvalidToken as exc:
+        raise EncryptionRotationError("Value is not decryptable by the configured keyring") from exc
+
+
+def value_uses_primary_key(value: Optional[str]) -> bool:
+    """Return whether an encrypted value is protected by the primary key."""
+    if value is None or value == "":
+        return True
+    if not value.startswith("enc:"):
+        return False
+    _get_cipher_suite()
+    if _primary_cipher is None:
+        return False
+    from cryptography.fernet import InvalidToken
+
+    try:
+        _primary_cipher.decrypt(value[4:].encode("utf-8"))
+        return True
+    except InvalidToken:
+        return False
 
 
 def is_encrypted(value: Optional[str]) -> bool:

--- a/app/utils/encryption_rotation.py
+++ b/app/utils/encryption_rotation.py
@@ -1,0 +1,67 @@
+"""Transactional rotation of database values encrypted by ``SESSION_SECRET``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models import ApplicationSettings, UserImapAccount, UserIntegration
+from app.utils.encryption import rotate_encrypted_value, value_uses_primary_key
+from app.utils.settings_service import get_setting_metadata
+
+
+@dataclass(frozen=True)
+class RotationReport:
+    scanned: int
+    rotated: int
+    invalid: int
+
+
+def _query_rows(db: Session, model: type[object], *, lock_rows: bool) -> list[object]:
+    query = db.query(model)
+    if lock_rows:
+        query = query.with_for_update()
+    return query.all()
+
+
+def _encrypted_columns(db: Session, *, lock_rows: bool) -> list[tuple[object, str]]:
+    """Return model rows and encrypted attributes without exposing values."""
+    rows: list[tuple[object, str]] = []
+    for setting in _query_rows(db, ApplicationSettings, lock_rows=lock_rows):
+        metadata = get_setting_metadata(setting.key)
+        if metadata.get("sensitive", False) and not metadata.get("environment_only", False):
+            rows.append((setting, "value"))
+    rows.extend((row, "credentials") for row in _query_rows(db, UserIntegration, lock_rows=lock_rows))
+    rows.extend((row, "password") for row in _query_rows(db, UserImapAccount, lock_rows=lock_rows))
+    return rows
+
+
+def rotate_database_encryption(db: Session, *, verify_only: bool = False) -> RotationReport:
+    """Rotate every known encrypted database column in one transaction.
+
+    The function reports counts only. Any undecryptable value aborts the whole
+    transaction so a partial key migration cannot be committed.
+    """
+    rows = _encrypted_columns(db, lock_rows=not verify_only)
+    rotated = 0
+    invalid = 0
+
+    if verify_only:
+        for row, attribute in rows:
+            if not value_uses_primary_key(getattr(row, attribute)):
+                invalid += 1
+        return RotationReport(scanned=len(rows), rotated=0, invalid=invalid)
+
+    try:
+        for row, attribute in rows:
+            new_value, changed = rotate_encrypted_value(getattr(row, attribute))
+            if changed:
+                setattr(row, attribute, new_value)
+                rotated += 1
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    return RotationReport(scanned=len(rows), rotated=rotated, invalid=0)

--- a/app/utils/settings_service.py
+++ b/app/utils/settings_service.py
@@ -223,6 +223,18 @@ SETTING_METADATA = {
         "required": True,  # Required when auth_enabled=True (validated in config.py)
         "restart_required": True,
     },
+    "session_secret_previous": {
+        "category": "Authentication",
+        "description": (
+            "Temporary previous session-encryption key used only while running the documented "
+            "database key-rotation command. Remove immediately after verification."
+        ),
+        "type": "string",
+        "sensitive": True,
+        "required": False,
+        "restart_required": True,
+        "environment_only": True,
+    },
     "session_lifetime_days": {
         "category": "Authentication",
         "description": "Session lifetime in days (default 30). Determines how long a user stays logged in.",
@@ -3768,6 +3780,10 @@ def save_setting_to_db(db: Session, key: str, value: Optional[str], changed_by: 
     try:
         # Check if this setting is sensitive and should be encrypted
         metadata = get_setting_metadata(key)
+        if metadata.get("environment_only", False):
+            logger.error("Refusing to persist environment-only setting %s", key)
+            db.rollback()
+            return False
         storage_value = value
 
         is_sensitive = bool(metadata.get("sensitive", False))
@@ -3918,6 +3934,8 @@ def get_settings_by_category() -> Dict[str, List[str]]:
     """
     categories = {}
     for key, metadata in SETTING_METADATA.items():
+        if metadata.get("environment_only", False):
+            continue
         category = metadata.get("category", "Other")
         if category not in categories:
             categories[category] = []
@@ -3937,6 +3955,8 @@ def validate_setting_value(key: str, value: str) -> Tuple[bool, Optional[str]]:
         Tuple of (is_valid, error_message)
     """
     metadata = get_setting_metadata(key)
+    if metadata.get("environment_only", False):
+        return False, f"{key} must be configured through the deployment secret"
     setting_type = metadata.get("type", "string")
 
     # Check required fields
@@ -3990,7 +4010,7 @@ def validate_setting_value(key: str, value: str) -> Tuple[bool, Optional[str]]:
 
     # Special validation for specific keys
     if key == "session_secret" and value and len(value) < 32:
-        return False, "session_secret must be at least 32 characters"
+        return False, f"{key} must be at least 32 characters"
 
     return True, None
 

--- a/docs/CredentialRotationGuide.md
+++ b/docs/CredentialRotationGuide.md
@@ -28,7 +28,7 @@ All credentials are stored either in environment variables or, when set via the 
 | OAuth refresh tokens | Rotate on revocation / after each re-authorization |
 | Passwords (SMTP, IMAP, FTP, SFTP, Nextcloud, WebDAV) | Every 90 days or on personnel change |
 | Admin password | Every 90 days or on personnel change |
-| `SESSION_SECRET` | On suspected compromise; note all active sessions will be invalidated |
+| `SESSION_SECRET` | On suspected compromise; use the keyring procedure below and expect active sessions to be invalidated |
 
 ---
 
@@ -180,13 +180,39 @@ Update `imap1_password` and/or `imap2_password` after rotating the credentials w
 
 > **Warning:** Rotating `SESSION_SECRET` invalidates all active user sessions. All logged-in users will be signed out immediately.
 
-1. Generate a new secret (minimum 32 characters):
+`SESSION_SECRET` also protects credentials stored in the database. DocuElevate
+supports a short-lived two-key handover so those values can be re-encrypted
+without asking users to reconnect every integration.
+
+1. Generate a new secret (minimum 32 characters) in your secret manager. Do
+   not print it into a shared terminal transcript or commit it to Git.
    ```bash
    python -c "import secrets; print(secrets.token_hex(32))"
    ```
-2. Update the environment variable or `.env` file.
-3. Restart the application.
-4. Existing encrypted settings stored in the database **will no longer be readable** because the encryption key is derived from `SESSION_SECRET`. You must re-enter all sensitive settings that were stored via the UI after rotating this value.
+2. Deploy both keys for the handover:
+   - `SESSION_SECRET` = the new primary key;
+   - `SESSION_SECRET_PREVIOUS` = the current/old key.
+3. Roll API and worker instances through the deployment controller. Verify that
+   all instances are ready before continuing.
+4. Run the transactional migration exactly once from an application container:
+   ```bash
+   python -m app.rotate_encryption_key
+   ```
+   The command emits counts only. If any value cannot be decrypted, the whole
+   transaction is rolled back and the command fails.
+5. Verify that every known encrypted database field uses the new key:
+   ```bash
+   python -m app.rotate_encryption_key --verify-only
+   ```
+6. Remove `SESSION_SECRET_PREVIOUS` from the secret manager and roll API and
+   workers again. Run `--verify-only` once more after the rollout.
+7. Revoke or destroy the old secret and record only the rotation timestamp and
+   counts in the incident log. Never retain the previous key as a permanent
+   fallback.
+
+The migration covers sensitive application settings, per-user integration
+credentials, and per-user IMAP passwords. It is idempotent and encrypts legacy
+plaintext rows encountered during the same transaction.
 
 ---
 

--- a/tests/test_encryption_rotation.py
+++ b/tests/test_encryption_rotation.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import pytest
+
+from app.config import settings
+from app.models import ApplicationSettings, UserImapAccount, UserIntegration
+from app.utils.encryption import (
+    EncryptionRotationError,
+    decrypt_value,
+    encrypt_value,
+    reset_cipher_cache,
+    value_uses_primary_key,
+)
+from app.utils.encryption_rotation import rotate_database_encryption
+
+OLD_SECRET = "old-session-secret-for-rotation-tests-000000000000"
+NEW_SECRET = "new-session-secret-for-rotation-tests-111111111111"
+
+
+@pytest.fixture(autouse=True)
+def restore_cipher_settings(monkeypatch: pytest.MonkeyPatch):
+    original_current = settings.session_secret
+    original_previous = settings.session_secret_previous
+    yield
+    monkeypatch.setattr(settings, "session_secret", original_current)
+    monkeypatch.setattr(settings, "session_secret_previous", original_previous)
+    reset_cipher_cache()
+
+
+def _use_keys(monkeypatch: pytest.MonkeyPatch, current: str, previous: str | None = None) -> None:
+    monkeypatch.setattr(settings, "session_secret", current)
+    monkeypatch.setattr(settings, "session_secret_previous", previous)
+    reset_cipher_cache()
+
+
+@pytest.mark.integration
+def test_rotates_all_database_encryption_surfaces_transactionally(db_session, monkeypatch: pytest.MonkeyPatch):
+    _use_keys(monkeypatch, OLD_SECRET)
+    setting = ApplicationSettings(key="openai_api_key", value=encrypt_value("operator-key"))
+    integration = UserIntegration(
+        owner_id="owner-1",
+        direction="SOURCE",
+        integration_type="DROPBOX",
+        name="Preprod source",
+        credentials=encrypt_value('{"refresh_token":"refresh"}'),
+    )
+    mailbox = UserImapAccount(
+        owner_id="owner-1",
+        name="Mailbox",
+        host="imap.example.test",
+        port=993,
+        username="owner@example.test",
+        password=encrypt_value("mail-password"),
+    )
+    db_session.add_all([setting, integration, mailbox])
+    db_session.commit()
+
+    _use_keys(monkeypatch, NEW_SECRET, OLD_SECRET)
+    report = rotate_database_encryption(db_session)
+
+    assert report.scanned == 3
+    assert report.rotated == 3
+    assert report.invalid == 0
+    assert value_uses_primary_key(setting.value)
+    assert value_uses_primary_key(integration.credentials)
+    assert value_uses_primary_key(mailbox.password)
+
+    _use_keys(monkeypatch, NEW_SECRET)
+    assert decrypt_value(setting.value) == "operator-key"
+    assert decrypt_value(integration.credentials) == '{"refresh_token":"refresh"}'
+    assert decrypt_value(mailbox.password) == "mail-password"
+
+    verification = rotate_database_encryption(db_session, verify_only=True)
+    assert verification.scanned == 3
+    assert verification.invalid == 0
+
+
+@pytest.mark.integration
+def test_rotation_is_idempotent_and_encrypts_legacy_plaintext(db_session, monkeypatch: pytest.MonkeyPatch):
+    _use_keys(monkeypatch, NEW_SECRET, OLD_SECRET)
+    setting = ApplicationSettings(key="openai_api_key", value="legacy-plaintext")
+    db_session.add(setting)
+    db_session.commit()
+
+    first = rotate_database_encryption(db_session)
+    first_value = setting.value
+    second = rotate_database_encryption(db_session)
+
+    assert first.rotated == 1
+    assert second.rotated == 0
+    assert setting.value == first_value
+    assert decrypt_value(setting.value) == "legacy-plaintext"
+
+
+@pytest.mark.integration
+def test_undecryptable_value_aborts_without_partial_commit(db_session, monkeypatch: pytest.MonkeyPatch):
+    _use_keys(monkeypatch, OLD_SECRET)
+    valid = ApplicationSettings(key="openai_api_key", value=encrypt_value("still-old"))
+    invalid = UserIntegration(
+        owner_id="owner-1",
+        direction="SOURCE",
+        integration_type="DROPBOX",
+        name="Broken fixture",
+        credentials="enc:not-a-fernet-token",
+    )
+    db_session.add_all([valid, invalid])
+    db_session.commit()
+    old_value = valid.value
+
+    _use_keys(monkeypatch, NEW_SECRET, OLD_SECRET)
+    with pytest.raises(EncryptionRotationError):
+        rotate_database_encryption(db_session)
+
+    db_session.refresh(valid)
+    assert valid.value == old_value
+    assert not value_uses_primary_key(valid.value)
+
+
+@pytest.mark.integration
+def test_verify_only_reports_plaintext_or_non_primary_values(db_session, monkeypatch: pytest.MonkeyPatch):
+    _use_keys(monkeypatch, OLD_SECRET)
+    old_encrypted = encrypt_value("old-value")
+    db_session.add_all(
+        [
+            ApplicationSettings(key="openai_api_key", value=old_encrypted),
+            UserIntegration(
+                owner_id="owner-1",
+                direction="SOURCE",
+                integration_type="DROPBOX",
+                name="Plaintext fixture",
+                credentials="legacy-plaintext",
+            ),
+        ]
+    )
+    db_session.commit()
+
+    _use_keys(monkeypatch, NEW_SECRET, OLD_SECRET)
+    report = rotate_database_encryption(db_session, verify_only=True)
+
+    assert report.scanned == 2
+    assert report.rotated == 0
+    assert report.invalid == 2
+
+
+@pytest.mark.integration
+def test_previous_session_key_is_never_a_database_rotation_target(db_session, monkeypatch: pytest.MonkeyPatch):
+    _use_keys(monkeypatch, NEW_SECRET, OLD_SECRET)
+    stale = ApplicationSettings(key="session_secret_previous", value=encrypt_value(OLD_SECRET))
+    db_session.add(stale)
+    db_session.commit()
+
+    report = rotate_database_encryption(db_session)
+
+    assert report.scanned == 0
+    assert report.rotated == 0

--- a/tests/test_rotate_encryption_key_command.py
+++ b/tests/test_rotate_encryption_key_command.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.rotate_encryption_key import main
+from app.utils.encryption import EncryptionRotationError
+
+
+@pytest.mark.unit
+def test_rotation_command_requires_previous_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("app.rotate_encryption_key.settings.session_secret_previous", None)
+
+    with patch("sys.argv", ["rotate_encryption_key"]), pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 2
+
+
+@pytest.mark.unit
+def test_rotation_command_reports_counts_without_values(monkeypatch: pytest.MonkeyPatch, capsys):
+    monkeypatch.setattr("app.rotate_encryption_key.settings.session_secret_previous", "x" * 32)
+    session_factory = MagicMock()
+    session_factory.return_value.__enter__.return_value = MagicMock()
+    report = SimpleNamespace(scanned=4, rotated=3, invalid=0)
+
+    with (
+        patch("sys.argv", ["rotate_encryption_key"]),
+        patch("app.rotate_encryption_key.SessionLocal", session_factory),
+        patch("app.rotate_encryption_key.rotate_database_encryption", return_value=report) as rotate,
+    ):
+        result = main()
+
+    assert result == 0
+    assert capsys.readouterr().out == "Encryption rotation counts: scanned=4 rotated=3 invalid=0\n"
+    rotate.assert_called_once_with(session_factory.return_value.__enter__.return_value, verify_only=False)
+
+
+@pytest.mark.unit
+def test_verify_command_fails_when_non_primary_values_remain(capsys):
+    session_factory = MagicMock()
+    session_factory.return_value.__enter__.return_value = MagicMock()
+    report = SimpleNamespace(scanned=5, rotated=0, invalid=1)
+
+    with (
+        patch("sys.argv", ["rotate_encryption_key", "--verify-only"]),
+        patch("app.rotate_encryption_key.SessionLocal", session_factory),
+        patch("app.rotate_encryption_key.rotate_database_encryption", return_value=report) as rotate,
+    ):
+        result = main()
+
+    assert result == 1
+    assert capsys.readouterr().out == "Encryption rotation counts: scanned=5 rotated=0 invalid=1\n"
+    rotate.assert_called_once_with(session_factory.return_value.__enter__.return_value, verify_only=True)
+
+
+@pytest.mark.unit
+def test_rotation_command_reports_encryption_failure_without_traceback(monkeypatch: pytest.MonkeyPatch, capsys):
+    monkeypatch.setattr("app.rotate_encryption_key.settings.session_secret_previous", "x" * 32)
+    session_factory = MagicMock()
+    session_factory.return_value.__enter__.return_value = MagicMock()
+
+    with (
+        patch("sys.argv", ["rotate_encryption_key"]),
+        patch("app.rotate_encryption_key.SessionLocal", session_factory),
+        patch(
+            "app.rotate_encryption_key.rotate_database_encryption",
+            side_effect=EncryptionRotationError("Value is not decryptable by the configured keyring"),
+        ),
+    ):
+        result = main()
+
+    assert result == 1
+    assert capsys.readouterr().out == (
+        "Encryption rotation failed: Value is not decryptable by the configured keyring\n"
+    )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -34,6 +34,15 @@ class TestSettingsService:
         value = get_setting_from_db(db_session, "test_key")
         assert value == "test_value"
 
+    def test_environment_only_setting_cannot_be_persisted(self, db_session: Session):
+        result = save_setting_to_db(db_session, "session_secret_previous", "x" * 32)
+        valid, message = validate_setting_value("session_secret_previous", "x" * 32)
+
+        assert result is False
+        assert db_session.query(ApplicationSettings).filter_by(key="session_secret_previous").first() is None
+        assert valid is False
+        assert message == "session_secret_previous must be configured through the deployment secret"
+
     def test_update_existing_setting(self, db_session: Session):
         """Test updating an existing setting"""
         # Save initial value
@@ -165,6 +174,12 @@ class TestSettingsService:
             f"The following config.py settings are missing from SETTING_METADATA "
             f"and will not appear on the settings page: {sorted(missing)}"
         )
+
+    def test_previous_session_secret_is_environment_only(self):
+        metadata = SETTING_METADATA["session_secret_previous"]
+        assert metadata["sensitive"] is True
+        assert metadata["restart_required"] is True
+        assert metadata["environment_only"] is True
 
     def test_redis_connection_urls_are_sensitive_restart_settings(self):
         """Redis URLs can contain credentials and only apply after process restart."""
@@ -370,6 +385,23 @@ class TestSettingsPrecedence:
 
         # Should still have default value
         assert test_settings.test_value == "default"
+
+    def test_environment_only_database_value_is_ignored(self, db_session: Session):
+        from pydantic_settings import BaseSettings
+
+        class TestSettings(BaseSettings):
+            session_secret_previous: str | None = None
+
+            class Config:
+                env_file = None
+
+        db_session.add(ApplicationSettings(key="session_secret_previous", value="must-not-load"))
+        db_session.commit()
+        test_settings = TestSettings()
+
+        load_settings_from_db(test_settings, db_session)
+
+        assert test_settings.session_secret_previous is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Part of #1162.

Adds a safe two-key handover for rotating SESSION_SECRET without invalidating database-backed integration and user credentials. The rotation command rewrites all encrypted values transactionally, verifies the result, and keeps the previous key environment-only so it cannot persist in the database.

Validation:
- Ruff: green
- Broad non-E2E suite: 6550 passed, 40 skipped, 11 deselected
- Final targeted suite: 121 passed, 1 skipped

Scope: application support required for the Preprod secret migration only. Production is untouched and remains pinned to the legacy release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for safely rotating encryption keys without requiring immediate data re-entry.
  * Added verification-only checks and transactional rotation reporting for encrypted data.
  * Added temporary fallback-key configuration with validation safeguards.
  * Environment-only security settings are excluded from database persistence and loading.

* **Documentation**
  * Updated key-rotation guidance, including verification, rollback behavior, and session invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->