### PR TITLE
Rotate encrypted settings audit history with SESSION_SECRET

### DIFF
--- a/app/utils/encryption_rotation.py
+++ b/app/utils/encryption_rotation.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
 
-from app.models import ApplicationSettings, UserImapAccount, UserIntegration
+from app.models import ApplicationSettings, SettingsAuditLog, UserImapAccount, UserIntegration
 from app.utils.encryption import rotate_encrypted_value, value_uses_primary_key
 from app.utils.settings_service import get_setting_metadata
 
@@ -32,6 +32,14 @@ def _encrypted_columns(db: Session, *, lock_rows: bool) -> list[tuple[object, st
         metadata = get_setting_metadata(setting.key)
         if metadata.get("sensitive", False) and not metadata.get("environment_only", False):
             rows.append((setting, "value"))
+    for entry in _query_rows(db, SettingsAuditLog, lock_rows=lock_rows):
+        metadata = get_setting_metadata(entry.key)
+        if not metadata.get("sensitive", False) or metadata.get("environment_only", False):
+            continue
+        if entry.old_value is not None:
+            rows.append((entry, "old_value"))
+        if entry.new_value is not None:
+            rows.append((entry, "new_value"))
     rows.extend((row, "credentials") for row in _query_rows(db, UserIntegration, lock_rows=lock_rows))
     rows.extend((row, "password") for row in _query_rows(db, UserImapAccount, lock_rows=lock_rows))
     return rows

--- a/docs/CredentialRotationGuide.md
+++ b/docs/CredentialRotationGuide.md
@@ -210,9 +210,11 @@ without asking users to reconnect every integration.
    counts in the incident log. Never retain the previous key as a permanent
    fallback.
 
-The migration covers sensitive application settings, per-user integration
-credentials, and per-user IMAP passwords. It is idempotent and encrypts legacy
-plaintext rows encountered during the same transaction.
+The migration covers sensitive application settings, their encrypted settings
+audit history, per-user integration credentials, and per-user IMAP passwords.
+Redacted legacy audit entries and non-sensitive audit values are ignored. The
+migration is idempotent and encrypts legacy plaintext rows encountered during
+the same transaction.
 
 ---
 

--- a/tests/test_encryption_rotation.py
+++ b/tests/test_encryption_rotation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from app.config import settings
-from app.models import ApplicationSettings, UserImapAccount, UserIntegration
+from app.models import ApplicationSettings, SettingsAuditLog, UserImapAccount, UserIntegration
 from app.utils.encryption import (
     EncryptionRotationError,
     decrypt_value,
@@ -52,26 +52,53 @@ def test_rotates_all_database_encryption_surfaces_transactionally(db_session, mo
         username="owner@example.test",
         password=encrypt_value("mail-password"),
     )
-    db_session.add_all([setting, integration, mailbox])
+    audit = SettingsAuditLog(
+        key="openai_api_key",
+        old_value=encrypt_value("previous-operator-key"),
+        new_value=setting.value,
+        changed_by="rotation-test",
+        action="update",
+    )
+    redacted_legacy_audit = SettingsAuditLog(
+        key="openai_api_key",
+        old_value=None,
+        new_value=None,
+        changed_by="migration",
+        action="update",
+    )
+    non_sensitive_audit = SettingsAuditLog(
+        key="workdir",
+        old_value="/old-workdir",
+        new_value="/new-workdir",
+        changed_by="rotation-test",
+        action="update",
+    )
+    db_session.add_all([setting, integration, mailbox, audit, redacted_legacy_audit, non_sensitive_audit])
     db_session.commit()
 
     _use_keys(monkeypatch, NEW_SECRET, OLD_SECRET)
     report = rotate_database_encryption(db_session)
 
-    assert report.scanned == 3
-    assert report.rotated == 3
+    assert report.scanned == 5
+    assert report.rotated == 5
     assert report.invalid == 0
     assert value_uses_primary_key(setting.value)
     assert value_uses_primary_key(integration.credentials)
     assert value_uses_primary_key(mailbox.password)
+    assert value_uses_primary_key(audit.old_value)
+    assert value_uses_primary_key(audit.new_value)
+    assert non_sensitive_audit.old_value == "/old-workdir"
+    assert non_sensitive_audit.new_value == "/new-workdir"
 
     _use_keys(monkeypatch, NEW_SECRET)
     assert decrypt_value(setting.value) == "operator-key"
     assert decrypt_value(integration.credentials) == '{"refresh_token":"refresh"}'
     assert decrypt_value(mailbox.password) == "mail-password"
+    assert decrypt_value(audit.old_value) == "previous-operator-key"
+    assert decrypt_value(audit.new_value) == "operator-key"
 
     verification = rotate_database_encryption(db_session, verify_only=True)
-    assert verification.scanned == 3
+    assert verification.scanned == 5
     assert verification.invalid == 0
 
 
@@ -96,23 +123,36 @@ def test_rotation_is_idempotent_and_encrypts_legacy_plaintext(db_session, monkey
 def test_undecryptable_value_aborts_without_partial_commit(db_session, monkeypatch: pytest.MonkeyPatch):
     _use_keys(monkeypatch, OLD_SECRET)
     valid = ApplicationSettings(key="openai_api_key", value=encrypt_value("still-old"))
-    invalid = UserIntegration(
+    integration = UserIntegration(
         owner_id="owner-1",
         direction="SOURCE",
         integration_type="DROPBOX",
-        name="Broken fixture",
-        credentials="enc:not-a-fernet-token",
+        name="Valid fixture",
+        credentials=encrypt_value("integration-old"),
     )
-    db_session.add_all([valid, invalid])
+    audit = SettingsAuditLog(
+        key="openai_api_key",
+        old_value=encrypt_value("audit-old"),
+        new_value="enc:not-a-fernet-token",
+        changed_by="rotation-test",
+        action="update",
+    )
+    db_session.add_all([valid, integration, audit])
     db_session.commit()
     old_value = valid.value
+    old_integration_value = integration.credentials
+    old_audit_value = audit.old_value
 
     _use_keys(monkeypatch, NEW_SECRET, OLD_SECRET)
     with pytest.raises(EncryptionRotationError):
         rotate_database_encryption(db_session)
 
     db_session.refresh(valid)
+    db_session.refresh(integration)
+    db_session.refresh(audit)
     assert valid.value == old_value
+    assert integration.credentials == old_integration_value
+    assert audit.old_value == old_audit_value
     assert not value_uses_primary_key(valid.value)
 
 
@@ -130,6 +170,13 @@ def test_verify_only_reports_plaintext_or_non_primary_values(db_session, monkeyp
                 name="Plaintext fixture",
                 credentials="legacy-plaintext",
             ),
+            SettingsAuditLog(
+                key="openai_api_key",
+                old_value=old_encrypted,
+                new_value="legacy-plaintext",
+                changed_by="rotation-test",
+                action="update",
+            ),
         ]
     )
     db_session.commit()
@@ -137,9 +184,9 @@ def test_verify_only_reports_plaintext_or_non_primary_values(db_session, monkeyp
     _use_keys(monkeypatch, NEW_SECRET, OLD_SECRET)
     report = rotate_database_encryption(db_session, verify_only=True)
 
-    assert report.scanned == 2
+    assert report.scanned == 4
     assert report.rotated == 0
-    assert report.invalid == 2
+    assert report.invalid == 4
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- include sensitive, non-environment-only settings audit values in transactional Session secret rotation
- ignore redacted legacy rows and non-sensitive audit values
- verify success, primary-key verification, and all-or-nothing rollback through an invalid audit value

## Validation
- 38 focused rotation, command, and settings-audit tests passed
- encryption rotation module remains at 100% focused coverage
- Ruff lint/format and diff checks passed

Closes #1197.

Preprod-only delivery; production remains pinned to the dedicated legacy image.