### PR TITLE
fix: update vulnerable mobile transitive dependencies

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -4720,9 +4720,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6875,9 +6875,9 @@
       }
     },
     "node_modules/expo/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8412,9 +8412,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -11433,9 +11433,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11931,9 +11931,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -61,18 +61,18 @@
   "overrides": {
     "postcss": "8.5.18",
     "uuid": "11.1.1",
-    "shell-quote": "1.8.4",
+    "shell-quote": "1.9.0",
     "undici": "6.27.0",
-    "tar": "7.5.16",
-    "js-yaml@^4.1.0": "4.2.0",
+    "tar": "7.5.21",
+    "js-yaml@^4.1.0": "4.3.0",
     "@react-native/dev-middleware": {
       "ws@^6.0.0": "6.2.4"
     },
     "react-native": {
       "ws@^6.0.0": "6.2.4"
     },
-    "brace-expansion@^1.1.7": "1.1.13",
-    "brace-expansion@^2.0.2": "2.1.0",
+    "brace-expansion@^1.1.7": "1.1.16",
+    "brace-expansion@^2.0.2": "2.1.2",
     "brace-expansion@^5.0.2": "5.0.8"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- update mobile dependency overrides for tar, shell-quote, js-yaml, and brace-expansion to patched versions
- regenerate the mobile lockfile

## Verification
- `npm ci --legacy-peer-deps`
- `npm ls brace-expansion shell-quote js-yaml tar --all`
- `npm run type-check` currently fails on the existing Expo/TypeScript moduleResolution mismatch
- `npm run lint` currently reaches existing FileSystem namespace errors in UploadScreen

This addresses the Jul 29 Dependabot digest findings without forcing the unrelated Expo 57 migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several bundled dependency versions to incorporate the latest maintenance and security improvements.
  * Refreshed transitive package overrides without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->